### PR TITLE
fix(cache): skip malformed cached responses to avoid invalid status line

### DIFF
--- a/internal/cache/handlers.go
+++ b/internal/cache/handlers.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"net/http/httputil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -180,6 +181,11 @@ func (d *DB) OnRequest(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *
 	key := key(r)
 	ctxdata.SetValue(ctx, keyValue, key)
 	if entry, ok := d.cacheDB[key]; ok {
+		if http.StatusText(entry.Status) == "" {
+			logrus.Warnf("skipping cache entry with invalid status code (%d) for %s", entry.Status, r.URL.String())
+			return r, nil
+		}
+
 		f, err := os.Open(entry.FilePath)
 		if err != nil {
 			logrus.Errorln("failed to open cache file:", err)
@@ -192,7 +198,18 @@ func (d *DB) OnRequest(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *
 		resp.TransferEncoding = r.TransferEncoding
 		resp.Header = entry.ResponseHeaders
 		resp.StatusCode = entry.Status
+		resp.Status = fmt.Sprintf("%d %s", entry.Status, http.StatusText(entry.Status))
+		resp.Proto = "HTTP/1.1"
+		resp.ProtoMajor = 1
+		resp.ProtoMinor = 1
 		resp.Body = f
+
+		if _, err := httputil.DumpResponse(resp, false); err != nil {
+			logrus.Warnf("skipping cache entry with invalid response metadata for %s: %v", r.URL.String(), err)
+			_ = f.Close()
+			return r, nil
+		}
+
 		return r, resp
 	}
 	return r, nil

--- a/internal/cache/handlers_test.go
+++ b/internal/cache/handlers_test.go
@@ -123,6 +123,23 @@ func TestCache(t *testing.T) {
 			t.Error("cache should have 1 entry, got", len(cacher.cacheDB))
 		}
 	})
+
+	t.Run("Corrupt cache entry with invalid status is ignored", func(t *testing.T) {
+		req := httptest.NewRequest("GET", URL+"/invalid-status", nil)
+		cacheKey := key(req)
+		cacher.cacheDB[cacheKey] = &Entry{
+			Status:          0,
+			FilePath:        filepath.Join(cacheDir, "missing.cache"),
+			ResponseHeaders: http.Header{},
+		}
+
+		ctx := &goproxy.ProxyCtx{Req: req}
+		_, resp := cacher.OnRequest(req, ctx)
+		if resp != nil {
+			resp.Body.Close()
+			t.Error("invalid cache entries should be ignored")
+		}
+	})
 }
 
 func Test_sanitize(t *testing.T) {


### PR DESCRIPTION
### What are you trying to accomplish?

Prevent Dependabot Cargo updates from failing with Weird server reply (Invalid status line) when fetching `crates.io` index entries through the proxy.

**Why:**
A malformed cached HTTP response could be replayed with invalid status metadata, which can produce an invalid HTTP status line for `Cargo/libcurl`. This caused update jobs to fail while downloading dependencies from `index.crates.io`.

What this change does:
Validates cached response `status/metadata` before replay, skips corrupt cache entries, and falls back to upstream fetch instead of returning malformed cached responses. Also adds a regression test to ensure invalid-status cache entries are ignored.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

1. Automated verification
- `handlers_test.go:127`passes, proving corrupt cache entries with invalid status are ignored.
- go test `./internal/cache` passes (no regression in cache behavior).
2. Behavioral verification (original failure mode)
- Re-running the previously failing Dependabot Cargo update through this proxy no longer returns Weird server reply (Invalid status line) for `crates.io index` downloads.
3. Runtime safety verification
- When a malformed cache entry is encountered, proxy logs show it is skipped (not replayed), and requests fall back to upstream successfully.
- No functional regression
Valid cached responses continue to be served normally (existing cache hit path remains intact), while only malformed cached metadata is rejected.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
