### PR TITLE
Fix GitHub Actions security issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 jobs:
   build:
     name: Build
@@ -15,7 +17,9 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
       - name: Test
         run: script/test
         env:
@@ -40,10 +44,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version-file: go.mod
 
@@ -72,15 +78,17 @@ jobs:
 
       - name: Compress binary artifact
         shell: bash
+        env:
+          PLATFORM_NAME: ${{ steps.platform.outputs.name }}
         run: |
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
             tar -czvf dependabot-proxy-win64.tar.gz dependabot-proxy.exe;
           else
-            tar -czvf dependabot-proxy-${{ steps.platform.outputs.name }}.tar.gz dependabot-proxy;
+            tar -czvf "dependabot-proxy-${PLATFORM_NAME}.tar.gz" dependabot-proxy;
           fi
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           path: dependabot-proxy-${{ steps.platform.outputs.name }}.tar.gz
           name: dependabot-proxy-${{ steps.platform.outputs.name }}

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   publish:
     name: Build and publish Docker images
@@ -15,7 +17,9 @@ jobs:
     
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
       - name: Publish Docker
         run: script/cibuild-publish-ghcr
         env:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,6 +8,8 @@ on:
     - cron: '30 1 * * 6' # https://crontab.guru/#30_1_*_*_6
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   analysis:
     name: Scorecard analysis
@@ -24,7 +26,7 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -31,20 +31,26 @@ jobs:
       matrix:
         suite: ${{ fromJSON(needs.suites.outputs.suites) }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      with:
+        persist-credentials: false
 
     - name: Download CLI and test
+      env:
+        SUITE: ${{ matrix.suite }}
       run: |
         gh release download --repo dependabot/cli -p "*linux-amd64.tar.gz"
         tar xzvf *.tar.gz >/dev/null 2>&1
         ./dependabot --version
-        URL=https://api.github.com/repos/dependabot/smoke-tests/contents/tests/smoke-${{ matrix.suite }}.yaml
-        curl $(gh api $URL --jq .download_url) -o smoke.yaml
+        URL="https://api.github.com/repos/dependabot/smoke-tests/contents/tests/smoke-${SUITE}.yaml"
+        curl $(gh api "$URL" --jq .download_url) -o smoke.yaml
 
     # Download the Proxy cache. The job is ideally 100% cached so no real calls are made.
     - name: Download cache
+      env:
+        SUITE: ${{ matrix.suite }}
       run: |
-        gh run download --repo dependabot/smoke-tests --name cache-${{ matrix.suite }} --dir cache
+        gh run download --repo dependabot/smoke-tests --name "cache-${SUITE}" --dir cache
 
     - name: Build proxy image
       run: docker build -t "dependabot/proxy:latest" .


### PR DESCRIPTION
Ran zizmor and fixed the issues it found:

- Pinned all actions to commit hashes (v6 tags → full SHAs)
- Added `persist-credentials: false` to checkout steps
- Replaced `${{ matrix.suite }}` in run blocks with env vars to avoid template injection warnings
- Added `permissions: {}` at workflow level so jobs must explicitly request what they need

zizmor now passes with no findings.