### PR TITLE
Simplify OIDC credential test parameter assertions

### DIFF
--- a/internal/oidc/oidc_credential_test.go
+++ b/internal/oidc/oidc_credential_test.go
@@ -386,54 +386,7 @@ func TestTryCreateOIDCCredential(t *testing.T) {
 			assert.Equal(t, tc.expectedParameters.Name(), actual.Provider())
 
 			// check parameters
-			switch p := actual.parameters.(type) {
-			case *AWSOIDCParameters:
-				expectedParams, ok := tc.expectedParameters.(*AWSOIDCParameters)
-				if !ok {
-					t.Fatalf("expected parameters of type AWSOIDCParameters, but got %T", tc.expectedParameters)
-				}
-				assert.Equal(t, expectedParams.Region, p.Region)
-				assert.Equal(t, expectedParams.AccountID, p.AccountID)
-				assert.Equal(t, expectedParams.RoleName, p.RoleName)
-				assert.Equal(t, expectedParams.Audience, p.Audience)
-				assert.Equal(t, expectedParams.Domain, p.Domain)
-				assert.Equal(t, expectedParams.DomainOwner, p.DomainOwner)
-			case *AzureOIDCParameters:
-				expectedParams, ok := tc.expectedParameters.(*AzureOIDCParameters)
-				if !ok {
-					t.Fatalf("expected parameters of type AzureOIDCParameters, but got %T", tc.expectedParameters)
-				}
-				assert.Equal(t, expectedParams.TenantID, p.TenantID)
-				assert.Equal(t, expectedParams.ClientID, p.ClientID)
-			case *JFrogOIDCParameters:
-				expectedParams, ok := tc.expectedParameters.(*JFrogOIDCParameters)
-				if !ok {
-					t.Fatalf("expected parameters of type JFrogOIDCParameters, but got %T", tc.expectedParameters)
-				}
-				assert.Equal(t, expectedParams.JFrogURL, p.JFrogURL)
-				assert.Equal(t, expectedParams.ProviderName, p.ProviderName)
-				assert.Equal(t, expectedParams.Audience, p.Audience)
-				assert.Equal(t, expectedParams.IdentityMappingName, p.IdentityMappingName)
-			case *CloudsmithOIDCParameters:
-				expectedParams, ok := tc.expectedParameters.(*CloudsmithOIDCParameters)
-				if !ok {
-					t.Fatalf("expected parameters of type CloudsmithOIDCParameters, but got %T", tc.expectedParameters)
-				}
-				assert.Equal(t, expectedParams.OrgName, p.OrgName)
-				assert.Equal(t, expectedParams.ServiceSlug, p.ServiceSlug)
-				assert.Equal(t, expectedParams.ApiHost, p.ApiHost)
-				assert.Equal(t, expectedParams.Audience, p.Audience)
-			case *GCPOIDCParameters:
-				expectedParams, ok := tc.expectedParameters.(*GCPOIDCParameters)
-				if !ok {
-					t.Fatalf("expected parameters of type GCPOIDCParameters, but got %T", tc.expectedParameters)
-				}
-				assert.Equal(t, expectedParams.WorkloadIdentityProvider, p.WorkloadIdentityProvider)
-				assert.Equal(t, expectedParams.ServiceAccount, p.ServiceAccount)
-				assert.Equal(t, expectedParams.Audience, p.Audience)
-			default:
-				t.Fatalf("unexpected parameters type %T", actual.parameters)
-			}
+			assert.Equal(t, tc.expectedParameters, actual.parameters)
 		})
 	}
 }


### PR DESCRIPTION
### What are you trying to accomplish?

Simplify the OIDC credential test parameter assertions in `oidc_credential_test.go`, as identified in [PR #108 follow-up](https://github.com/dependabot/proxy/pull/108#issuecomment-4291857690).

### Changes

Replace the ~50-line type switch that does field-by-field comparison of parameter structs across all 5 providers with a single `assert.Equal` call.

**Before:** Manual type switch with per-provider field assertions (~50 lines)
**After:** `assert.Equal(t, tc.expectedParameters, actual.parameters)` (1 line)

This works because all OIDC parameter types (`AWSOIDCParameters`, `AzureOIDCParameters`, etc.) are simple value structs with no unexported fields. `assert.Equal` uses `reflect.DeepEqual` under the hood, which handles comparison correctly and provides clear diffs on failure.

### How will you know you have accomplished your goal?

- `go test ./internal/oidc/ -run TestTryCreateOIDCCredential` — all 17 subtests pass
- No behavior change — same coverage, better maintainability

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request.
- [x] I have ensured that the code is well-documented and easy to understand.
