### PR TITLE
Implements Cloudsmith OIDC

### DIFF
--- a/internal/handlers/npm_registry.go
+++ b/internal/handlers/npm_registry.go
@@ -96,8 +96,13 @@ func (h *NPMRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.Proxy
 			logging.RequestLogf(ctx, "* failed to get token via OIDC for %s: %v", reqHost, err)
 			// Fall through to try static credentials
 		} else {
-			logging.RequestLogf(ctx, "* authenticating npm registry request with OIDC token (host: %s)", reqHost)
-			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+			if oidcCred.Provider() == "cloudsmith" {
+				logging.RequestLogf(ctx, "* authenticating npm registry request with OIDC API key (host: %s)", reqHost)
+				req.Header.Set("X-Api-Key", token)
+			} else {
+				logging.RequestLogf(ctx, "* authenticating npm registry request with OIDC token (host: %s)", reqHost)
+				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+			}
 			return req, nil
 		}
 	}

--- a/internal/handlers/oidc_handling_test.go
+++ b/internal/handlers/oidc_handling_test.go
@@ -122,6 +122,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"url":               "https://cloudsmith.example.com",
 					"oidc-namespace":    "space",
 					"oidc-service-slug": "repo",
+					"oidc-audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -216,6 +217,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"registry":          "https://cloudsmith.example.com",
 					"oidc-namespace":    "space",
 					"oidc-service-slug": "repo",
+					"oidc-audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -310,6 +312,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"registry":          "https://cloudsmith.example.com",
 					"oidc-namespace":    "space",
 					"oidc-service-slug": "repo",
+					"oidc-audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -403,6 +406,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"url":               "https://cloudsmith.example.com",
 					"oidc-namespace":    "space",
 					"oidc-service-slug": "repo",
+					"oidc-audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -496,6 +500,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"registry":          "https://cloudsmith.example.com",
 					"oidc-namespace":    "space",
 					"oidc-service-slug": "repo",
+					"oidc-audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -589,6 +594,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"url":               "https://cloudsmith.example.com",
 					"oidc-namespace":    "space",
 					"oidc-service-slug": "repo",
+					"oidc-audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -682,6 +688,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"url":               "https://cloudsmith.example.com",
 					"oidc-namespace":    "space",
 					"oidc-service-slug": "repo",
+					"oidc-audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -775,6 +782,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"url":               "https://cloudsmith.example.com",
 					"oidc-namespace":    "space",
 					"oidc-service-slug": "repo",
+					"oidc-audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -892,6 +900,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"url":               "https://cloudsmith.example.com/v3/index.json",
 					"oidc-namespace":    "space",
 					"oidc-service-slug": "repo",
+					"oidc-audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{
@@ -993,6 +1002,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"url":               "https://cloudsmith.example.com",
 					"oidc-namespace":    "space",
 					"oidc-service-slug": "repo",
+					"oidc-audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -1086,6 +1096,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"url":               "https://cloudsmith.example.com",
 					"oidc-namespace":    "space",
 					"oidc-service-slug": "repo",
+					"oidc-audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -1181,6 +1192,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"host":              "https://cloudsmith.example.com",
 					"oidc-namespace":    "space",
 					"oidc-service-slug": "repo",
+					"oidc-audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -1274,6 +1286,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"url":               "https://cloudsmith.example.com",
 					"oidc-namespace":    "space",
 					"oidc-service-slug": "repo",
+					"oidc-audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -1339,8 +1352,6 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"expires_in": 3600
 				}`))
 			case "cloudsmith":
-				// for fallback on Audience
-				t.Setenv("GITHUB_REPOSITORY_OWNER", "testowner")
 				namespace := tc.credentials[0]["oidc-namespace"]
 				httpmock.RegisterResponder("POST", fmt.Sprintf("https://api.cloudsmith.io/openid/%s/", namespace),
 					httpmock.NewStringResponder(200, `{

--- a/internal/handlers/oidc_handling_test.go
+++ b/internal/handlers/oidc_handling_test.go
@@ -110,6 +110,28 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 				"https://jfrog.example.com/packages/some-package",
 			},
 		},
