### PR TITLE
Fix GHCR publish workflow failing to push tags

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -10,16 +10,15 @@ jobs:
   publish:
     name: Build and publish Docker images
     runs-on: ubuntu-latest
-    
+
     permissions:
       contents: write
       packages: write
-    
+
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
+
       - name: Publish Docker
         run: script/cibuild-publish-ghcr
         env:


### PR DESCRIPTION
The GHCR publish workflow started failing after #10 with:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

The `persist-credentials: false` option removed git credentials after checkout, so the script couldn't push the version tag. Removing that option restores the default behavior where credentials remain available for the `git push` command.