### PR TITLE
Replace deprecated `ioutil.ReadAll`

### DIFF
--- a/internal/cache/handlers.go
+++ b/internal/cache/handlers.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"os"
@@ -65,7 +64,7 @@ var ignoreHeaders = map[string]struct{}{
 
 // generates the key used in the DB, includes a hash of the body
 func key(r *http.Request) Key {
-	data, _ := ioutil.ReadAll(r.Body)
+	data, _ := io.ReadAll(r.Body)
 	r.Body.Close()
 	r.Body = io.NopCloser(bytes.NewBuffer(data))
 	k := Key{

--- a/internal/cache/handlers_test.go
+++ b/internal/cache/handlers_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -86,7 +85,7 @@ func TestCache(t *testing.T) {
 			Body:       io.NopCloser(bytes.NewBufferString(body)),
 		}
 		resp = cacher.OnResponse(resp, ctx)
-		result, _ := ioutil.ReadAll(resp.Body)
+		result, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if len(cacher.cacheDB) != 1 {
 			t.Error("cache should have 1 entry, got", len(cacher.cacheDB))

--- a/internal/handlers/git_server_test.go
+++ b/internal/handlers/git_server_test.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -393,7 +392,7 @@ func TestGitServerHandler_TokenFallbackWithPost(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var capturedTokens []string
 			roundTripper := goproxy.RoundTripperFunc(func(r *http.Request, c *goproxy.ProxyCtx) (*http.Response, error) {
-				body, err := ioutil.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
 				require.NoError(t, err, "failed to read req body")
 				assert.Equal(t, "test body", string(body), "request body mismatch")
 


### PR DESCRIPTION
Replace deprecated uses of `ioutil.ReadAll` with `io.ReadAll`[1]

> ReadAll reads from r until an error or EOF and returns the data it read. A successful call returns err == nil, not err == EOF. Because ReadAll is defined to read from src until EOF, it does not treat an EOF from Read as an error to be reported.
>
> Deprecated: As of Go 1.16, this function simply calls io.ReadAll.

[1]: https://pkg.go.dev/io/ioutil#ReadAll