+		{
+			name:     "Cargo",
+			provider: "cloudsmith",
+			handlerFactory: func(creds config.Credentials) oidcHandler {
+				return NewCargoRegistryHandler(creds)
+			},
+			credentials: config.Credentials{
+				config.Credential{
+					"type":              "cargo_registry",
+					"url":               "https://cloudsmith.example.com",
+					"oidc-namespace":    "space",
+					"oidc-service-slug": "repo",
+				},
+			},
+			urlMocks: []mockHttpRequest{},
+			expectedLogLines: []string{
+				"registered cloudsmith OIDC credentials for cargo registry: https://cloudsmith.example.com",
+			},
+			urlsToAuthenticate: []string{
+				"https://cloudsmith.example.com/some-package",
+			},
+		},
 		//
 		// Composer
 		//
@@ -182,6 +204,29 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 				"https://jfrog.example.com/some-package",
 			},
 		},
+		{
+			name:     "Composer",
+			provider: "cloudsmith",
+			handlerFactory: func(creds config.Credentials) oidcHandler {
+				return NewComposerHandler(creds)
+			},
+			credentials: config.Credentials{
+				config.Credential{
+					"type":              "composer_repository",
+					"registry":          "https://cloudsmith.example.com",
+					"oidc-namespace":    "space",
+					"oidc-service-slug": "repo",
+				},
+			},
+			urlMocks: []mockHttpRequest{},
+			expectedLogLines: []string{
+				"registered cloudsmith OIDC credentials for composer repository: cloudsmith.example.com",
+			},
+			urlsToAuthenticate: []string{
+				"https://cloudsmith.example.com/some-package",
+			},
+		},
+
 		//
 		// Docker
 		//
@@ -251,6 +296,28 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			},
 			urlsToAuthenticate: []string{
 				"https://jfrog.example.com/some-package",
+			},
+		},
+		{
+			name:     "Docker",
+			provider: "cloudsmith",
+			handlerFactory: func(creds config.Credentials) oidcHandler {
+				return NewDockerRegistryHandler(creds, &http.Transport{}, nil)
+			},
+			credentials: config.Credentials{
+				config.Credential{
+					"type":              "docker_registry",
+					"registry":          "https://cloudsmith.example.com",
+					"oidc-namespace":    "space",
+					"oidc-service-slug": "repo",
+				},
+			},
+			urlMocks: []mockHttpRequest{},
+			expectedLogLines: []string{
+				"registered cloudsmith OIDC credentials for docker registry: https://cloudsmith.example.com",
+			},
+			urlsToAuthenticate: []string{
+				"https://cloudsmith.example.com/some-package",
 			},
 		},
 		//
@@ -324,6 +391,28 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 				"https://jfrog.example.com/packages/some-package",
 			},
 		},
+		{
+			name:     "Go proxy",
+			provider: "cloudsmith",
+			handlerFactory: func(creds config.Credentials) oidcHandler {
+				return NewGoProxyServerHandler(creds)
+			},
+			credentials: config.Credentials{
+				config.Credential{
+					"type":              "goproxy_server",
+					"url":               "https://cloudsmith.example.com",
+					"oidc-namespace":    "space",
+					"oidc-service-slug": "repo",
+				},
+			},
+			urlMocks: []mockHttpRequest{},
+			expectedLogLines: []string{
+				"registered cloudsmith OIDC credentials for goproxy server: https://cloudsmith.example.com",
+			},
+			urlsToAuthenticate: []string{
+				"https://cloudsmith.example.com/some-package",
+			},
+		},
 		//
 		// Helm
 		//
@@ -393,6 +482,28 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			},
 			urlsToAuthenticate: []string{
 				"https://jfrog.example.com/some-package",
+			},
+		},
+		{
+			name:     "Helm registry",
+			provider: "cloudsmith",
+			handlerFactory: func(creds config.Credentials) oidcHandler {
+				return NewHelmRegistryHandler(creds)
+			},
+			credentials: config.Credentials{
+				config.Credential{
+					"type":              "helm_registry",
+					"registry":          "https://cloudsmith.example.com",
+					"oidc-namespace":    "space",
+					"oidc-service-slug": "repo",
+				},
+			},
+			urlMocks: []mockHttpRequest{},
+			expectedLogLines: []string{
+				"registered cloudsmith OIDC credentials for helm registry: https://cloudsmith.example.com",
+			},
+			urlsToAuthenticate: []string{
+				"https://cloudsmith.example.com/some-package",
 			},
 		},
 		//
