### PR TITLE
fix: public github release downloads should not be authenticated

### DIFF
--- a/internal/handlers/git_server.go
+++ b/internal/handlers/git_server.go
@@ -333,6 +333,10 @@ func getCredentialsForRequest(r *http.Request, credentials *gitCredentialsMap, e
 		return nil
 	}
 
+	if isPublicGitHubDownload(host, r.URL.Path) {
+		return nil
+	}
+
 	// Get credentials for the host that not unscoped to specific repositories.
 	hostCreds := credentials.get(host)
 	credsForRequest := hostCreds.getCredentialsForRepo(allReposScopeIdentifier)
@@ -351,6 +355,12 @@ func getCredentialsForRequest(r *http.Request, credentials *gitCredentialsMap, e
 	}
 
 	return credsForRequest
+}
+
+// GitHub release download URLs are public
+// and do not require authentication
+func isPublicGitHubDownload(host string, path string) bool {
+	return host == "github.com" && strings.Contains(path, "/releases/download/")
 }
 
 // HandleResponse handles retrying failed auth responses with alternate credentials

--- a/internal/handlers/git_server_test.go
+++ b/internal/handlers/git_server_test.go
@@ -127,6 +127,29 @@ func TestGitServerHandler(t *testing.T) {
 		"valid github request")
 }
 
