### PR TITLE
Migrate hex handler to OIDCRegistry

### DIFF
--- a/internal/handlers/hex_repository.go
+++ b/internal/handlers/hex_repository.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"net/http"
 	"strings"
-	"sync"
 
 	"github.com/elazarl/goproxy"
 
@@ -15,9 +14,8 @@ import (
 
 // HexRepositoryHandler handles requests to private hex repositories, adding auth
 type HexRepositoryHandler struct {
-	credentials     []hexRepositoryCredentials
-	oidcCredentials map[string]*oidc.OIDCCredential
-	mutex           sync.RWMutex
+	credentials  []hexRepositoryCredentials
+	oidcRegistry *oidc.OIDCRegistry
 }
 
 type hexRepositoryCredentials struct {
@@ -27,8 +25,8 @@ type hexRepositoryCredentials struct {
 
 func NewHexRepositoryHandler(creds config.Credentials) *HexRepositoryHandler {
 	handler := HexRepositoryHandler{
-		credentials:     []hexRepositoryCredentials{},
-		oidcCredentials: make(map[string]*oidc.OIDCCredential),
+		credentials:  []hexRepositoryCredentials{},
+		oidcRegistry: oidc.NewOIDCRegistry(),
 	}
 
 	for _, cred := range creds {
@@ -38,12 +36,14 @@ func NewHexRepositoryHandler(creds config.Credentials) *HexRepositoryHandler {
 
 		url := cred.GetString("url")
 
-		oidcCredential, _ := oidc.CreateOIDCCredential(cred)
-		if oidcCredential != nil {
-			if url != "" {
-				handler.oidcCredentials[url] = oidcCredential
-				logging.RequestLogf(nil, "registered %s OIDC credentials for hex repository: %s", oidcCredential.Provider(), url)
+		// Hex credentials must remain URL-scoped; do not allow OIDC
+		// registration to fall back to host-only matching when url is empty.
+		// OIDC credentials are not used as static credentials.
+		if url != "" {
+			if oidcCred, _, _ := handler.oidcRegistry.Register(cred, []string{"url"}, "hex repository"); oidcCred != nil {
+				continue
 			}
+		} else if oidcCred, _ := oidc.CreateOIDCCredential(cred); oidcCred != nil {
 			continue
 		}
 
@@ -70,7 +70,7 @@ func (h *HexRepositoryHandler) HandleRequest(req *http.Request, ctx *goproxy.Pro
 	}
 
 	// Try OIDC credentials first
-	if oidc.TryAuthOIDCRequestWithPrefix(&h.mutex, h.oidcCredentials, req, ctx) {
+	if h.oidcRegistry.TryAuth(req, ctx) {
 		return req, nil
 	}
 


### PR DESCRIPTION
## What

Migrate the Hex repository handler from manual OIDC credential map + mutex to the shared `OIDCRegistry` type introduced in #78.

## Why

Part of the phased migration to fix OIDC credential collisions when multiple registries share a host (#87).

## Behavior changes

- **Credential selection is now deterministic.** The old code iterated over a Go map (`map[string]*OIDCCredential`), so with multiple OIDC credentials on the same host, which one matched was nondeterministic. `OIDCRegistry.TryAuth` uses longest path-prefix matching, ensuring the most specific credential always wins. This is the core fix for #87.

- **Host matching uses `strings.ToLower` instead of IDNA normalization.** The old `TryAuthOIDCRequestWithPrefix` used `helpers.AreHostnamesEqual` (IDNA `ToASCII`), while `OIDCRegistry.TryAuth` uses lowercase comparison. This is acceptable because all real OIDC registries (Azure DevOps, JFrog, AWS CodeArtifact, Cloudsmith) use ASCII hostnames — no package registry uses internationalized domain names.

- **OIDC registration guarded with `url != ""`** to preserve the original URL-scoped behavior and prevent fallback to host-only matching when the URL field is empty.

Single-file diff, no test changes needed — existing OIDC tests cover Hex.