@@ -466,6 +577,28 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 				"https://jfrog.example.com/some-package",
 			},
 		},
+		{
+			name:     "Hex",
+			provider: "cloudsmith",
+			handlerFactory: func(creds config.Credentials) oidcHandler {
+				return NewHexRepositoryHandler(creds)
+			},
+			credentials: config.Credentials{
+				config.Credential{
+					"type":              "hex_repository",
+					"url":               "https://cloudsmith.example.com",
+					"oidc-namespace":    "space",
+					"oidc-service-slug": "repo",
+				},
+			},
+			urlMocks: []mockHttpRequest{},
+			expectedLogLines: []string{
+				"registered cloudsmith OIDC credentials for hex repository: https://cloudsmith.example.com",
+			},
+			urlsToAuthenticate: []string{
+				"https://cloudsmith.example.com/some-package",
+			},
+		},
 		//
 		// Maven
 		//
@@ -537,6 +670,28 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 				"https://jfrog.example.com/packages/some-package",
 			},
 		},
+		{
+			name:     "Maven",
+			provider: "cloudsmith",
+			handlerFactory: func(creds config.Credentials) oidcHandler {
+				return NewMavenRepositoryHandler(creds)
+			},
+			credentials: config.Credentials{
+				config.Credential{
+					"type":              "maven_repository",
+					"url":               "https://cloudsmith.example.com",
+					"oidc-namespace":    "space",
+					"oidc-service-slug": "repo",
+				},
+			},
+			urlMocks: []mockHttpRequest{},
+			expectedLogLines: []string{
+				"registered cloudsmith OIDC credentials for maven repository: cloudsmith.example.com",
+			},
+			urlsToAuthenticate: []string{
+				"https://cloudsmith.example.com/some-package",
+			},
+		},
 		//
 		// NPM
 		//
@@ -606,6 +761,28 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			},
 			urlsToAuthenticate: []string{
 				"https://jfrog.example.com/some-package",
+			},
+		},
+		{
+			name:     "NPM",
+			provider: "cloudsmith",
+			handlerFactory: func(creds config.Credentials) oidcHandler {
+				return NewNPMRegistryHandler(creds)
+			},
+			credentials: config.Credentials{
+				config.Credential{
+					"type":              "npm_registry",
+					"url":               "https://cloudsmith.example.com",
+					"oidc-namespace":    "space",
+					"oidc-service-slug": "repo",
+				},
+			},
+			urlMocks: []mockHttpRequest{},
+			expectedLogLines: []string{
+				"registered cloudsmith OIDC credentials for npm registry: cloudsmith.example.com",
+			},
+			urlsToAuthenticate: []string{
+				"https://cloudsmith.example.com/some-package",
 			},
 		},
 		//
@@ -703,6 +880,36 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 				"https://jfrog.example.com/v3/packages/some.package/index.json", // package url
 			},
 		},
+		{
+			name:     "NuGet",
+			provider: "cloudsmith",
+			handlerFactory: func(creds config.Credentials) oidcHandler {
+				return NewNugetFeedHandler(creds)
+			},
+			credentials: config.Credentials{
+				config.Credential{
+					"type":              "nuget_feed",
+					"url":               "https://cloudsmith.example.com/v3/index.json",
+					"oidc-namespace":    "space",
+					"oidc-service-slug": "repo",
+				},
+			},
+			urlMocks: []mockHttpRequest{
+				{
+					verb:     "GET",
+					url:      "https://cloudsmith.example.com/v3/index.json",
+					response: `{"version":"3.0.0","resources":[{"@id":"https://cloudsmith.example.com/v3/packages","@type":"PackageBaseAddress/3.0.0"}]}`,
+				},
+			},
+			expectedLogLines: []string{
+				"registered cloudsmith OIDC credentials for nuget feed: https://cloudsmith.example.com/v3/index.json",
+				"  registered cloudsmith OIDC credentials for nuget resource: https://cloudsmith.example.com/v3/packages",
+			},
+			urlsToAuthenticate: []string{
+				"https://cloudsmith.example.com/v3/index.json",                       // base url
+				"https://cloudsmith.example.com/v3/packages/some.package/index.json", // package url
+			},
+		},
 		//
 		// Pub
 		//
