### PR TITLE
[Task] Refactor CloudSmith OIDC credential keys to remove oidc- prefix

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+### What are you trying to accomplish?
+
+<!-- Provide both a what and a _why_ for the change. -->
+
+<!-- What issues does this affect or fix? -->
+
+### Anything you want to highlight for special attention from reviewers?
+
+<!-- If there were multiple ways to approach the problem, why did you pick this one? -->
+
+### How will you know you've accomplished your goal?
+
+<!--
+  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
+  * If you've added a new feature, how will you demonstrate it to others?
+  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
+-->
+
+### Checklist
+
+<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->
+
+- [ ] I have run the complete test suite to ensure all tests and linters pass.
+- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
+- [ ] I have written clear and descriptive commit messages.
+- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
+- [ ] I have ensured that the code is well-documented and easy to understand.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /dependabot-proxy
 /proxy
 /config.json
+/tmp

--- a/internal/handlers/oidc_handling_test.go
+++ b/internal/handlers/oidc_handling_test.go
@@ -118,11 +118,11 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			},
 			credentials: config.Credentials{
 				config.Credential{
-					"type":              "cargo_registry",
-					"url":               "https://cloudsmith.example.com",
-					"oidc-namespace":    "space",
-					"oidc-service-slug": "repo",
-					"oidc-audience":     "my-audience",
+					"type":         "cargo_registry",
+					"url":          "https://cloudsmith.example.com",
+					"namespace":    "space",
+					"service-slug": "repo",
+					"audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -213,11 +213,11 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			},
 			credentials: config.Credentials{
 				config.Credential{
-					"type":              "composer_repository",
-					"registry":          "https://cloudsmith.example.com",
-					"oidc-namespace":    "space",
-					"oidc-service-slug": "repo",
-					"oidc-audience":     "my-audience",
+					"type":         "composer_repository",
+					"registry":     "https://cloudsmith.example.com",
+					"namespace":    "space",
+					"service-slug": "repo",
+					"audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -308,11 +308,11 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			},
 			credentials: config.Credentials{
 				config.Credential{
-					"type":              "docker_registry",
-					"registry":          "https://cloudsmith.example.com",
-					"oidc-namespace":    "space",
-					"oidc-service-slug": "repo",
-					"oidc-audience":     "my-audience",
+					"type":         "docker_registry",
+					"registry":     "https://cloudsmith.example.com",
+					"namespace":    "space",
+					"service-slug": "repo",
+					"audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -402,11 +402,11 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			},
 			credentials: config.Credentials{
 				config.Credential{
-					"type":              "goproxy_server",
-					"url":               "https://cloudsmith.example.com",
-					"oidc-namespace":    "space",
-					"oidc-service-slug": "repo",
-					"oidc-audience":     "my-audience",
+					"type":         "goproxy_server",
+					"url":          "https://cloudsmith.example.com",
+					"namespace":    "space",
+					"service-slug": "repo",
+					"audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -496,11 +496,11 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			},
 			credentials: config.Credentials{
 				config.Credential{
-					"type":              "helm_registry",
-					"registry":          "https://cloudsmith.example.com",
-					"oidc-namespace":    "space",
-					"oidc-service-slug": "repo",
-					"oidc-audience":     "my-audience",
+					"type":         "helm_registry",
+					"registry":     "https://cloudsmith.example.com",
+					"namespace":    "space",
+					"service-slug": "repo",
+					"audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -590,11 +590,11 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			},
 			credentials: config.Credentials{
 				config.Credential{
-					"type":              "hex_repository",
-					"url":               "https://cloudsmith.example.com",
-					"oidc-namespace":    "space",
-					"oidc-service-slug": "repo",
-					"oidc-audience":     "my-audience",
+					"type":         "hex_repository",
+					"url":          "https://cloudsmith.example.com",
+					"namespace":    "space",
+					"service-slug": "repo",
+					"audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -684,11 +684,11 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			},
 			credentials: config.Credentials{
 				config.Credential{
-					"type":              "maven_repository",
-					"url":               "https://cloudsmith.example.com",
-					"oidc-namespace":    "space",
-					"oidc-service-slug": "repo",
-					"oidc-audience":     "my-audience",
+					"type":         "maven_repository",
+					"url":          "https://cloudsmith.example.com",
+					"namespace":    "space",
+					"service-slug": "repo",
+					"audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -778,11 +778,11 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			},
 			credentials: config.Credentials{
 				config.Credential{
-					"type":              "npm_registry",
-					"url":               "https://cloudsmith.example.com",
-					"oidc-namespace":    "space",
-					"oidc-service-slug": "repo",
-					"oidc-audience":     "my-audience",
+					"type":         "npm_registry",
+					"url":          "https://cloudsmith.example.com",
+					"namespace":    "space",
+					"service-slug": "repo",
+					"audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -896,11 +896,11 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			},
 			credentials: config.Credentials{
 				config.Credential{
-					"type":              "nuget_feed",
-					"url":               "https://cloudsmith.example.com/v3/index.json",
-					"oidc-namespace":    "space",
-					"oidc-service-slug": "repo",
-					"oidc-audience":     "my-audience",
+					"type":         "nuget_feed",
+					"url":          "https://cloudsmith.example.com/v3/index.json",
+					"namespace":    "space",
+					"service-slug": "repo",
+					"audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{
@@ -998,11 +998,11 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			},
 			credentials: config.Credentials{
 				config.Credential{
-					"type":              "pub_repository",
-					"url":               "https://cloudsmith.example.com",
-					"oidc-namespace":    "space",
-					"oidc-service-slug": "repo",
-					"oidc-audience":     "my-audience",
+					"type":         "pub_repository",
+					"url":          "https://cloudsmith.example.com",
+					"namespace":    "space",
+					"service-slug": "repo",
+					"audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -1092,11 +1092,11 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			},
 			credentials: config.Credentials{
 				config.Credential{
-					"type":              "python_index",
-					"url":               "https://cloudsmith.example.com",
-					"oidc-namespace":    "space",
-					"oidc-service-slug": "repo",
-					"oidc-audience":     "my-audience",
+					"type":         "python_index",
+					"url":          "https://cloudsmith.example.com",
+					"namespace":    "space",
+					"service-slug": "repo",
+					"audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -1187,12 +1187,12 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			},
 			credentials: config.Credentials{
 				config.Credential{
-					"type":              "rubygems_server",
-					"url":               "https://cloudsmith.example.com",
-					"host":              "https://cloudsmith.example.com",
-					"oidc-namespace":    "space",
-					"oidc-service-slug": "repo",
-					"oidc-audience":     "my-audience",
+					"type":         "rubygems_server",
+					"url":          "https://cloudsmith.example.com",
+					"host":         "https://cloudsmith.example.com",
+					"namespace":    "space",
+					"service-slug": "repo",
+					"audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -1282,11 +1282,11 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			},
 			credentials: config.Credentials{
 				config.Credential{
-					"type":              "terraform_registry",
-					"url":               "https://cloudsmith.example.com",
-					"oidc-namespace":    "space",
-					"oidc-service-slug": "repo",
-					"oidc-audience":     "my-audience",
+					"type":         "terraform_registry",
+					"url":          "https://cloudsmith.example.com",
+					"namespace":    "space",
+					"service-slug": "repo",
+					"audience":     "my-audience",
 				},
 			},
 			urlMocks: []mockHttpRequest{},
@@ -1352,7 +1352,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"expires_in": 3600
 				}`))
 			case "cloudsmith":
-				namespace := tc.credentials[0]["oidc-namespace"]
+				namespace := tc.credentials[0]["namespace"]
 				httpmock.RegisterResponder("POST", fmt.Sprintf("https://api.cloudsmith.io/openid/%s/", namespace),
 					httpmock.NewStringResponder(200, `{
 						"token": "__test_token__"

--- a/internal/oidc/oidc_credential.go
+++ b/internal/oidc/oidc_credential.go
@@ -98,9 +98,9 @@ func CreateOIDCCredential(cred config.Credential) (*OIDCCredential, error) {
 	domainOwner := cred.GetString("domain-owner")
 
 	// cloudsmith values
-	orgName := cred.GetString("oidc-namespace")
-	serviceSlug := cred.GetString("oidc-service-slug")
-	cloudsmithAudience := cred.GetString("oidc-audience")
+	orgName := cred.GetString("namespace")
+	serviceSlug := cred.GetString("service-slug")
+	cloudsmithAudience := cred.GetString("audience")
 
 	switch {
 	case tenantID != "" && clientID != "":

--- a/internal/oidc/oidc_credential_test.go
+++ b/internal/oidc/oidc_credential_test.go
@@ -271,9 +271,9 @@ func TestTryCreateOIDCCredential(t *testing.T) {
 		{
 			"cloudsmith",
 			config.Credential{
-				"oidc-namespace":    "my-org",
-				"oidc-service-slug": "my-service",
-				"oidc-audience":     "my-audience",
+				"namespace":    "my-org",
+				"service-slug": "my-service",
+				"audience":     "my-audience",
 			},
 			&CloudsmithOIDCParameters{
 				OrgName:     "my-org",
@@ -285,10 +285,10 @@ func TestTryCreateOIDCCredential(t *testing.T) {
 		{
 			"cloudsmith with explicit values",
 			config.Credential{
-				"oidc-namespace":    "my-org",
-				"oidc-service-slug": "my-service",
-				"api-host":          "api.example.com",
-				"oidc-audience":     "my-audience",
+				"namespace":    "my-org",
+				"service-slug": "my-service",
+				"api-host":     "api.example.com",
+				"audience":     "my-audience",
 			},
 			&CloudsmithOIDCParameters{
 				OrgName:     "my-org",
@@ -300,23 +300,23 @@ func TestTryCreateOIDCCredential(t *testing.T) {
 		{
 			"looks like cloudsmith but missing service slug and audience",
 			config.Credential{
-				"oidc-namespace": "my-org",
+				"namespace": "my-org",
 			},
 			nil,
 		},
 		{
 			"looks like cloudsmith but missing service slug",
 			config.Credential{
-				"oidc-namespace": "my-org",
-				"oidc-audience":  "my-audience",
+				"namespace": "my-org",
+				"audience":  "my-audience",
 			},
 			nil,
 		},
 		{
 			"looks like cloudsmith but missing audience",
 			config.Credential{
-				"oidc-namespace":    "my-org",
-				"oidc-service-slug": "my-service",
+				"namespace":    "my-org",
+				"service-slug": "my-service",
 			},
 			nil,
 		},

--- a/internal/oidc/oidc_registry_test.go
+++ b/internal/oidc/oidc_registry_test.go
@@ -382,11 +382,11 @@ func mockCloudsmithOIDC(t *testing.T, namespace, token string) {
 
 func cloudsmithCred(namespace, serviceSlug, audience, url string) config.Credential {
 	return config.Credential{
-		"type":              "test_registry",
-		"oidc-namespace":    namespace,
-		"oidc-service-slug": serviceSlug,
-		"oidc-audience":     audience,
-		"url":               url,
+		"type":         "test_registry",
+		"namespace":    namespace,
+		"service-slug": serviceSlug,
+		"audience":     audience,
+		"url":          url,
 	}
 }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Refactor CloudSmith OIDC credential field names to remove the `oidc-` prefix for consistency with other OIDC providers (Azure, AWS, JFrog).

Changes:
- `oidc-namespace` → `namespace`
- `oidc-service-slug` → `service-slug`
- `oidc-audience` → `audience`

This also adds a PR template modeled after [dependabot-core](https://github.com/dependabot/dependabot-core/blob/main/.github/pull_request_template.md) to standardize PR descriptions.

### Anything you want to highlight for special attention from reviewers?

The credential key names (`namespace`, `service-slug`, `audience`) are now consistent with how other providers define their OIDC parameters — without a provider-specific prefix. This is a breaking change for any configuration currently using the `oidc-` prefixed keys, so companion PRs in github/github and github-ui must land together.

### How will you know you have accomplished your goal?

All existing tests pass with the updated key names, confirming functional equivalence. The companion PRs in github/github and github-ui will update the configuration layer to emit the new key names.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.