### PR TITLE
Unifies authorization for all outbound requests

### DIFF
--- a/internal/handlers/azdo_api.go
+++ b/internal/handlers/azdo_api.go
@@ -71,7 +71,7 @@ func (h *AzureDevOpsAPIHandler) HandleRequest(req *http.Request, ctx *goproxy.Pr
 	}
 
 	logging.RequestLogf(ctx, "* authenticating azure devops api request with token for %s", host)
-	helpers.SetAuthorization(req, helpers.BasicAuth(creds[0].username, creds[0].password))
+	helpers.SetBasicAuthorization(req, creds[0].username, creds[0].password)
 
 	// Azure DevOps requires an api-version to be set for requests. Add it if it is not present.
 	var queryParams = req.URL.Query()

--- a/internal/handlers/azdo_api.go
+++ b/internal/handlers/azdo_api.go
@@ -71,7 +71,7 @@ func (h *AzureDevOpsAPIHandler) HandleRequest(req *http.Request, ctx *goproxy.Pr
 	}
 
 	logging.RequestLogf(ctx, "* authenticating azure devops api request with token for %s", host)
-	req.SetBasicAuth(creds[0].username, creds[0].password)
+	helpers.SetAuthorization(req, helpers.BasicAuth(creds[0].username, creds[0].password))
 
 	// Azure DevOps requires an api-version to be set for requests. Add it if it is not present.
 	var queryParams = req.URL.Query()

--- a/internal/handlers/cargo_registry.go
+++ b/internal/handlers/cargo_registry.go
@@ -101,7 +101,7 @@ func (h *CargoRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.Pro
 		}
 
 		logging.RequestLogf(ctx, "* authenticating cargo registry request (url: %s)", cred.url)
-		helpers.SetAuthorization(req, helpers.RawAuth(cred.authorization))
+		helpers.SetRawAuthorization(req, cred.authorization)
 
 		return req, nil
 	}

--- a/internal/handlers/cargo_registry.go
+++ b/internal/handlers/cargo_registry.go
@@ -101,7 +101,7 @@ func (h *CargoRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.Pro
 		}
 
 		logging.RequestLogf(ctx, "* authenticating cargo registry request (url: %s)", cred.url)
-		req.Header.Set("Authorization", cred.authorization)
+		helpers.SetAuthorization(req, helpers.RawAuth(cred.authorization))
 
 		return req, nil
 	}