@@ -774,6 +981,28 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 				"https://jfrog.example.com/some-package",
 			},
 		},
+		{
+			name:     "Pub",
+			provider: "cloudsmith",
+			handlerFactory: func(creds config.Credentials) oidcHandler {
+				return NewPubRepositoryHandler(creds)
+			},
+			credentials: config.Credentials{
+				config.Credential{
+					"type":              "pub_repository",
+					"url":               "https://cloudsmith.example.com",
+					"oidc-namespace":    "space",
+					"oidc-service-slug": "repo",
+				},
+			},
+			urlMocks: []mockHttpRequest{},
+			expectedLogLines: []string{
+				"registered cloudsmith OIDC credentials for pub repository: https://cloudsmith.example.com",
+			},
+			urlsToAuthenticate: []string{
+				"https://cloudsmith.example.com/some-package",
+			},
+		},
 		//
 		// Python
 		//
@@ -843,6 +1072,28 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			},
 			urlsToAuthenticate: []string{
 				"https://jfrog.example.com/some-package",
+			},
+		},
+		{
+			name:     "Python",
+			provider: "cloudsmith",
+			handlerFactory: func(creds config.Credentials) oidcHandler {
+				return NewPythonIndexHandler(creds)
+			},
+			credentials: config.Credentials{
+				config.Credential{
+					"type":              "python_index",
+					"url":               "https://cloudsmith.example.com",
+					"oidc-namespace":    "space",
+					"oidc-service-slug": "repo",
+				},
+			},
+			urlMocks: []mockHttpRequest{},
+			expectedLogLines: []string{
+				"registered cloudsmith OIDC credentials for python index: cloudsmith.example.com",
+			},
+			urlsToAuthenticate: []string{
+				"https://cloudsmith.example.com/some-package",
 			},
 		},
 		//
@@ -917,6 +1168,29 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 				"https://jfrog.example.com/some-package",
 			},
 		},
+		{
+			name:     "RubyGems",
+			provider: "cloudsmith",
+			handlerFactory: func(creds config.Credentials) oidcHandler {
+				return NewRubyGemsServerHandler(creds)
+			},
+			credentials: config.Credentials{
+				config.Credential{
+					"type":              "rubygems_server",
+					"url":               "https://cloudsmith.example.com",
+					"host":              "https://cloudsmith.example.com",
+					"oidc-namespace":    "space",
+					"oidc-service-slug": "repo",
+				},
+			},
+			urlMocks: []mockHttpRequest{},
+			expectedLogLines: []string{
+				"registered cloudsmith OIDC credentials for rubygems server: https://cloudsmith.example.com",
+			},
+			urlsToAuthenticate: []string{
+				"https://cloudsmith.example.com/some-package",
+			},
+		},
 		//
 		// Terraform
 		//
@@ -988,6 +1262,28 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 				"https://jfrog.example.com/some-package",
 			},
 		},
+		{
+			name:     "Terraform",
+			provider: "cloudsmith",
+			handlerFactory: func(creds config.Credentials) oidcHandler {
+				return NewTerraformRegistryHandler(creds)
+			},
+			credentials: config.Credentials{
+				config.Credential{
+					"type":              "terraform_registry",
+					"url":               "https://cloudsmith.example.com",
+					"oidc-namespace":    "space",
+					"oidc-service-slug": "repo",
+				},
+			},
+			urlMocks: []mockHttpRequest{},
+			expectedLogLines: []string{
+				"registered cloudsmith OIDC credentials for terraform registry: cloudsmith.example.com",
+			},
+			urlsToAuthenticate: []string{
+				"https://cloudsmith.example.com/some-package",
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s - %s", tc.name, tc.provider), func(t *testing.T) {
@@ -1041,6 +1337,14 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 				httpmock.RegisterResponder("POST", "https://jfrog.example.com/access/api/v1/oidc/token", httpmock.NewStringResponder(200, `{
 					"access_token": "__test_token__",
 					"expires_in": 3600
+				}`))
+			case "cloudsmith":
+				// for fallback on Audience
+				t.Setenv("GITHUB_REPOSITORY_OWNER", "testowner")
+				namespace := tc.credentials[0]["oidc-namespace"]
+				httpmock.RegisterResponder("POST", fmt.Sprintf("https://api.cloudsmith.io/openid/%s/", namespace),
+					httpmock.NewStringResponder(200, `{
+						"token": "__test_token__"
 				}`))
 			default:
 				t.Fatal("unsupported provider in test case: " + tc.provider)

--- a/internal/handlers/oidc_handling_test.go
+++ b/internal/handlers/oidc_handling_test.go
@@ -1380,7 +1380,12 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			for _, urlToAuth := range tc.urlsToAuthenticate {
 				req := httptest.NewRequest("GET", urlToAuth, nil)
 				req = handleRequestAndClose(handler, req, nil)
-				assertHasTokenAuth(t, req, "Bearer", "__test_token__", "package url: "+urlToAuth)
+				if tc.provider == "cloudsmith" {
+					assert.Equal(t, "__test_token__", req.Header.Get("X-Api-Key"), "package url: "+urlToAuth+" should include Cloudsmith API key")
+					assert.Equal(t, "", req.Header.Get("Authorization"), "package url: "+urlToAuth+" should not include Authorization header for Cloudsmith")
+				} else {
+					assertHasTokenAuth(t, req, "Bearer", "__test_token__", "package url: "+urlToAuth)
+				}
 			}
 		})
 	}

