### PR TITLE
Remove dead TryAuthOIDCRequestWithPrefix function

### DIFF
--- a/internal/oidc/oidc_credential.go
+++ b/internal/oidc/oidc_credential.go
@@ -3,16 +3,11 @@ package oidc
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"net/url"
 	"sync"
 	"time"
 
-	"github.com/elazarl/goproxy"
-
 	"github.com/dependabot/proxy/internal/config"
-	"github.com/dependabot/proxy/internal/helpers"
-	"github.com/dependabot/proxy/internal/logging"
 )
 
 type OIDCParameters interface {
@@ -202,41 +197,4 @@ func GetOrRefreshOIDCToken(cred *OIDCCredential, ctx context.Context) (string, e
 	cred.tokenExpiry = time.Now().Add(oidcAccessToken.ExpiresIn).Add(-time.Minute * 5) // refresh 5 minutes before expiry
 
 	return oidcAccessToken.Token, nil
-}
-
-// TryAuthOIDCRequestWithPrefix tries to authenticate the request using OIDC credentials if available
-func TryAuthOIDCRequestWithPrefix(mutex *sync.RWMutex, oidcCredentials map[string]*OIDCCredential, req *http.Request, ctx *goproxy.ProxyCtx) bool {
-	// Find matching credential while holding the lock, then release before token refresh
-	var matchedCred *OIDCCredential
-	if len(oidcCredentials) > 0 {
-		mutex.RLock()
-		for key, oidcCred := range oidcCredentials {
-			// Match by URL or host
-			if helpers.UrlMatchesRequest(req, key, true) || helpers.CheckHost(req, key) {
-				matchedCred = oidcCred
-				break
-			}
-		}
-		mutex.RUnlock()
-	}
-
-	if matchedCred != nil {
-		token, err := GetOrRefreshOIDCToken(matchedCred, req.Context())
-		if err != nil {
-			logging.RequestLogf(ctx, "* failed to get %s token via OIDC for %s: %v", matchedCred.Provider(), req.URL.Hostname(), err)
-		} else {
-			switch matchedCred.parameters.(type) {
-			case *CloudsmithOIDCParameters:
-				logging.RequestLogf(ctx, "* authenticating request with OIDC API key (host: %s)", req.URL.Hostname())
-				req.Header.Set("X-Api-Key", token)
-			default:
-				logging.RequestLogf(ctx, "* authenticating request with OIDC token (host: %s)", req.URL.Hostname())
-				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-			}
-
-			return true
-		}
-	}
-
-	return false
 }


### PR DESCRIPTION
### What are you trying to accomplish?

Remove dead code left behind after the OIDCRegistry migration (PRs #78–#92). The `TryAuthOIDCRequestWithPrefix` function in `internal/oidc/oidc_credential.go` was the old per-handler OIDC authentication pattern. All handlers now use `OIDCRegistry.TryAuth()` instead, leaving this function with **zero callers** anywhere in the codebase.

Cleaning this up reduces confusion for future contributors and removes unused dependencies from the file.

### Anything you want to highlight for special attention from reviewers?

Removing the function also allows removing 4 imports that were only used by it: `net/http`, `goproxy`, `helpers`, and `logging`. The `sync` import is retained since it is still used by the `OIDCCredential.mutex` field.

The `CreateOIDCCredential` calls in cargo/hex/pub handlers (used as guard clauses to skip URL-less OIDC credentials) were reviewed and confirmed to be intentional, not dead code.

### How will you know you have accomplished your goal?

- Confirmed zero callers via `grep` across the entire codebase
- `go build ./...` succeeds
- `go test ./...` passes (all packages)

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