--- a/internal/handlers/composer.go
+++ b/internal/handlers/composer.go
@@ -81,10 +81,10 @@ func (h *ComposerHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx
 
 		if cred.token != "" {
 			logging.RequestLogf(ctx, "* authenticating composer registry request (host: %s, token auth)", req.URL.Hostname())
-			helpers.SetAuthorization(req, helpers.BearerAuth(cred.token))
+			helpers.SetBearerAuthorization(req, cred.token)
 		} else {
 			logging.RequestLogf(ctx, "* authenticating composer registry request (host: %s, basic auth)", req.URL.Hostname())
-			helpers.SetAuthorization(req, helpers.BasicAuth(cred.username, cred.password))
+			helpers.SetBasicAuthorization(req, cred.username, cred.password)
 		}
 
 		return req, nil

--- a/internal/handlers/composer.go
+++ b/internal/handlers/composer.go
@@ -81,10 +81,10 @@ func (h *ComposerHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx
 
 		if cred.token != "" {
 			logging.RequestLogf(ctx, "* authenticating composer registry request (host: %s, token auth)", req.URL.Hostname())
-			req.Header.Set("Authorization", "Bearer "+cred.token)
+			helpers.SetAuthorization(req, helpers.BearerAuth(cred.token))
 		} else {
 			logging.RequestLogf(ctx, "* authenticating composer registry request (host: %s, basic auth)", req.URL.Hostname())
-			req.SetBasicAuth(cred.username, cred.password)
+			helpers.SetAuthorization(req, helpers.BasicAuth(cred.username, cred.password))
 		}
 
 		return req, nil

--- a/internal/handlers/docker_registry.go
+++ b/internal/handlers/docker_registry.go
@@ -120,7 +120,7 @@ func (h *DockerRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.Pr
 
 		if cred.getECRCredentials(ctx) {
 			logging.RequestLogf(ctx, "* authenticating docker ecr request (host: %s)", req.URL.Hostname())
-			helpers.SetAuthorization(req, helpers.BasicAuth(cred.ecrUsername, cred.ecrPassword))
+			helpers.SetBasicAuthorization(req, cred.ecrUsername, cred.ecrPassword)
 		} else {
 			logging.RequestLogf(ctx, "* authenticating docker registry request (host: %s)", req.URL.Hostname())
 			transport := &registry.BasicTransport{

--- a/internal/handlers/docker_registry.go
+++ b/internal/handlers/docker_registry.go
@@ -120,7 +120,7 @@ func (h *DockerRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.Pr
 
 		if cred.getECRCredentials(ctx) {
 			logging.RequestLogf(ctx, "* authenticating docker ecr request (host: %s)", req.URL.Hostname())
-			req.SetBasicAuth(cred.ecrUsername, cred.ecrPassword)
+			helpers.SetAuthorization(req, helpers.BasicAuth(cred.ecrUsername, cred.ecrPassword))
 		} else {
 			logging.RequestLogf(ctx, "* authenticating docker registry request (host: %s)", req.URL.Hostname())
 			transport := &registry.BasicTransport{

--- a/internal/handlers/git_server.go
+++ b/internal/handlers/git_server.go
@@ -282,7 +282,7 @@ func (h *GitServerHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCt
 
 	logging.RequestLogf(ctx, "* authenticating git server request (host: %s)", helpers.GetHost(req))
 	credsToUse := creds[0]
-	req.SetBasicAuth(credsToUse.username, credsToUse.password)
+	helpers.SetAuthorization(req, helpers.BasicAuth(credsToUse.username, credsToUse.password))
 	if ctx != nil {
 		ctxdata.SetValue(ctx, addedAuthCtxKey, credsToUse)
 	}
@@ -472,7 +472,7 @@ func (h *GitServerHandler) requestWithAlternativeAuth(ctx *goproxy.ProxyCtx, bod
 		newReq.Body = io.NopCloser(bytes.NewReader(body))
 	}
 
-	newReq.SetBasicAuth(creds.username, creds.password)
+	helpers.SetAuthorization(newReq, helpers.BasicAuth(creds.username, creds.password))
 	newRsp, err := ctx.RoundTrip(newReq)
 	if err != nil {
 		return nil

--- a/internal/handlers/git_server.go
+++ b/internal/handlers/git_server.go
@@ -282,7 +282,7 @@ func (h *GitServerHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCt
 
 	logging.RequestLogf(ctx, "* authenticating git server request (host: %s)", helpers.GetHost(req))
 	credsToUse := creds[0]
-	helpers.SetAuthorization(req, helpers.BasicAuth(credsToUse.username, credsToUse.password))
+	helpers.SetBasicAuthorization(req, credsToUse.username, credsToUse.password)
 	if ctx != nil {
 		ctxdata.SetValue(ctx, addedAuthCtxKey, credsToUse)
 	}
@@ -472,7 +472,7 @@ func (h *GitServerHandler) requestWithAlternativeAuth(ctx *goproxy.ProxyCtx, bod
 		newReq.Body = io.NopCloser(bytes.NewReader(body))
 	}
 
-	helpers.SetAuthorization(newReq, helpers.BasicAuth(creds.username, creds.password))
+	helpers.SetBasicAuthorization(newReq, creds.username, creds.password)
 	newRsp, err := ctx.RoundTrip(newReq)
 	if err != nil {
 		return nil

--- a/internal/handlers/goproxy_server_handler.go
+++ b/internal/handlers/goproxy_server_handler.go
@@ -77,7 +77,7 @@ func (h *GoProxyServerHandler) HandleRequest(req *http.Request, ctx *goproxy.Pro
 		}
 
 		logging.RequestLogf(ctx, "* authenticating goproxy request (host: %s)", req.URL.Hostname())
-		req.SetBasicAuth(cred.username, cred.password)
+		helpers.SetAuthorization(req, helpers.BasicAuth(cred.username, cred.password))
 
 		return req, nil
 	}

--- a/internal/handlers/goproxy_server_handler.go
+++ b/internal/handlers/goproxy_server_handler.go
@@ -77,7 +77,7 @@ func (h *GoProxyServerHandler) HandleRequest(req *http.Request, ctx *goproxy.Pro
 		}
 
 		logging.RequestLogf(ctx, "* authenticating goproxy request (host: %s)", req.URL.Hostname())
-		helpers.SetAuthorization(req, helpers.BasicAuth(cred.username, cred.password))
+		helpers.SetBasicAuthorization(req, cred.username, cred.password)
 
 		return req, nil
 	}

--- a/internal/handlers/helm_registry.go
+++ b/internal/handlers/helm_registry.go
@@ -74,7 +74,7 @@ func (h *HelmRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.Prox
 		}
 
 		logging.RequestLogf(ctx, "* authenticating helm registry request (host: %s)", req.URL.Hostname())
-		req.SetBasicAuth(cred.username, cred.password)
+		helpers.SetAuthorization(req, helpers.BasicAuth(cred.username, cred.password))
 
 		return req, nil
 	}

--- a/internal/handlers/helm_registry.go
+++ b/internal/handlers/helm_registry.go
@@ -74,7 +74,7 @@ func (h *HelmRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.Prox
 		}
 
 		logging.RequestLogf(ctx, "* authenticating helm registry request (host: %s)", req.URL.Hostname())
-		helpers.SetAuthorization(req, helpers.BasicAuth(cred.username, cred.password))
+		helpers.SetBasicAuthorization(req, cred.username, cred.password)
 
 		return req, nil
 	}

--- a/internal/handlers/hex_organization.go
+++ b/internal/handlers/hex_organization.go
@@ -69,7 +69,7 @@ func (h *HexOrganizationHandler) HandleRequest(req *http.Request, ctx *goproxy.P
 	for _, cred := range h.credentials {
 		if cred.organization == reqOrg {
 			logging.RequestLogf(ctx, "* authenticating hex request (org: %s)", reqOrg)
-			req.Header.Set("authorization", cred.key)
+			helpers.SetAuthorization(req, helpers.RawAuth(cred.key))
 			return req, nil
 		}
 	}

--- a/internal/handlers/hex_organization.go
+++ b/internal/handlers/hex_organization.go
@@ -69,7 +69,7 @@ func (h *HexOrganizationHandler) HandleRequest(req *http.Request, ctx *goproxy.P
 	for _, cred := range h.credentials {
 		if cred.organization == reqOrg {
 			logging.RequestLogf(ctx, "* authenticating hex request (org: %s)", reqOrg)
-			helpers.SetAuthorization(req, helpers.RawAuth(cred.key))
+			helpers.SetRawAuthorization(req, cred.key)
 			return req, nil
 		}
 	}

--- a/internal/handlers/hex_repository.go
+++ b/internal/handlers/hex_repository.go
@@ -85,7 +85,7 @@ func (h *HexRepositoryHandler) HandleRequest(req *http.Request, ctx *goproxy.Pro
 		}
 
 		logging.RequestLogf(ctx, "* authenticating hex repository request (host: %s)", req.URL.Hostname())
-		helpers.SetAuthorization(req, helpers.RawAuth(cred.authKey))
+		helpers.SetRawAuthorization(req, cred.authKey)
 
 		return req, nil
 	}

--- a/internal/handlers/hex_repository.go
+++ b/internal/handlers/hex_repository.go
@@ -85,7 +85,7 @@ func (h *HexRepositoryHandler) HandleRequest(req *http.Request, ctx *goproxy.Pro
 		}
 
 		logging.RequestLogf(ctx, "* authenticating hex repository request (host: %s)", req.URL.Hostname())
-		req.Header.Set("authorization", cred.authKey)
+		helpers.SetAuthorization(req, helpers.RawAuth(cred.authKey))
 
 		return req, nil
 	}

--- a/internal/handlers/maven_repository.go
+++ b/internal/handlers/maven_repository.go
@@ -79,7 +79,7 @@ func (h *MavenRepositoryHandler) HandleRequest(req *http.Request, ctx *goproxy.P
 		}
 
 		logging.RequestLogf(ctx, "* authenticating maven repository request (host: %s)", req.URL.Hostname())
-		req.SetBasicAuth(cred.username, cred.password)
+		helpers.SetAuthorization(req, helpers.BasicAuth(cred.username, cred.password))
 
 		return req, nil
 	}

--- a/internal/handlers/maven_repository.go
+++ b/internal/handlers/maven_repository.go
@@ -79,7 +79,7 @@ func (h *MavenRepositoryHandler) HandleRequest(req *http.Request, ctx *goproxy.P
 		}
 
 		logging.RequestLogf(ctx, "* authenticating maven repository request (host: %s)", req.URL.Hostname())
-		helpers.SetAuthorization(req, helpers.BasicAuth(cred.username, cred.password))
+		helpers.SetBasicAuthorization(req, cred.username, cred.password)
 
 		return req, nil
 	}

--- a/internal/handlers/npm_registry.go
+++ b/internal/handlers/npm_registry.go
@@ -108,10 +108,10 @@ func (h *NPMRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.Proxy
 		username, password, found := strings.Cut(cred.token, ":")
 		if found {
 			logging.RequestLogf(ctx, "* authenticating npm registry request (host: %s, basic auth)", reqHost)
-			helpers.SetAuthorization(req, helpers.BasicAuth(username, password))
+			helpers.SetBasicAuthorization(req, username, password)
 		} else {
 			logging.RequestLogf(ctx, "* authenticating npm registry request (host: %s, token auth)", reqHost)
-			helpers.SetAuthorization(req, helpers.BearerAuth(cred.token))
+			helpers.SetBearerAuthorization(req, cred.token)
 		}
 		return req, nil
 	}

--- a/internal/handlers/npm_registry.go
+++ b/internal/handlers/npm_registry.go
@@ -108,10 +108,10 @@ func (h *NPMRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.Proxy
 		username, password, found := strings.Cut(cred.token, ":")
 		if found {
 			logging.RequestLogf(ctx, "* authenticating npm registry request (host: %s, basic auth)", reqHost)
-			req.SetBasicAuth(username, password)
+			helpers.SetAuthorization(req, helpers.BasicAuth(username, password))
 		} else {
 			logging.RequestLogf(ctx, "* authenticating npm registry request (host: %s, token auth)", reqHost)
-			req.Header.Set("authorization", "Bearer "+cred.token)
+			helpers.SetAuthorization(req, helpers.BearerAuth(cred.token))
 		}
 		return req, nil
 	}

--- a/internal/handlers/nuget_feed.go
+++ b/internal/handlers/nuget_feed.go
@@ -300,14 +300,14 @@ func authenticateNugetRequest(req *http.Request, cred nugetFeedCredentials, ctx 
 	username, password, found := strings.Cut(token, ":")
 	if found {
 		logging.RequestLogf(ctx, "* authenticating nuget feed request (host: %s, basic auth)", req.URL.Hostname())
-		helpers.SetAuthorization(req, helpers.BasicAuth(username, password))
+		helpers.SetBasicAuthorization(req, username, password)
 	} else if token != "" {
 		if shouldTreatTokenAsPassword(req.URL) {
 			logging.RequestLogf(ctx, "* authenticating nuget feed request (host: %s, basic auth for Azure DevOps)", req.URL.Hostname())
-			helpers.SetAuthorization(req, helpers.BasicAuth("", token))
+			helpers.SetBasicAuthorization(req, "", token)
 		} else {
 			logging.RequestLogf(ctx, "* authenticating nuget feed request (host: %s, bearer auth)", req.URL.Hostname())
-			helpers.SetAuthorization(req, helpers.BearerAuth(token))
+			helpers.SetBearerAuthorization(req, token)
 		}
 	}
 }

--- a/internal/handlers/nuget_feed.go
+++ b/internal/handlers/nuget_feed.go
@@ -300,14 +300,14 @@ func authenticateNugetRequest(req *http.Request, cred nugetFeedCredentials, ctx 
 	username, password, found := strings.Cut(token, ":")
 	if found {
 		logging.RequestLogf(ctx, "* authenticating nuget feed request (host: %s, basic auth)", req.URL.Hostname())
-		req.SetBasicAuth(username, password)
+		helpers.SetAuthorization(req, helpers.BasicAuth(username, password))
 	} else if token != "" {
 		if shouldTreatTokenAsPassword(req.URL) {
 			logging.RequestLogf(ctx, "* authenticating nuget feed request (host: %s, basic auth for Azure DevOps)", req.URL.Hostname())
-			req.SetBasicAuth("", token)
+			helpers.SetAuthorization(req, helpers.BasicAuth("", token))
 		} else {
 			logging.RequestLogf(ctx, "* authenticating nuget feed request (host: %s, bearer auth)", req.URL.Hostname())
-			req.Header.Set("authorization", "Bearer "+token)
+			helpers.SetAuthorization(req, helpers.BearerAuth(token))
 		}
 	}
 }

--- a/internal/handlers/pub_repository.go
+++ b/internal/handlers/pub_repository.go
@@ -83,7 +83,7 @@ func (h *PubRepositoryHandler) HandleRequest(req *http.Request, ctx *goproxy.Pro
 		}
 
 		logging.RequestLogf(ctx, "* authenticating pub repository request (url: %s)", cred.url)
-		helpers.SetAuthorization(req, helpers.BearerAuth(cred.token))
+		helpers.SetBearerAuthorization(req, cred.token)
 
 		return req, nil
 	}

--- a/internal/handlers/pub_repository.go
+++ b/internal/handlers/pub_repository.go
@@ -83,7 +83,7 @@ func (h *PubRepositoryHandler) HandleRequest(req *http.Request, ctx *goproxy.Pro
 		}
 
 		logging.RequestLogf(ctx, "* authenticating pub repository request (url: %s)", cred.url)
-		req.Header.Set("Authorization", "Bearer "+cred.token)
+		helpers.SetAuthorization(req, helpers.BearerAuth(cred.token))
 
 		return req, nil
 	}

--- a/internal/handlers/python_index.go
+++ b/internal/handlers/python_index.go
@@ -107,7 +107,7 @@ func (h *PythonIndexHandler) HandleRequest(req *http.Request, ctx *goproxy.Proxy
 		}
 		// ignore `found` because it's okay for the password to be an empty string
 		username, password, _ := strings.Cut(token, ":")
-		req.SetBasicAuth(username, password)
+		helpers.SetAuthorization(req, helpers.BasicAuth(username, password))
 
 		return req, nil
 	}

--- a/internal/handlers/python_index.go
+++ b/internal/handlers/python_index.go
@@ -107,7 +107,7 @@ func (h *PythonIndexHandler) HandleRequest(req *http.Request, ctx *goproxy.Proxy
 		}
 		// ignore `found` because it's okay for the password to be an empty string
 		username, password, _ := strings.Cut(token, ":")
-		helpers.SetAuthorization(req, helpers.BasicAuth(username, password))
+		helpers.SetBasicAuthorization(req, username, password)
 
 		return req, nil
 	}

--- a/internal/handlers/rubygems_server.go
+++ b/internal/handlers/rubygems_server.go
@@ -80,7 +80,7 @@ func (h *RubyGemsServerHandler) HandleRequest(req *http.Request, ctx *goproxy.Pr
 
 		// ignore `found` because it's okay for the password to be an empty string
 		username, password, _ := strings.Cut(cred.token, ":")
-		req.SetBasicAuth(username, password)
+		helpers.SetAuthorization(req, helpers.BasicAuth(username, password))
 
 		return req, nil
 	}

--- a/internal/handlers/rubygems_server.go
+++ b/internal/handlers/rubygems_server.go
@@ -80,7 +80,7 @@ func (h *RubyGemsServerHandler) HandleRequest(req *http.Request, ctx *goproxy.Pr
 
 		// ignore `found` because it's okay for the password to be an empty string
 		username, password, _ := strings.Cut(cred.token, ":")
-		helpers.SetAuthorization(req, helpers.BasicAuth(username, password))
+		helpers.SetBasicAuthorization(req, username, password)
 
 		return req, nil
 	}

--- a/internal/handlers/terraform_registry.go
+++ b/internal/handlers/terraform_registry.go
@@ -88,7 +88,7 @@ func (h *TerraformRegistryHandler) HandleRequest(request *http.Request, context 
 		}
 
 		logging.RequestLogf(context, "* authenticating terraform registry request (host: %s)", request.URL.Hostname())
-		helpers.SetAuthorization(request, helpers.BearerAuth(cred.token))
+		helpers.SetBearerAuthorization(request, cred.token)
 		return request, nil
 	}
 

--- a/internal/handlers/terraform_registry.go
+++ b/internal/handlers/terraform_registry.go
@@ -88,7 +88,7 @@ func (h *TerraformRegistryHandler) HandleRequest(request *http.Request, context 
 		}
 
 		logging.RequestLogf(context, "* authenticating terraform registry request (host: %s)", request.URL.Hostname())
-		request.Header.Set("Authorization", "Bearer "+cred.token)
+		helpers.SetAuthorization(request, helpers.BearerAuth(cred.token))
 		return request, nil
 	}
 

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -44,6 +44,8 @@ func RawAuth(value string) authorization {
 
 // SetAuthorization clears the existing authorization header on req and sets it to the value
 // described by auth. The header key defaults to "Authorization" if not provided.
+//
+// Note: The "Authorization" header is always cleared.
 func SetAuthorization(req *http.Request, auth authorization, key ...string) {
 	h := "Authorization"
 	if len(key) > 0 {

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -2,7 +2,6 @@ package helpers
 
 import (
 	"encoding/base64"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -26,21 +25,17 @@ func SetRawAuthorization(req *http.Request, authorization string) {
 }
 
 func SetBasicAuthorization(req *http.Request, username, password string) {
-	SetRawAuthorization(
-		req,
-		fmt.Sprintf(
-			"Basic %s",
-			base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password))),
-		),
-	)
+	credentials := username + ":" + password
+	encoded := base64.StdEncoding.EncodeToString([]byte(credentials))
+	SetRawAuthorization(req, "Basic "+encoded)
 }
 
 func SetBearerAuthorization(req *http.Request, token string) {
-	SetRawAuthorization(req, fmt.Sprintf("Bearer %s", token))
+	SetRawAuthorization(req, "Bearer "+token)
 }
 
-func SetGithubAPITokenAuthorization(req *http.Request, token string) {
-	SetRawAuthorization(req, fmt.Sprintf("token %s", token))
+func SetGitHubAPITokenAuthorization(req *http.Request, token string) {
+	SetRawAuthorization(req, "token "+token)
 }
 
 func CheckGitHubAPIHost(r *http.Request) bool {

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -1,6 +1,8 @@
 package helpers
 
 import (
+	"encoding/base64"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -9,6 +11,49 @@ import (
 
 	"golang.org/x/net/idna"
 )
+
+// authorization holds a pre-formatted Authorization header value.
+// Obtain instances via BasicAuth, BearerAuth, TokenAuth, or RawAuth.
+type authorization struct {
+	value string
+}
+
+func (a authorization) asHeader() string { return a.value }
+
+// BasicAuth returns an authorization for "Basic <base64(username:password)>".
+func BasicAuth(username, password string) authorization {
+	encoded := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
+	return authorization{fmt.Sprintf("Basic %s", encoded)}
+}
+
+// BearerAuth returns an authorization for "Bearer <token>".
+func BearerAuth(token string) authorization {
+	return authorization{fmt.Sprintf("Bearer %s", token)}
+}
+
+// TokenAuth returns an authorization for "token <value>" (GitHub legacy format).
+func TokenAuth(value string) authorization {
+	return authorization{fmt.Sprintf("token %s", value)}
+}
+
+// RawAuth returns an authorization whose header value is the given string as-is.
+// Use only when the credential is already a fully-formed header value.
+func RawAuth(value string) authorization {
+	return authorization{value}
+}
+
+// SetAuthorization clears the existing authorization header on req and sets it to the value
+// described by auth. The header key defaults to "Authorization" if not provided.
+func SetAuthorization(req *http.Request, auth authorization, key ...string) {
+	h := "Authorization"
+	if len(key) > 0 {
+		h = key[0]
+	}
+	// Clear any auth passed by Dependabot Core
+	req.Header.Del("Authorization")
+	req.Header.Del(h)
+	req.Header.Set(h, auth.asHeader())
+}
 
 func CheckGitHubAPIHost(r *http.Request) bool {
 	hostname := GetHost(r)

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -31,7 +31,7 @@ func BearerAuth(token string) authorization {
 	return authorization{fmt.Sprintf("Bearer %s", token)}
 }
 
-// TokenAuth returns an authorization for "token <value>" (GitHub legacy format).
+// TokenAuth returns an authorization for "token <value>", used at least by Github API.
 func TokenAuth(value string) authorization {
 	return authorization{fmt.Sprintf("token %s", value)}
 }

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -12,49 +12,35 @@ import (
 	"golang.org/x/net/idna"
 )
 
-// authorization holds a pre-formatted Authorization header value.
-// Obtain instances via BasicAuth, BearerAuth, TokenAuth, or RawAuth.
-type authorization struct {
-	value string
-}
-
-func (a authorization) asHeader() string { return a.value }
-
-// BasicAuth returns an authorization for "Basic <base64(username:password)>".
-func BasicAuth(username, password string) authorization {
-	encoded := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
-	return authorization{fmt.Sprintf("Basic %s", encoded)}
-}
-
-// BearerAuth returns an authorization for "Bearer <token>".
-func BearerAuth(token string) authorization {
-	return authorization{fmt.Sprintf("Bearer %s", token)}
-}
-
-// TokenAuth returns an authorization for "token <value>", used at least by Github API.
-func TokenAuth(value string) authorization {
-	return authorization{fmt.Sprintf("token %s", value)}
-}
-
-// RawAuth returns an authorization whose header value is the given string as-is.
-// Use only when the credential is already a fully-formed header value.
-func RawAuth(value string) authorization {
-	return authorization{value}
-}
-
-// SetAuthorization clears the existing authorization header on req and sets it to the value
-// described by auth. The header key defaults to "Authorization" if not provided.
+// ReplaceAuthorization replaces the authorization configured on req with the given key and value.
 //
-// Note: The "Authorization" header is always cleared.
-func SetAuthorization(req *http.Request, auth authorization, key ...string) {
-	h := "Authorization"
-	if len(key) > 0 {
-		h = key[0]
-	}
-	// Clear any auth passed by Dependabot Core
+// Note: "Authorization"-header is always cleared to avoid multiple auth headers being set on the request.
+func ReplaceAuthorization(req *http.Request, key string, value string) {
 	req.Header.Del("Authorization")
-	req.Header.Del(h)
-	req.Header.Set(h, auth.asHeader())
+	req.Header.Set(key, value)
+}
+
+// SetRawAuthorization sets the authorization header on req to the given value
+func SetRawAuthorization(req *http.Request, authorization string) {
+	ReplaceAuthorization(req, "Authorization", authorization)
+}
+
+func SetBasicAuthorization(req *http.Request, username, password string) {
+	SetRawAuthorization(
+		req,
+		fmt.Sprintf(
+			"Basic %s",
+			base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password))),
+		),
+	)
+}
+
+func SetBearerAuthorization(req *http.Request, token string) {
+	SetRawAuthorization(req, fmt.Sprintf("Bearer %s", token))
+}
+
+func SetGithubAPITokenAuthorization(req *http.Request, token string) {
+	SetRawAuthorization(req, fmt.Sprintf("token %s", token))
 }
 
 func CheckGitHubAPIHost(r *http.Request) bool {

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -23,10 +23,10 @@ func newRequestWithAuth(t *testing.T, rawURL, existing string) *http.Request {
 	return req
 }
 
-func TestSetAuthorization_BasicAuth(t *testing.T) {
+func TestSetBasicAuthorization(t *testing.T) {
 	t.Run("sets correct Basic header", func(t *testing.T) {
 		req := newRequest(t, "https://example.com")
-		SetAuthorization(req, BasicAuth("user", "pass"))
+		SetBasicAuthorization(req, "user", "pass")
 
 		want := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:pass"))
 		if got := req.Header.Get("Authorization"); got != want {
@@ -36,7 +36,7 @@ func TestSetAuthorization_BasicAuth(t *testing.T) {
 
 	t.Run("clears pre-existing Authorization header", func(t *testing.T) {
 		req := newRequestWithAuth(t, "https://example.com", "Bearer old-token")
-		SetAuthorization(req, BasicAuth("user", "pass"))
+		SetBasicAuthorization(req, "user", "pass")
 
 		want := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:pass"))
 		if got := req.Header.Get("Authorization"); got != want {
@@ -49,7 +49,7 @@ func TestSetAuthorization_BasicAuth(t *testing.T) {
 
 	t.Run("encodes empty username correctly", func(t *testing.T) {
 		req := newRequest(t, "https://example.com")
-		SetAuthorization(req, BasicAuth("", "token"))
+		SetBasicAuthorization(req, "", "token")
 
 		want := "Basic " + base64.StdEncoding.EncodeToString([]byte(":token"))
 		if got := req.Header.Get("Authorization"); got != want {
@@ -58,10 +58,10 @@ func TestSetAuthorization_BasicAuth(t *testing.T) {
 	})
 }
 
-func TestSetAuthorization_BearerAuth(t *testing.T) {
+func TestSetBearerAuthorization(t *testing.T) {
 	t.Run("sets correct Bearer header", func(t *testing.T) {
 		req := newRequest(t, "https://example.com")
-		SetAuthorization(req, BearerAuth("my-token"))
+		SetBearerAuthorization(req, "my-token")
 
 		if got := req.Header.Get("Authorization"); got != "Bearer my-token" {
 			t.Errorf("Authorization = %q, want %q", got, "Bearer my-token")
@@ -70,7 +70,7 @@ func TestSetAuthorization_BearerAuth(t *testing.T) {
 
 	t.Run("clears pre-existing Authorization header", func(t *testing.T) {
 		req := newRequestWithAuth(t, "https://example.com", "Basic dXNlcjpwYXNz")
-		SetAuthorization(req, BearerAuth("new-token"))
+		SetBearerAuthorization(req, "new-token")
 
 		if got := req.Header.Get("Authorization"); got != "Bearer new-token" {
 			t.Errorf("Authorization = %q, want %q", got, "Bearer new-token")
@@ -81,10 +81,10 @@ func TestSetAuthorization_BearerAuth(t *testing.T) {
 	})
 }
 
-func TestSetAuthorization_TokenAuth(t *testing.T) {
+func TestSetGithubAPITokenAuthorization(t *testing.T) {
 	t.Run("sets correct token header", func(t *testing.T) {
 		req := newRequest(t, "https://api.github.com")
-		SetAuthorization(req, TokenAuth("ghp_abc123"))
+		SetGithubAPITokenAuthorization(req, "ghp_abc123")
 
 		if got := req.Header.Get("Authorization"); got != "token ghp_abc123" {
 			t.Errorf("Authorization = %q, want %q", got, "token ghp_abc123")
@@ -93,7 +93,7 @@ func TestSetAuthorization_TokenAuth(t *testing.T) {
 
 	t.Run("clears pre-existing Authorization header", func(t *testing.T) {
 		req := newRequestWithAuth(t, "https://api.github.com", "token old-token")
-		SetAuthorization(req, TokenAuth("new-token"))
+		SetGithubAPITokenAuthorization(req, "new-token")
 
 		if got := req.Header.Get("Authorization"); got != "token new-token" {
 			t.Errorf("Authorization = %q, want %q", got, "token new-token")
@@ -104,10 +104,10 @@ func TestSetAuthorization_TokenAuth(t *testing.T) {
 	})
 }
 
-func TestSetAuthorization_RawAuth(t *testing.T) {
+func TestSetRawAuthorization(t *testing.T) {
 	t.Run("sets pre-formatted value as-is", func(t *testing.T) {
 		req := newRequest(t, "https://example.com")
-		SetAuthorization(req, RawAuth("Bearer already-formatted"))
+		SetRawAuthorization(req, "Bearer already-formatted")
 
 		if got := req.Header.Get("Authorization"); got != "Bearer already-formatted" {
 			t.Errorf("Authorization = %q, want %q", got, "Bearer already-formatted")
@@ -116,7 +116,7 @@ func TestSetAuthorization_RawAuth(t *testing.T) {
 
 	t.Run("clears pre-existing Authorization header", func(t *testing.T) {
 		req := newRequestWithAuth(t, "https://example.com", "Bearer stale")
-		SetAuthorization(req, RawAuth("token new-raw"))
+		SetRawAuthorization(req, "token new-raw")
 
 		if got := req.Header.Get("Authorization"); got != "token new-raw" {
 			t.Errorf("Authorization = %q, want %q", got, "token new-raw")
@@ -127,10 +127,10 @@ func TestSetAuthorization_RawAuth(t *testing.T) {
 	})
 }
 
-func TestSetAuthorization_CustomKey(t *testing.T) {
+func TestReplaceAuthorization_CustomKey(t *testing.T) {
 	t.Run("sets value on custom header key", func(t *testing.T) {
 		req := newRequest(t, "https://cloudsmith.example.com")
-		SetAuthorization(req, RawAuth("my-api-key"), "X-Api-Key")
+		ReplaceAuthorization(req, "X-Api-Key", "my-api-key")
 
 		if got := req.Header.Get("X-Api-Key"); got != "my-api-key" {
 			t.Errorf("X-Api-Key = %q, want %q", got, "my-api-key")
@@ -140,10 +140,10 @@ func TestSetAuthorization_CustomKey(t *testing.T) {
 		}
 	})
 
-	t.Run("clears pre-existing custom header before setting", func(t *testing.T) {
+	t.Run("clears pre-existing Authorization header before setting custom key", func(t *testing.T) {
 		req := newRequest(t, "https://cloudsmith.example.com")
 		req.Header.Set("X-Api-Key", "old-key")
-		SetAuthorization(req, RawAuth("new-key"), "X-Api-Key")
+		ReplaceAuthorization(req, "X-Api-Key", "new-key")
 
 		if got := req.Header.Get("X-Api-Key"); got != "new-key" {
 			t.Errorf("X-Api-Key = %q, want %q", got, "new-key")

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -1,10 +1,158 @@
 package helpers
 
 import (
+	"encoding/base64"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 )
+
+// newRequest builds a GET request to the given raw URL for use in tests.
+func newRequest(t *testing.T, rawURL string) *http.Request {
+	t.Helper()
+	return httptest.NewRequest(http.MethodGet, rawURL, nil)
+}
+
+// newRequestWithAuth builds a request that already carries an Authorization header,
+// simulating a client that sent credentials which should be replaced.
+func newRequestWithAuth(t *testing.T, rawURL, existing string) *http.Request {
+	t.Helper()
+	req := newRequest(t, rawURL)
+	req.Header.Set("Authorization", existing)
+	return req
+}
+
+func TestSetAuthorization_BasicAuth(t *testing.T) {
+	t.Run("sets correct Basic header", func(t *testing.T) {
+		req := newRequest(t, "https://example.com")
+		SetAuthorization(req, BasicAuth("user", "pass"))
+
+		want := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:pass"))
+		if got := req.Header.Get("Authorization"); got != want {
+			t.Errorf("Authorization = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("clears pre-existing Authorization header", func(t *testing.T) {
+		req := newRequestWithAuth(t, "https://example.com", "Bearer old-token")
+		SetAuthorization(req, BasicAuth("user", "pass"))
+
+		want := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:pass"))
+		if got := req.Header.Get("Authorization"); got != want {
+			t.Errorf("Authorization = %q, want %q", got, want)
+		}
+		if vals := req.Header["Authorization"]; len(vals) != 1 {
+			t.Errorf("expected exactly 1 Authorization value, got %d: %v", len(vals), vals)
+		}
+	})
+
+	t.Run("encodes empty password correctly", func(t *testing.T) {
+		req := newRequest(t, "https://example.com")
+		SetAuthorization(req, BasicAuth("", "token"))
+
+		want := "Basic " + base64.StdEncoding.EncodeToString([]byte(":token"))
+		if got := req.Header.Get("Authorization"); got != want {
+			t.Errorf("Authorization = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestSetAuthorization_BearerAuth(t *testing.T) {
+	t.Run("sets correct Bearer header", func(t *testing.T) {
+		req := newRequest(t, "https://example.com")
+		SetAuthorization(req, BearerAuth("my-token"))
+
+		if got := req.Header.Get("Authorization"); got != "Bearer my-token" {
+			t.Errorf("Authorization = %q, want %q", got, "Bearer my-token")
+		}
+	})
+
+	t.Run("clears pre-existing Authorization header", func(t *testing.T) {
+		req := newRequestWithAuth(t, "https://example.com", "Basic dXNlcjpwYXNz")
+		SetAuthorization(req, BearerAuth("new-token"))
+
+		if got := req.Header.Get("Authorization"); got != "Bearer new-token" {
+			t.Errorf("Authorization = %q, want %q", got, "Bearer new-token")
+		}
+		if vals := req.Header["Authorization"]; len(vals) != 1 {
+			t.Errorf("expected exactly 1 Authorization value, got %d: %v", len(vals), vals)
+		}
+	})
+}
+
+func TestSetAuthorization_TokenAuth(t *testing.T) {
+	t.Run("sets correct token header", func(t *testing.T) {
+		req := newRequest(t, "https://api.github.com")
+		SetAuthorization(req, TokenAuth("ghp_abc123"))
+
+		if got := req.Header.Get("Authorization"); got != "token ghp_abc123" {
+			t.Errorf("Authorization = %q, want %q", got, "token ghp_abc123")
+		}
+	})
+
+	t.Run("clears pre-existing Authorization header", func(t *testing.T) {
+		req := newRequestWithAuth(t, "https://api.github.com", "token old-token")
+		SetAuthorization(req, TokenAuth("new-token"))
+
+		if got := req.Header.Get("Authorization"); got != "token new-token" {
+			t.Errorf("Authorization = %q, want %q", got, "token new-token")
+		}
+		if vals := req.Header["Authorization"]; len(vals) != 1 {
+			t.Errorf("expected exactly 1 Authorization value, got %d: %v", len(vals), vals)
+		}
+	})
+}
+
+func TestSetAuthorization_RawAuth(t *testing.T) {
+	t.Run("sets pre-formatted value as-is", func(t *testing.T) {
+		req := newRequest(t, "https://example.com")
+		SetAuthorization(req, RawAuth("Bearer already-formatted"))
+
+		if got := req.Header.Get("Authorization"); got != "Bearer already-formatted" {
+			t.Errorf("Authorization = %q, want %q", got, "Bearer already-formatted")
+		}
+	})
+
+	t.Run("clears pre-existing Authorization header", func(t *testing.T) {
+		req := newRequestWithAuth(t, "https://example.com", "Bearer stale")
+		SetAuthorization(req, RawAuth("token new-raw"))
+
+		if got := req.Header.Get("Authorization"); got != "token new-raw" {
+			t.Errorf("Authorization = %q, want %q", got, "token new-raw")
+		}
+		if vals := req.Header["Authorization"]; len(vals) != 1 {
+			t.Errorf("expected exactly 1 Authorization value, got %d: %v", len(vals), vals)
+		}
+	})
+}
+
+func TestSetAuthorization_CustomKey(t *testing.T) {
+	t.Run("sets value on custom header key", func(t *testing.T) {
+		req := newRequest(t, "https://cloudsmith.example.com")
+		SetAuthorization(req, RawAuth("my-api-key"), "X-Api-Key")
+
+		if got := req.Header.Get("X-Api-Key"); got != "my-api-key" {
+			t.Errorf("X-Api-Key = %q, want %q", got, "my-api-key")
+		}
+		if got := req.Header.Get("Authorization"); got != "" {
+			t.Errorf("Authorization should be empty, got %q", got)
+		}
+	})
+
+	t.Run("clears pre-existing custom header before setting", func(t *testing.T) {
+		req := newRequest(t, "https://cloudsmith.example.com")
+		req.Header.Set("X-Api-Key", "old-key")
+		SetAuthorization(req, RawAuth("new-key"), "X-Api-Key")
+
+		if got := req.Header.Get("X-Api-Key"); got != "new-key" {
+			t.Errorf("X-Api-Key = %q, want %q", got, "new-key")
+		}
+		if vals := req.Header["X-Api-Key"]; len(vals) != 1 {
+			t.Errorf("expected exactly 1 X-Api-Key value, got %d: %v", len(vals), vals)
+		}
+	})
+}
 
 func TestUrlMatchesRequest(t *testing.T) {
 	tests := []struct {

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -81,10 +81,10 @@ func TestSetBearerAuthorization(t *testing.T) {
 	})
 }
 
-func TestSetGithubAPITokenAuthorization(t *testing.T) {
+func TestSetGitHubAPITokenAuthorization(t *testing.T) {
 	t.Run("sets correct token header", func(t *testing.T) {
 		req := newRequest(t, "https://api.github.com")
-		SetGithubAPITokenAuthorization(req, "ghp_abc123")
+		SetGitHubAPITokenAuthorization(req, "ghp_abc123")
 
 		if got := req.Header.Get("Authorization"); got != "token ghp_abc123" {
 			t.Errorf("Authorization = %q, want %q", got, "token ghp_abc123")
@@ -93,7 +93,7 @@ func TestSetGithubAPITokenAuthorization(t *testing.T) {
 
 	t.Run("clears pre-existing Authorization header", func(t *testing.T) {
 		req := newRequestWithAuth(t, "https://api.github.com", "token old-token")
-		SetGithubAPITokenAuthorization(req, "new-token")
+		SetGitHubAPITokenAuthorization(req, "new-token")
 
 		if got := req.Header.Get("Authorization"); got != "token new-token" {
 			t.Errorf("Authorization = %q, want %q", got, "token new-token")

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -47,7 +47,7 @@ func TestSetAuthorization_BasicAuth(t *testing.T) {
 		}
 	})
 
-	t.Run("encodes empty password correctly", func(t *testing.T) {
+	t.Run("encodes empty username correctly", func(t *testing.T) {
 		req := newRequest(t, "https://example.com")
 		SetAuthorization(req, BasicAuth("", "token"))
 

--- a/internal/oidc/oidc_registry.go
+++ b/internal/oidc/oidc_registry.go
@@ -1,7 +1,6 @@
 package oidc
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 	"sync"
@@ -143,18 +142,18 @@ func (r *OIDCRegistry) TryAuth(req *http.Request, ctx *goproxy.ProxyCtx) bool {
 	switch matched.parameters.(type) {
 	case *CloudsmithOIDCParameters:
 		logging.RequestLogf(ctx, "* authenticating request with OIDC API key (host: %s)", host)
-		req.Header.Set("X-Api-Key", token)
+		helpers.SetAuthorization(req, helpers.RawAuth(token), "X-Api-Key")
 	case *GCPOIDCParameters:
 		if strings.HasSuffix(host, "-docker.pkg.dev") {
 			logging.RequestLogf(ctx, "* authenticating request with OIDC oauth2accesstoken (host: %s)", host)
-			req.SetBasicAuth("oauth2accesstoken", token)
+			helpers.SetAuthorization(req, helpers.BasicAuth("oauth2accesstoken", token))
 		} else {
 			logging.RequestLogf(ctx, "* authenticating request with OIDC token (host: %s)", host)
-			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+			helpers.SetAuthorization(req, helpers.BearerAuth(token))
 		}
 	default:
 		logging.RequestLogf(ctx, "* authenticating request with OIDC token (host: %s)", host)
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+		helpers.SetAuthorization(req, helpers.BearerAuth(token))
 	}
 
 	return true

--- a/internal/oidc/oidc_registry.go
+++ b/internal/oidc/oidc_registry.go
@@ -142,18 +142,18 @@ func (r *OIDCRegistry) TryAuth(req *http.Request, ctx *goproxy.ProxyCtx) bool {
 	switch matched.parameters.(type) {
 	case *CloudsmithOIDCParameters:
 		logging.RequestLogf(ctx, "* authenticating request with OIDC API key (host: %s)", host)
-		helpers.SetAuthorization(req, helpers.RawAuth(token), "X-Api-Key")
+		helpers.ReplaceAuthorization(req, "X-Api-Key", token)
 	case *GCPOIDCParameters:
 		if strings.HasSuffix(host, "-docker.pkg.dev") {
 			logging.RequestLogf(ctx, "* authenticating request with OIDC oauth2accesstoken (host: %s)", host)
-			helpers.SetAuthorization(req, helpers.BasicAuth("oauth2accesstoken", token))
+			helpers.SetBasicAuthorization(req, "oauth2accesstoken", token)
 		} else {
 			logging.RequestLogf(ctx, "* authenticating request with OIDC token (host: %s)", host)
-			helpers.SetAuthorization(req, helpers.BearerAuth(token))
+			helpers.SetBearerAuthorization(req, token)
 		}
 	default:
 		logging.RequestLogf(ctx, "* authenticating request with OIDC token (host: %s)", host)
-		helpers.SetAuthorization(req, helpers.BearerAuth(token))
+		helpers.SetBearerAuthorization(req, token)
 	}
 
 	return true


### PR DESCRIPTION
_This PR is co-authored by Copilot_

- Clears any existing Authorization or overlapping headers
- Adds a unified helper for setting auth
- Unifies behavior in all supported registries
- Leaves dependabot and github api handlers untouched

### What are you trying to accomplish?

Fix #126

### Anything you want to highlight for special attention from reviewers?

Please sanity check this implementation

### How will you know you've accomplished your goal?

I need review to be sure, I am just going by the code and am not sure how to test this locally end-2-end.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