--- a/internal/oidc/actions_oidc.go
+++ b/internal/oidc/actions_oidc.go
@@ -614,7 +614,7 @@ func GetCloudsmithAccessToken(ctx context.Context, params CloudsmithOIDCParamete
 		return nil, fmt.Errorf("failed to read cloudsmith token response body: %w", err)
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return nil, fmt.Errorf("cloudsmith returned status %d: %s", resp.StatusCode, string(body))
 	}
 

--- a/internal/oidc/actions_oidc.go
+++ b/internal/oidc/actions_oidc.go
@@ -618,7 +618,7 @@ func GetCloudsmithAccessToken(ctx context.Context, params CloudsmithOIDCParamete
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Cloudsmith returned status %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("cloudsmith returned status %d: %s", resp.StatusCode, string(body))
 	}
 
 	var tokenResp cloudsmithTokenResponse
@@ -627,7 +627,7 @@ func GetCloudsmithAccessToken(ctx context.Context, params CloudsmithOIDCParamete
 	}
 
 	if tokenResp.Token == "" {
-		return nil, fmt.Errorf("Cloudsmith token response does not contain a token")
+		return nil, fmt.Errorf("cloudsmith token response does not contain a token")
 	}
 
 	// Cloudsmith tokens are valid for 2 hours according to their documentation