+func TestGitServerPublicReleaseDownload(t *testing.T) {
+	installationCred := testGitSourceCred("github.com", "x-access-token", "v1.token")
+	gheCred := testGitSourceCred("ghe.some-corp.com", "x-access-token", "corp")
+
+	credentials := config.Credentials{
+		installationCred,
+		gheCred,
+	}
+	handler := NewGitServerHandler(credentials, nil)
+
+	req := httptest.NewRequest("HEAD", "https://github.com/gradle/gradle-distributions/releases/download/v9.3.0/gradle-9.3.0-bin.zip", nil)
+	req, _ = handler.HandleRequest(req, nil)
+	assertUnauthenticated(t, req, "Public github.com release downloads should not be authenticated")
+
+	req = httptest.NewRequest("HEAD", "https://ghe.some-corp.com/gradle/gradle-distributions/releases/download/v9.3.0/gradle-9.3.0-bin.zip", nil)
+	req, _ = handler.HandleRequest(req, nil)
+	assertHasBasicAuth(t, req,
+		gheCred.GetString("username"),
+		gheCred.GetString("password"),
+		"valid github request")
+
+}
+
 func TestGitServerHandler_AuthenticatedAccessToGitHubRepos(t *testing.T) {
 	installationToken1 := "v1.token1"
 	privateRepo1Cred := testGitSourceCred("github.com", "x-access-token", installationToken1, withAccessibleRepos([]string{"github/private-repo-1"}))


### PR DESCRIPTION
The proxy should not assume that asset release downloads require authentication. These endpoints are public, and including a token can actually cause access to fail with an unauthorized error.

For additional context and analysis see https://github.com/dependabot/proxy/issues/15#issuecomment-3839157204

Fixes https://github.com/dependabot/proxy/issues/15

Logs: 

### Before this change

```
2026/02/04 06:50:39 proxy starting, commit: dev
2026/02/04 01:50:39 Listening (:1080)
2026/02/04 01:51:02 [002] HEAD https://services.gradle.org:443/distributions/gradle-9.2.0-bin.zip
2026/02/04 01:51:02 [002] 307 https://services.gradle.org:443/distributions/gradle-9.2.0-bin.zip
2026/02/04 01:51:02 [004] HEAD https://github.com:443/gradle/gradle-distributions/releases/download/v9.2.0/gradle-9.2.0-bin.zip
2026/02/04 01:51:02 [004] * authenticating git server request (host: github.com)
2026/02/04 01:51:02 [004] 302 https://github.com:443/gradle/gradle-distributions/releases/download/v9.2.0/gradle-9.2.0-bin.zip
2026/02/04 01:51:03 [006] HEAD https://objects.githubusercontent.com:443/github-production-release-asset-2e65be/696192900/59c24fc6-8617-4334-917a-58d539c557d3?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20260204%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260204T065104Z&X-Amz-Expires=1800&X-Amz-Signature=f20b2f55b452f1b7ca94086a2c62f17bcba2b0ee382e77d322fdbd50a243e527&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dgradle-9.2.0-bin.zip&response-content-type=application%2Foctet-stream
2026/02/04 01:51:03 [006] 401 https://objects.githubusercontent.com:443/github-production-release-asset-2e65be/696192900/59c24fc6-8617-4334-917a-58d539c557d3?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20260204%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260204T065104Z&X-Amz-Expires=1800&X-Amz-Signature=f20b2f55b452f1b7ca94086a2c62f17bcba2b0ee382e77d322fdbd50a243e527&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dgradle-9.2.0-bin.zip&response-content-type=application%2Foctet-stream
```

### After this change

```
2026/02/04 06:49:02 proxy starting, commit: dev
2026/02/04 01:49:02 Listening (:1080)
2026/02/04 01:49:35 [002] HEAD https://services.gradle.org:443/distributions/gradle-9.2.0-bin.zip
2026/02/04 01:49:35 [002] 307 https://services.gradle.org:443/distributions/gradle-9.2.0-bin.zip
2026/02/04 01:49:35 [004] HEAD https://github.com:443/gradle/gradle-distributions/releases/download/v9.2.0/gradle-9.2.0-bin.zip
2026/02/04 01:49:35 [004] 302 https://github.com:443/gradle/gradle-distributions/releases/download/v9.2.0/gradle-9.2.0-bin.zip
2026/02/04 01:49:35 [006] HEAD https://release-assets.githubusercontent.com:443/github-production-release-asset/696192900/59c24fc6-8617-4334-917a-58d539c557d3?sp=r&sv=2018-11-09&sr=b&spr=https&se=2026-02-04T07%3A30%3A36Z&rscd=attachment%3B+filename%3Dgradle-9.2.0-bin.zip&rsct=application%2Foctet-stream&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2026-02-04T06%3A30%3A32Z&ske=2026-02-04T07%3A30%3A36Z&sks=b&skv=2018-11-09&sig=kasSevSu%2BWrZDWMK1tepgTDuLhkDuakwTTnEBX2F4f4%3D&jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmVsZWFzZS1hc3NldHMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwia2V5Ijoia2V5MSIsImV4cCI6MTc3MDE5MTM3NywibmJmIjoxNzcwMTg3Nzc3LCJwYXRoIjoicmVsZWFzZWFzc2V0cHJvZHVjdGlvbi5ibG9iLmNvcmUud2luZG93cy5uZXQifQ.3DIcTnpywlfoHQyUxPWmo9214Qe8zClbdFZTxtSNDmk&response-content-disposition=attachment%3B%20filename%3Dgradle-9.2.0-bin.zip&response-content-type=application%2Foctet-stream
2026/02/04 01:49:35 [006] 200 https://release-assets.githubusercontent.com:443/github-production-release-asset/696192900/59c24fc6-8617-4334-917a-58d539c557d3?sp=r&sv=2018-11-09&sr=b&spr=https&se=2026-02-04T07%3A30%3A36Z&rscd=attachment%3B+filename%3Dgradle-9.2.0-bin.zip&rsct=application%2Foctet-stream&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2026-02-04T06%3A30%3A32Z&ske=2026-02-04T07%3A30%3A36Z&sks=b&skv=2018-11-09&sig=kasSevSu%2BWrZDWMK1tepgTDuLhkDuakwTTnEBX2F4f4%3D&jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmVsZWFzZS1hc3NldHMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwia2V5Ijoia2V5MSIsImV4cCI6MTc3MDE5MTM3NywibmJmIjoxNzcwMTg3Nzc3LCJwYXRoIjoicmVsZWFzZWFzc2V0cHJvZHVjdGlvbi5ibG9iLmNvcmUud2luZG93cy5uZXQifQ.3DIcTnpywlfoHQyUxPWmo9214Qe8zClbdFZTxtSNDmk&response-content-disposition=attachment%3B%20filename%3Dgradle-9.2.0-bin.zip&response-content-type=application%2Foctet-stream
```