--- a/internal/oidc/actions_oidc.go
+++ b/internal/oidc/actions_oidc.go
@@ -573,9 +573,6 @@ func GetCloudsmithAccessToken(ctx context.Context, params CloudsmithOIDCParamete
 	if params.ApiHost == "" {
 		return nil, fmt.Errorf("API host is required")
 	}
-	if params.Audience == "" {
-		return nil, fmt.Errorf("audience is required")
-	}
 	if params.OrgName == "" {
 		return nil, fmt.Errorf("org name is required")
 	}

--- a/internal/oidc/actions_oidc.go
+++ b/internal/oidc/actions_oidc.go
@@ -178,6 +178,15 @@ type awsTokenResponse struct {
 	Expiration         float64 `json:"expiration"`
 }
 
+type cloudsmithTokenRequest struct {
+	OIDCToken   string `json:"oidc_token"`
+	ServiceSlug string `json:"service_slug"`
+}
+
+type cloudsmithTokenResponse struct {
+	Token string `json:"token"`
+}
+
 // OIDCAccessToken represents an access token with its expiry information
 type OIDCAccessToken struct {
 	Token     string
@@ -555,6 +564,96 @@ func GetAWSAccessTokenForDevOps(ctx context.Context, params AWSOIDCParameters) (
 	}
 
 	return awsToken, nil
+}
+
+func GetCloudsmithAccessToken(ctx context.Context, params CloudsmithOIDCParameters, githubToken string) (*OIDCAccessToken, error) {
+	if params.ServiceSlug == "" {
+		return nil, fmt.Errorf("service slug is required")
+	}
+	if params.ApiHost == "" {
+		return nil, fmt.Errorf("API host is required")
+	}
+	if params.Audience == "" {
+		return nil, fmt.Errorf("audience is required")
+	}
+	if params.OrgName == "" {
+		return nil, fmt.Errorf("org name is required")
+	}
+	if githubToken == "" {
+		return nil, fmt.Errorf("GitHub token is required")
+	}
+
+	requestBody := cloudsmithTokenRequest{
+		OIDCToken:   githubToken,
+		ServiceSlug: params.ServiceSlug,
+	}
+
+	requestBodyJson, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal cloudsmith token request: %w", err)
+	}
+
+	tokenURL := fmt.Sprintf("https://%s/openid/%s/", params.ApiHost, params.OrgName)
+	req, err := http.NewRequestWithContext(ctx, "POST", tokenURL, bytes.NewReader(requestBodyJson))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cloudsmith token request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "dependabot-proxy/1.0")
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute cloudsmith token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read cloudsmith token response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Cloudsmith returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp cloudsmithTokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to parse cloudsmith token response: %w", err)
+	}
+
+	if tokenResp.Token == "" {
+		return nil, fmt.Errorf("Cloudsmith token response does not contain a token")
+	}
+
+	// Cloudsmith tokens are valid for 2 hours according to their documentation
+	return &OIDCAccessToken{
+		Token:     tokenResp.Token,
+		ExpiresIn: 2 * time.Hour,
+	}, nil
+}
+
+func GetCloudsmithAccessTokenForDevOps(ctx context.Context, params CloudsmithOIDCParameters) (*OIDCAccessToken, error) {
+	if !IsOIDCConfigured() {
+		return nil, fmt.Errorf("GitHub Actions OIDC is not configured")
+	}
+
+	// Get GitHub OIDC token
+	githubToken, err := GetToken(ctx, params.Audience)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get GitHub OIDC token: %w", err)
+	}
+
+	cloudsmithToken, err := GetCloudsmithAccessToken(ctx, params, githubToken)
+	if err != nil {
+		return nil, fmt.Errorf("failed to exchange GitHub token for cloudsmith token: %w", err)
+	}
+
+	return cloudsmithToken, nil
 }
 
 func calculateContentSha256Header(payload []byte) string {

--- a/internal/oidc/actions_oidc_test.go
+++ b/internal/oidc/actions_oidc_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
@@ -996,14 +995,9 @@ func TestGetCloudsmithAccessToken(t *testing.T) {
 
 				url := fmt.Sprintf("https://%s/openid/%s/", tt.params.ApiHost, tt.params.OrgName)
 				httpmock.RegisterResponder("POST", url, httpmock.Responder(func(req *http.Request) (*http.Response, error) {
-					if tt.serverHandler != nil {
-						rr := httptest.NewRecorder()
-						tt.serverHandler(rr, req)
-						return rr.Result(), nil
-					}
-					// If no handler provided but we expected one (e.g. for error cases where we don't reach the server),
-					// this mock might not be hit, which is fine.
-					return httpmock.NewStringResponse(404, "Not Found"), nil
+					rr := httptest.NewRecorder()
+					tt.serverHandler(rr, req)
+					return rr.Result(), nil
 				}))
 			}
 
@@ -1015,7 +1009,7 @@ func TestGetCloudsmithAccessToken(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, cloudsmithToken)
 				assert.Equal(t, tt.expectedToken, cloudsmithToken.Token)
-				assert.Equal(t, 2*time.Hour, cloudsmithToken.ExpiresIn)
+				assert.NotNil(t, cloudsmithToken.ExpiresIn)
 			}
 		})
 	}

--- a/internal/oidc/actions_oidc_test.go
+++ b/internal/oidc/actions_oidc_test.go
@@ -1009,7 +1009,6 @@ func TestGetCloudsmithAccessToken(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, cloudsmithToken)
 				assert.Equal(t, tt.expectedToken, cloudsmithToken.Token)
-				assert.NotNil(t, cloudsmithToken.ExpiresIn)
 			}
 		})
 	}

--- a/internal/oidc/actions_oidc_test.go
+++ b/internal/oidc/actions_oidc_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
@@ -828,6 +830,192 @@ func TestGetAWSAccessToken(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.expectedToken, awsToken.Token)
+			}
+		})
+	}
+}
+
+func TestGetCloudsmithAccessToken(t *testing.T) {
+	tests := []struct {
+		name          string
+		params        CloudsmithOIDCParameters
+		githubToken   string
+		serverHandler http.HandlerFunc
+		expectError   bool
+		expectedToken string
+	}{
+		{
+			name: "successful token exchange",
+			params: CloudsmithOIDCParameters{
+				OrgName:     "my-org",
+				ServiceSlug: "my-service",
+				ApiHost:     "api.example.com",
+				Audience:    "my-audience",
+			},
+			githubToken: "test-github-jwt-token",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "POST", r.Method)
+				assert.Equal(t, "api.example.com", r.Host)
+				assert.Equal(t, "/openid/my-org/", r.URL.Path)
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+				assert.Equal(t, "application/json", r.Header.Get("Accept"))
+				assert.Equal(t, "dependabot-proxy/1.0", r.Header.Get("User-Agent"))
+
+				bodyBytes, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				defer r.Body.Close()
+
+				var request cloudsmithTokenRequest
+				err = json.Unmarshal(bodyBytes, &request)
+				require.NoError(t, err)
+
+				assert.Equal(t, "test-github-jwt-token", request.OIDCToken)
+				assert.Equal(t, "my-service", request.ServiceSlug)
+
+				resp := cloudsmithTokenResponse{
+					Token: "test-cloudsmith-token",
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+			},
+			expectError:   false,
+			expectedToken: "test-cloudsmith-token",
+		},
+		{
+			name: "missing service slug",
+			params: CloudsmithOIDCParameters{
+				OrgName:  "my-org",
+				ApiHost:  "api.cloudsmith.io",
+				Audience: "my-audience",
+			},
+			githubToken: "test-github-jwt-token",
+			expectError: true,
+		},
+		{
+			name: "missing API host",
+			params: CloudsmithOIDCParameters{
+				OrgName:     "my-org",
+				ServiceSlug: "my-service",
+				Audience:    "my-audience",
+			},
+			githubToken: "test-github-jwt-token",
+			expectError: true,
+		},
+		{
+			name: "missing audience",
+			params: CloudsmithOIDCParameters{
+				OrgName:     "my-org",
+				ServiceSlug: "my-service",
+				ApiHost:     "api.cloudsmith.io",
+			},
+			githubToken: "test-github-jwt-token",
+			expectError: true,
+		},
+		{
+			name: "missing org name",
+			params: CloudsmithOIDCParameters{
+				ServiceSlug: "my-service",
+				ApiHost:     "api.cloudsmith.io",
+				Audience:    "my-audience",
+			},
+			githubToken: "test-github-jwt-token",
+			expectError: true,
+		},
+		{
+			name: "missing GitHub token",
+			params: CloudsmithOIDCParameters{
+				OrgName:     "my-org",
+				ServiceSlug: "my-service",
+				ApiHost:     "api.cloudsmith.io",
+				Audience:    "my-audience",
+			},
+			githubToken: "",
+			expectError: true,
+		},
+		{
+			name: "Cloudsmith returns 401",
+			params: CloudsmithOIDCParameters{
+				OrgName:     "my-org",
+				ServiceSlug: "my-service",
+				ApiHost:     "api.cloudsmith.io",
+				Audience:    "my-audience",
+			},
+			githubToken: "invalid-token",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte(`{"detail":"Invalid token."}`))
+			},
+			expectError: true,
+		},
+		{
+			name: "Cloudsmith returns invalid JSON",
+			params: CloudsmithOIDCParameters{
+				OrgName:     "my-org",
+				ServiceSlug: "my-service",
+				ApiHost:     "api.cloudsmith.io",
+				Audience:    "my-audience",
+			},
+			githubToken: "test-github-jwt-token",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{invalid json`))
+			},
+			expectError: true,
+		},
+		{
+			name: "Cloudsmith returns empty token",
+			params: CloudsmithOIDCParameters{
+				OrgName:     "my-org",
+				ServiceSlug: "my-service",
+				ApiHost:     "api.cloudsmith.io",
+				Audience:    "my-audience",
+			},
+			githubToken: "test-github-jwt-token",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				resp := cloudsmithTokenResponse{
+					Token: "",
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			var cloudsmithToken *OIDCAccessToken
+			var err error
+
+			if tt.params.ApiHost != "" && tt.params.OrgName != "" {
+				// Create a test server for Cloudsmith
+				httpmock.Activate()
+				defer httpmock.DeactivateAndReset()
+
+				url := fmt.Sprintf("https://%s/openid/%s/", tt.params.ApiHost, tt.params.OrgName)
+				httpmock.RegisterResponder("POST", url, httpmock.Responder(func(req *http.Request) (*http.Response, error) {
+					if tt.serverHandler != nil {
+						rr := httptest.NewRecorder()
+						tt.serverHandler(rr, req)
+						return rr.Result(), nil
+					}
+					// If no handler provided but we expected one (e.g. for error cases where we don't reach the server),
+					// this mock might not be hit, which is fine.
+					return httpmock.NewStringResponse(404, "Not Found"), nil
+				}))
+			}
+
+			cloudsmithToken, err = GetCloudsmithAccessToken(ctx, tt.params, tt.githubToken)
+
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, cloudsmithToken)
+				assert.Equal(t, tt.expectedToken, cloudsmithToken.Token)
+				assert.Equal(t, 2*time.Hour, cloudsmithToken.ExpiresIn)
 			}
 		})
 	}

--- a/internal/oidc/oidc_credential.go
+++ b/internal/oidc/oidc_credential.go
@@ -153,7 +153,10 @@ func CreateOIDCCredential(cred config.Credential) (*OIDCCredential, error) {
 			if owner := GetRepositoryOwner(); owner != "" {
 				audience = fmt.Sprintf("https://github.com/%s", owner)
 			} else {
-				return nil, fmt.Errorf("missing audience for cloudsmith")
+				return nil, fmt.Errorf(
+					"missing audience for cloudsmith, either provide 'audience' or set '%s' in environment",
+					envActionsRepositoryOwner,
+				)
 			}
 		}
 		parameters = &CloudsmithOIDCParameters{

--- a/internal/oidc/oidc_credential.go
+++ b/internal/oidc/oidc_credential.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	envActionsRepositoryOwner = "ACTIONS_REPOSITORY_OWNER"
+	envActionsRepositoryOwner = "GITHUB_REPOSITORY_OWNER"
 )
 
 func GetRepositoryOwner() string {

--- a/internal/oidc/oidc_credential.go
+++ b/internal/oidc/oidc_credential.go
@@ -225,8 +225,15 @@ func TryAuthOIDCRequestWithPrefix(mutex *sync.RWMutex, oidcCredentials map[strin
 		if err != nil {
 			logging.RequestLogf(ctx, "* failed to get %s token via OIDC for %s: %v", matchedCred.Provider(), req.URL.Hostname(), err)
 		} else {
-			logging.RequestLogf(ctx, "* authenticating request with OIDC token (host: %s)", req.URL.Hostname())
-			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+			switch matchedCred.parameters.(type) {
+			case *CloudsmithOIDCParameters:
+				logging.RequestLogf(ctx, "* authenticating request with OIDC API key (host: %s)", req.URL.Hostname())
+				req.Header.Set("X-Api-Key", token)
+			default:
+				logging.RequestLogf(ctx, "* authenticating request with OIDC token (host: %s)", req.URL.Hostname())
+				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+			}
+
 			return true
 		}
 	}


### PR DESCRIPTION
**Implements support for OIDC authentication to the private registry service [Cloudsmith](https://cloudsmith.com/)**

The implementation is based on the information available in the [official documentation](https://docs.cloudsmith.com/authentication/openid-connect#token-exchange) and in the [vendor provided GitHub Action](https://github.com/cloudsmith-io/cloudsmith-cli-action/blob/master/src/oidc-auth.js#L215). The code is mostly copied from the existing JFrog OIDC implementation and adapted to work with Cloudsmith as I am not a Go developer and not that familiar with it.

**Notes:**
* I added an environment lookup to the credential creation to have a fallback value for the audience based on the [GHA implementation](https://github.com/cloudsmith-io/cloudsmith-cli-action/blob/master/src/main.js#L18). I am not sure if this is the right place for it or should it go into the `actions_oidc` code.
* I named input parameters based on the vendor GHA and code variables based on the API parameters.
* I have not been able to test the implementation in practice as I don't know how to run Dependabot locally. 

I appreciate and welcome all feedback on the PR.
