### PR TITLE
Authenticate Python downloads discovered from Simple API responses

### DIFF
--- a/internal/handlers/oidc_handling_test.go
+++ b/internal/handlers/oidc_handling_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -1739,6 +1740,64 @@ func TestPythonOIDCSimpleSuffixStripping(t *testing.T) {
 	reqB := httptest.NewRequest("GET", "https://pkgs.example.com/org/feed-B/pkg/b", nil)
 	reqB = handleRequestAndClose(handler, reqB, nil)
 	assertHasTokenAuth(t, reqB, "Bearer", "__token_B__", "feed-B request should use token B")
+}
+
+func TestPythonOIDCAuthenticatesDiscoveredDownloadPrefix(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	tenantID := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	clientID := "87654321-4321-4321-4321-210987654321"
+	tokenURL := "https://token.actions.example.com" //nolint:gosec // test URL
+
+	httpmock.RegisterResponder("GET", tokenURL,
+		httpmock.NewStringResponder(200, `{"count":1,"value":"sometoken"}`))
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenantID),
+		httpmock.NewStringResponder(200, `{"access_token":"__oidc_token__","expires_in":3600,"token_type":"Bearer"}`))
+
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", tokenURL)
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "sometoken")
+
+	handler := NewPythonIndexHandler(config.Credentials{
+		config.Credential{
+			"type":      "python_index",
+			"index-url": "https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/",
+			"tenant-id": tenantID,
+			"client-id": clientID,
+		},
+	})
+
+	ctx := &goproxy.ProxyCtx{}
+	indexReq := httptest.NewRequest(
+		"GET",
+		"https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
+		nil,
+	)
+	indexReq = handleRequestAndClose(handler, indexReq, ctx)
+	assertHasTokenAuth(t, indexReq, "Bearer", "__oidc_token__", "simple index request should use OIDC token")
+
+	indexResp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/html"},
+		},
+		Body: io.NopCloser(strings.NewReader(`
+			<html><body>
+				<a href="https://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl#sha256=abc">
+					my-package-1.0.0.whl
+				</a>
+			</body></html>
+		`)),
+	}
+	handler.HandleResponse(indexResp, ctx)
+
+	downloadReq := httptest.NewRequest(
+		"HEAD",
+		"https://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
+		nil,
+	)
+	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})
+	assertHasTokenAuth(t, downloadReq, "Bearer", "__oidc_token__", "discovered download request should use OIDC token")
 }
 
 // TestNPMOIDCSameHostDifferentPaths verifies that two npm OIDC credentials on

--- a/internal/handlers/python_index.go
+++ b/internal/handlers/python_index.go
@@ -3,13 +3,11 @@ package handlers
 import (
 	"net/http"
 	"regexp"
-	"strings"
 
 	"github.com/elazarl/goproxy"
 
 	"github.com/dependabot/proxy/internal/config"
 	"github.com/dependabot/proxy/internal/helpers"
-	"github.com/dependabot/proxy/internal/logging"
 	"github.com/dependabot/proxy/internal/oidc"
 )
 
@@ -18,6 +16,7 @@ var simpleSuffixRe = regexp.MustCompile(`/\+?simple/?\z`)
 // PythonIndexHandler handles requests to Python indexes, adding auth.
 type PythonIndexHandler struct {
 	credentials  []pythonIndexCredentials
+	downloadAuth *pythonIndexDownloadAuthStore
 	oidcRegistry *oidc.OIDCRegistry
 }
 
@@ -33,6 +32,7 @@ type pythonIndexCredentials struct {
 func NewPythonIndexHandler(creds config.Credentials) *PythonIndexHandler {
 	handler := PythonIndexHandler{
 		credentials:  []pythonIndexCredentials{},
+		downloadAuth: newPythonIndexDownloadAuthStore(),
 		oidcRegistry: oidc.NewOIDCRegistry(),
 	}
 
@@ -87,8 +87,13 @@ func (h *PythonIndexHandler) HandleRequest(req *http.Request, ctx *goproxy.Proxy
 		return req, nil
 	}
 
+	if auth, ok := h.downloadAuth.authFor(req); ok && h.applyAuth(req, ctx, auth) {
+		return req, nil
+	}
+
 	// Try OIDC credentials first
-	if h.oidcRegistry.TryAuth(req, ctx) {
+	if credential := h.oidcRegistry.CredentialForRequest(req); h.oidcRegistry.TryAuthCredential(req, ctx, credential) {
+		rememberPythonIndexResponseAuth(ctx, req.URL, pythonIndexAuth{oidc: credential})
 		return req, nil
 	}
 
@@ -99,15 +104,9 @@ func (h *PythonIndexHandler) HandleRequest(req *http.Request, ctx *goproxy.Proxy
 			continue
 		}
 
-		logging.RequestLogf(ctx, "* authenticating python index request (host: %s)", req.URL.Hostname())
-
-		token := cred.token
-		if token == "" && cred.password != "" {
-			token = cred.username + ":" + cred.password
-		}
-		// ignore `found` because it's okay for the password to be an empty string
-		username, password, _ := strings.Cut(token, ":")
-		helpers.SetBasicAuthorization(req, username, password)
+		auth := pythonIndexAuth{basic: cred, hasBasic: true}
+		h.applyAuth(req, ctx, auth)
+		rememberPythonIndexResponseAuth(ctx, req.URL, auth)
 
 		return req, nil
 	}

--- a/internal/handlers/python_index_auth.go
+++ b/internal/handlers/python_index_auth.go
@@ -1,0 +1,135 @@
+package handlers
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/elazarl/goproxy"
+
+	"github.com/dependabot/proxy/internal/ctxdata"
+	"github.com/dependabot/proxy/internal/helpers"
+	"github.com/dependabot/proxy/internal/logging"
+	"github.com/dependabot/proxy/internal/oidc"
+)
+
+const pythonIndexResponseAuthKey = "python-index-response-auth"
+
+type pythonIndexAuth struct {
+	oidc     *oidc.OIDCCredential
+	basic    pythonIndexCredentials
+	hasBasic bool
+}
+
+type pythonIndexResponseAuth struct {
+	auth    pythonIndexAuth
+	baseURL url.URL
+}
+
+type pythonIndexDownloadAuthStore struct {
+	mutex   sync.RWMutex
+	entries []pythonIndexDownloadAuthEntry
+}
+
+type pythonIndexDownloadAuthEntry struct {
+	prefix *url.URL
+	auth   pythonIndexAuth
+}
+
+func newPythonIndexDownloadAuthStore() *pythonIndexDownloadAuthStore {
+	return &pythonIndexDownloadAuthStore{}
+}
+
+func (s *pythonIndexDownloadAuthStore) add(prefix *url.URL, auth pythonIndexAuth) {
+	if prefix == nil {
+		return
+	}
+
+	normalized := normalizedPythonIndexDownloadURL(prefix)
+	if normalized == nil {
+		return
+	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	for i := range s.entries {
+		if sameOrigin(s.entries[i].prefix, normalized) && s.entries[i].prefix.Path == normalized.Path {
+			return
+		}
+	}
+
+	s.entries = append(s.entries, pythonIndexDownloadAuthEntry{
+		prefix: normalized,
+		auth:   auth,
+	})
+}
+
+func (s *pythonIndexDownloadAuthStore) authFor(req *http.Request) (pythonIndexAuth, bool) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	var matched pythonIndexAuth
+	bestPathLen := -1
+	for _, entry := range s.entries {
+		if !sameOrigin(entry.prefix, req.URL) || !isPathPrefix(entry.prefix.Path, req.URL.Path) {
+			continue
+		}
+		if len(entry.prefix.Path) > bestPathLen {
+			matched = entry.auth
+			bestPathLen = len(entry.prefix.Path)
+		}
+	}
+
+	if bestPathLen < 0 {
+		return pythonIndexAuth{}, false
+	}
+	return matched, true
+}
+
+func (h *PythonIndexHandler) applyAuth(req *http.Request, ctx *goproxy.ProxyCtx, auth pythonIndexAuth) bool {
+	if auth.oidc != nil {
+		return h.oidcRegistry.TryAuthCredential(req, ctx, auth.oidc)
+	}
+	if !auth.hasBasic {
+		return false
+	}
+
+	logging.RequestLogf(ctx, "* authenticating python index request (host: %s)", req.URL.Hostname())
+
+	token := auth.basic.token
+	if token == "" && auth.basic.password != "" {
+		token = auth.basic.username + ":" + auth.basic.password
+	}
+	// ignore `found` because it's okay for the password to be an empty string
+	username, password, _ := strings.Cut(token, ":")
+	helpers.SetBasicAuthorization(req, username, password)
+
+	return true
+}
+
+func rememberPythonIndexResponseAuth(ctx *goproxy.ProxyCtx, baseURL *url.URL, auth pythonIndexAuth) {
+	if ctx == nil || baseURL == nil {
+		return
+	}
+
+	ctxdata.SetValue(ctx, pythonIndexResponseAuthKey, pythonIndexResponseAuth{
+		auth:    auth,
+		baseURL: *baseURL,
+	})
+}
+
+func pythonIndexResponseAuthFromContext(ctx *goproxy.ProxyCtx) (pythonIndexResponseAuth, bool) {
+	if ctx == nil {
+		return pythonIndexResponseAuth{}, false
+	}
+
+	value, ok := ctxdata.GetValue(ctx, pythonIndexResponseAuthKey)
+	if !ok {
+		return pythonIndexResponseAuth{}, false
+	}
+
+	responseAuth, ok := value.(pythonIndexResponseAuth)
+	return responseAuth, ok
+}

--- a/internal/handlers/python_index_auth.go
+++ b/internal/handlers/python_index_auth.go
@@ -14,7 +14,10 @@ import (
 	"github.com/dependabot/proxy/internal/oidc"
 )
 
-const pythonIndexResponseAuthKey = "python-index-response-auth"
+const (
+	pythonIndexResponseAuthKey        = "python-index-response-auth"
+	maxPythonIndexDownloadAuthEntries = 1024
+)
 
 type pythonIndexAuth struct {
 	oidc     *oidc.OIDCCredential
@@ -60,10 +63,16 @@ func (s *pythonIndexDownloadAuthStore) add(prefix *url.URL, auth pythonIndexAuth
 		}
 	}
 
-	s.entries = append(s.entries, pythonIndexDownloadAuthEntry{
+	entry := pythonIndexDownloadAuthEntry{
 		prefix: normalized,
 		auth:   auth,
-	})
+	}
+	if len(s.entries) >= maxPythonIndexDownloadAuthEntries {
+		copy(s.entries, s.entries[1:])
+		s.entries[len(s.entries)-1] = entry
+		return
+	}
+	s.entries = append(s.entries, entry)
 }
 
 func (s *pythonIndexDownloadAuthStore) authFor(req *http.Request) (pythonIndexAuth, bool) {

--- a/internal/handlers/python_index_download_prefixes.go
+++ b/internal/handlers/python_index_download_prefixes.go
@@ -186,8 +186,9 @@ func normalizedPythonIndexDownloadURL(u *url.URL) *url.URL {
 
 	normalized := *u
 	normalized.Scheme = strings.ToLower(normalized.Scheme)
+	port := normalizedPort(&normalized)
 	normalized.Host = strings.ToLower(normalized.Hostname())
-	if port := normalizedPort(&normalized); !isDefaultPort(normalized.Scheme, port) {
+	if port != "" && !isDefaultPort(normalized.Scheme, port) {
 		normalized.Host += ":" + port
 	}
 	normalized.RawQuery = ""

--- a/internal/handlers/python_index_download_prefixes.go
+++ b/internal/handlers/python_index_download_prefixes.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"html"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -164,6 +165,9 @@ func resolveSameScopedURL(link string, baseURL *url.URL) (*url.URL, bool) {
 	return resolved, true
 }
 
+// pythonDownloadPrefixPath recognizes Azure Artifacts package download URLs,
+// whose Simple API responses can rewrite /pypi/simple/ registry paths to
+// /_packaging/<feed-id>/pypi/download/ file paths.
 func pythonDownloadPrefixPath(path string) (string, bool) {
 	segments := pathSegments(path)
 	for i, segment := range segments {
@@ -189,7 +193,9 @@ func normalizedPythonIndexDownloadURL(u *url.URL) *url.URL {
 	port := normalizedPort(&normalized)
 	normalized.Host = strings.ToLower(normalized.Hostname())
 	if port != "" && !isDefaultPort(normalized.Scheme, port) {
-		normalized.Host += ":" + port
+		normalized.Host = net.JoinHostPort(normalized.Host, port)
+	} else if strings.Contains(normalized.Host, ":") {
+		normalized.Host = "[" + normalized.Host + "]"
 	}
 	normalized.RawQuery = ""
 	normalized.Fragment = ""

--- a/internal/handlers/python_index_download_prefixes.go
+++ b/internal/handlers/python_index_download_prefixes.go
@@ -33,7 +33,7 @@ func (h *PythonIndexHandler) HandleResponse(resp *http.Response, ctx *goproxy.Pr
 	}
 
 	responseAuth, ok := pythonIndexResponseAuthFromContext(ctx)
-	if !ok || !isSimpleAPIResponse(resp) {
+	if !ok || !isPythonSimpleAPIPath(responseAuth.baseURL.Path) || !isSimpleAPIResponse(resp) {
 		return resp
 	}
 
@@ -237,6 +237,15 @@ func firstPathSegment(path string) string {
 		return ""
 	}
 	return segments[0]
+}
+
+func isPythonSimpleAPIPath(path string) bool {
+	for _, segment := range pathSegments(path) {
+		if segment == "simple" || segment == "+simple" {
+			return true
+		}
+	}
+	return false
 }
 
 func isPathPrefix(prefix, path string) bool {

--- a/internal/handlers/python_index_download_prefixes.go
+++ b/internal/handlers/python_index_download_prefixes.go
@@ -13,6 +13,8 @@ import (
 	"github.com/elazarl/goproxy"
 )
 
+const maxPythonIndexDiscoveryBytes = 2 * 1024 * 1024
+
 var hrefAttrRe = regexp.MustCompile(`(?is)<a\b[^>]*\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^'"\s>]+))`)
 
 type simpleJSONResponse struct {
@@ -35,10 +37,11 @@ func (h *PythonIndexHandler) HandleResponse(resp *http.Response, ctx *goproxy.Pr
 		return resp
 	}
 
-	body, err := io.ReadAll(resp.Body)
-	resp.Body.Close()
-	resp.Body = io.NopCloser(bytes.NewReader(body))
+	body, complete, err := readPythonIndexDiscoveryBody(resp)
 	if err != nil {
+		return resp
+	}
+	if !complete {
 		return resp
 	}
 
@@ -49,6 +52,30 @@ func (h *PythonIndexHandler) HandleResponse(resp *http.Response, ctx *goproxy.Pr
 	}
 
 	return resp
+}
+
+func readPythonIndexDiscoveryBody(resp *http.Response) ([]byte, bool, error) {
+	// Only buffer a bounded prefix for discovery. If the response is larger
+	// than the cap, skip learning but replay the bytes already consumed so the
+	// package manager still receives the original full response.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxPythonIndexDiscoveryBytes+1))
+	resp.Body = &replayReadCloser{
+		Reader: io.MultiReader(bytes.NewReader(body), resp.Body),
+		Closer: resp.Body,
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	if len(body) > maxPythonIndexDiscoveryBytes {
+		return nil, false, nil
+	}
+
+	return body, true, nil
+}
+
+type replayReadCloser struct {
+	io.Reader
+	io.Closer
 }
 
 func distributionFileLinks(contentType string, body []byte) []string {

--- a/internal/handlers/python_index_download_prefixes.go
+++ b/internal/handlers/python_index_download_prefixes.go
@@ -1,0 +1,221 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"html"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/elazarl/goproxy"
+)
+
+var hrefAttrRe = regexp.MustCompile(`(?is)<a\b[^>]*\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^'"\s>]+))`)
+
+type simpleJSONResponse struct {
+	Files []struct {
+		URL string `json:"url"`
+	} `json:"files"`
+}
+
+// HandleResponse learns stable Python package download prefixes from
+// authenticated Simple API responses. Some indexes return file URLs outside
+// the configured /simple/ prefix (for example, /pypi/download/...), so the
+// request matcher needs one extra prefix learned from the registry response.
+func (h *PythonIndexHandler) HandleResponse(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
+	if resp == nil || resp.Body == nil || resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return resp
+	}
+
+	responseAuth, ok := pythonIndexResponseAuthFromContext(ctx)
+	if !ok || !isSimpleAPIResponse(resp) {
+		return resp
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	if err != nil {
+		return resp
+	}
+
+	for _, link := range distributionFileLinks(resp.Header.Get("Content-Type"), body) {
+		if prefix, ok := pythonDownloadPrefixFromSimpleLink(link, &responseAuth.baseURL); ok {
+			h.downloadAuth.add(prefix, responseAuth.auth)
+		}
+	}
+
+	return resp
+}
+
+func distributionFileLinks(contentType string, body []byte) []string {
+	if strings.Contains(strings.ToLower(contentType), "json") {
+		return distributionFileLinksFromJSON(body)
+	}
+
+	return distributionFileLinksFromHTML(body)
+}
+
+func distributionFileLinksFromJSON(body []byte) []string {
+	var parsed simpleJSONResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil
+	}
+
+	links := make([]string, 0, len(parsed.Files))
+	for _, file := range parsed.Files {
+		if file.URL != "" {
+			links = append(links, file.URL)
+		}
+	}
+
+	return links
+}
+
+func distributionFileLinksFromHTML(body []byte) []string {
+	var links []string
+	for _, match := range hrefAttrRe.FindAllSubmatch(body, -1) {
+		for _, group := range match[1:] {
+			if len(group) == 0 {
+				continue
+			}
+			links = append(links, html.UnescapeString(string(group)))
+			break
+		}
+	}
+
+	return links
+}
+
+func isSimpleAPIResponse(resp *http.Response) bool {
+	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
+	return strings.Contains(contentType, "text/html") ||
+		strings.Contains(contentType, "application/vnd.pypi.simple.v1+json") ||
+		strings.Contains(contentType, "application/json")
+}
+
+func pythonDownloadPrefixFromSimpleLink(link string, baseURL *url.URL) (*url.URL, bool) {
+	downloadURL, ok := resolveSameScopedURL(link, baseURL)
+	if !ok {
+		return nil, false
+	}
+
+	prefixPath, ok := pythonDownloadPrefixPath(downloadURL.Path)
+	if !ok {
+		return nil, false
+	}
+
+	prefix := *downloadURL
+	prefix.Path = prefixPath
+	prefix.RawQuery = ""
+	prefix.Fragment = ""
+	prefix.User = nil
+
+	return &prefix, true
+}
+
+func resolveSameScopedURL(link string, baseURL *url.URL) (*url.URL, bool) {
+	if baseURL == nil {
+		return nil, false
+	}
+
+	parsedLink, err := url.Parse(link)
+	if err != nil {
+		return nil, false
+	}
+
+	resolved := baseURL.ResolveReference(parsedLink)
+	if resolved.Scheme != "https" || !sameOrigin(baseURL, resolved) || firstPathSegment(baseURL.Path) != firstPathSegment(resolved.Path) {
+		return nil, false
+	}
+	resolved.Fragment = ""
+	resolved.User = nil
+
+	return resolved, true
+}
+
+func pythonDownloadPrefixPath(path string) (string, bool) {
+	segments := pathSegments(path)
+	for i, segment := range segments {
+		if segment != "_packaging" || i+3 >= len(segments) {
+			continue
+		}
+		if segments[i+2] != "pypi" || segments[i+3] != "download" {
+			continue
+		}
+		return "/" + strings.Join(segments[:i+4], "/") + "/", true
+	}
+
+	return "", false
+}
+
+func normalizedPythonIndexDownloadURL(u *url.URL) *url.URL {
+	if u == nil || u.Scheme == "" || u.Hostname() == "" || u.Path == "" {
+		return nil
+	}
+
+	normalized := *u
+	normalized.Scheme = strings.ToLower(normalized.Scheme)
+	normalized.Host = strings.ToLower(normalized.Hostname())
+	if port := normalizedPort(&normalized); !isDefaultPort(normalized.Scheme, port) {
+		normalized.Host += ":" + port
+	}
+	normalized.RawQuery = ""
+	normalized.Fragment = ""
+	normalized.User = nil
+
+	return &normalized
+}
+
+func sameOrigin(a, b *url.URL) bool {
+	return strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		normalizedPort(a) == normalizedPort(b)
+}
+
+func normalizedPort(u *url.URL) string {
+	if port := u.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
+}
+
+func isDefaultPort(scheme, port string) bool {
+	return (scheme == "https" && port == "443") || (scheme == "http" && port == "80")
+}
+
+func pathSegments(path string) []string {
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return nil
+	}
+
+	return strings.Split(trimmed, "/")
+}
+
+func firstPathSegment(path string) string {
+	segments := pathSegments(path)
+	if len(segments) == 0 {
+		return ""
+	}
+	return segments[0]
+}
+
+func isPathPrefix(prefix, path string) bool {
+	if prefix == path {
+		return true
+	}
+
+	suffix, ok := strings.CutPrefix(path, prefix)
+	return ok && (strings.HasSuffix(prefix, "/") || strings.HasPrefix(suffix, "/"))
+}

--- a/internal/handlers/python_index_test.go
+++ b/internal/handlers/python_index_test.go
@@ -214,6 +214,54 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromJSON(t *test
 	assertHasBasicAuth(t, downloadReq, "user", "pass", "discovered JSON download request")
 }
 
+func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixPort(t *testing.T) {
+	handler := NewPythonIndexHandler(config.Credentials{
+		config.Credential{
+			"type":      "python_index",
+			"index-url": "https://pkgs.example.com:8443/my-org/my-project/_packaging/my-feed/pypi/simple/",
+			"token":     "user:pass",
+		},
+	})
+
+	ctx := &goproxy.ProxyCtx{}
+	indexReq := httptest.NewRequest(
+		"GET",
+		"https://pkgs.example.com:8443/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
+		nil,
+	)
+	indexReq = handleRequestAndClose(handler, indexReq, ctx)
+	assertHasBasicAuth(t, indexReq, "user", "pass", "simple index request")
+
+	indexResp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/html"},
+		},
+		Body: io.NopCloser(strings.NewReader(`
+			<a href="https://pkgs.example.com:8443/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl">
+				my-package-1.0.0.whl
+			</a>
+		`)),
+	}
+	handler.HandleResponse(indexResp, ctx)
+
+	downloadReq := httptest.NewRequest(
+		"GET",
+		"https://pkgs.example.com:8443/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
+		nil,
+	)
+	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})
+	assertHasBasicAuth(t, downloadReq, "user", "pass", "discovered download request on custom port")
+
+	defaultPortReq := httptest.NewRequest(
+		"GET",
+		"https://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
+		nil,
+	)
+	defaultPortReq = handleRequestAndClose(handler, defaultPortReq, &goproxy.ProxyCtx{})
+	assertUnauthenticated(t, defaultPortReq, "download request on default port should not match custom port prefix")
+}
+
 func TestPythonIndexHandlerSkipsDiscoveryForLargeSimpleResponse(t *testing.T) {
 	handler := NewPythonIndexHandler(config.Credentials{
 		config.Credential{

--- a/internal/handlers/python_index_test.go
+++ b/internal/handlers/python_index_test.go
@@ -2,8 +2,13 @@ package handlers
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/elazarl/goproxy"
 
 	"github.com/dependabot/proxy/internal/config"
 )
@@ -104,4 +109,107 @@ func TestPythonIndexHandler(t *testing.T) {
 	req = httptest.NewRequest("GET", "https://PKGS.dev.azure.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "azure devops case insensitive registry request")
+}
+
+func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromHTML(t *testing.T) {
+	handler := NewPythonIndexHandler(config.Credentials{
+		config.Credential{
+			"type":      "python_index",
+			"index-url": "https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/",
+			"token":     "user:pass",
+		},
+	})
+
+	ctx := &goproxy.ProxyCtx{}
+	indexReq := httptest.NewRequest(
+		"GET",
+		"https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
+		nil,
+	)
+	indexReq = handleRequestAndClose(handler, indexReq, ctx)
+	assertHasBasicAuth(t, indexReq, "user", "pass", "simple index request")
+
+	indexResp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/html"},
+		},
+		Body: io.NopCloser(strings.NewReader(`
+			<html><body>
+				<a href="https://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl#sha256=abc">
+					my-package-1.0.0.whl
+				</a>
+				<a href="https://pkgs.example.com/other-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl">
+					other-org file
+				</a>
+			</body></html>
+		`)),
+	}
+	handler.HandleResponse(indexResp, ctx)
+
+	downloadReq := httptest.NewRequest(
+		"HEAD",
+		"https://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
+		nil,
+	)
+	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})
+	assertHasBasicAuth(t, downloadReq, "user", "pass", "discovered download request")
+
+	samePrefixReq := httptest.NewRequest(
+		"GET",
+		"https://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/another-package/2.0.0/another-package-2.0.0.whl",
+		nil,
+	)
+	samePrefixReq = handleRequestAndClose(handler, samePrefixReq, &goproxy.ProxyCtx{})
+	assertHasBasicAuth(t, samePrefixReq, "user", "pass", "same discovered download prefix request")
+
+	otherOrgReq := httptest.NewRequest(
+		"GET",
+		"https://pkgs.example.com/other-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
+		nil,
+	)
+	otherOrgReq = handleRequestAndClose(handler, otherOrgReq, &goproxy.ProxyCtx{})
+	assertUnauthenticated(t, otherOrgReq, "download request outside authenticated path scope")
+}
+
+func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromJSON(t *testing.T) {
+	handler := NewPythonIndexHandler(config.Credentials{
+		config.Credential{
+			"type":      "python_index",
+			"index-url": "https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/",
+			"token":     "user:pass",
+		},
+	})
+
+	ctx := &goproxy.ProxyCtx{}
+	indexReq := httptest.NewRequest(
+		"GET",
+		"https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
+		nil,
+	)
+	indexReq = handleRequestAndClose(handler, indexReq, ctx)
+	assertHasBasicAuth(t, indexReq, "user", "pass", "simple index request")
+
+	indexResp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"application/vnd.pypi.simple.v1+json"},
+		},
+		Body: io.NopCloser(strings.NewReader(`{
+			"meta": {"api-version": "1.4"},
+			"name": "my-package",
+			"files": [
+				{"filename": "my-package-1.0.0.whl", "url": "/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl#sha256=abc"}
+			]
+		}`)),
+	}
+	handler.HandleResponse(indexResp, ctx)
+
+	downloadReq := httptest.NewRequest(
+		"GET",
+		"https://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
+		nil,
+	)
+	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})
+	assertHasBasicAuth(t, downloadReq, "user", "pass", "discovered JSON download request")
 }

--- a/internal/handlers/python_index_test.go
+++ b/internal/handlers/python_index_test.go
@@ -215,6 +215,43 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromJSON(t *test
 	assertHasBasicAuth(t, downloadReq, "user", "pass", "discovered JSON download request")
 }
 
+func TestPythonDownloadPrefixFromSimpleLinkRejectsUnscopedLinks(t *testing.T) {
+	baseURL, err := url.Parse("https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/")
+	if err != nil {
+		t.Fatalf("failed to parse base URL: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		link string
+	}{
+		{
+			name: "non-HTTPS",
+			link: "http://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
+		},
+		{
+			name: "different host",
+			link: "https://files.example.com/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
+		},
+		{
+			name: "different port",
+			link: "https://pkgs.example.com:8443/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
+		},
+		{
+			name: "different first path segment",
+			link: "https://pkgs.example.com/other-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if prefix, ok := pythonDownloadPrefixFromSimpleLink(tt.link, baseURL); ok {
+				t.Fatalf("expected download prefix discovery to be rejected, got %s", prefix)
+			}
+		})
+	}
+}
+
 func TestPythonIndexHandlerSkipsDiscoveryForAuthenticatedNonSimpleResponse(t *testing.T) {
 	handler := NewPythonIndexHandler(config.Credentials{
 		config.Credential{

--- a/internal/handlers/python_index_test.go
+++ b/internal/handlers/python_index_test.go
@@ -213,3 +213,45 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromJSON(t *test
 	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})
 	assertHasBasicAuth(t, downloadReq, "user", "pass", "discovered JSON download request")
 }
+
+func TestPythonIndexHandlerSkipsDiscoveryForLargeSimpleResponse(t *testing.T) {
+	handler := NewPythonIndexHandler(config.Credentials{
+		config.Credential{
+			"type":      "python_index",
+			"index-url": "https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/",
+			"token":     "user:pass",
+		},
+	})
+
+	ctx := &goproxy.ProxyCtx{}
+	indexReq := httptest.NewRequest(
+		"GET",
+		"https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
+		nil,
+	)
+	indexReq = handleRequestAndClose(handler, indexReq, ctx)
+	assertHasBasicAuth(t, indexReq, "user", "pass", "simple index request")
+
+	downloadURL := "https://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl"
+	responseBody := `<a href="` + downloadURL + `">file</a>` + strings.Repeat("x", maxPythonIndexDiscoveryBytes)
+	indexResp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/html"},
+		},
+		Body: io.NopCloser(strings.NewReader(responseBody)),
+	}
+	handler.HandleResponse(indexResp, ctx)
+
+	replayedBody, err := io.ReadAll(indexResp.Body)
+	if err != nil {
+		t.Fatalf("failed to read replayed response body: %v", err)
+	}
+	if string(replayedBody) != responseBody {
+		t.Fatal("large Simple API response body was not replayed unchanged")
+	}
+
+	downloadReq := httptest.NewRequest("GET", downloadURL, nil)
+	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})
+	assertUnauthenticated(t, downloadReq, "large Simple API response should not be used for discovery")
+}

--- a/internal/handlers/python_index_test.go
+++ b/internal/handlers/python_index_test.go
@@ -215,6 +215,42 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromJSON(t *test
 	assertHasBasicAuth(t, downloadReq, "user", "pass", "discovered JSON download request")
 }
 
+func TestPythonIndexHandlerSkipsDiscoveryForAuthenticatedNonSimpleResponse(t *testing.T) {
+	handler := NewPythonIndexHandler(config.Credentials{
+		config.Credential{
+			"type":      "python_index",
+			"index-url": "https://pkgs.example.com/org/project/",
+			"token":     "user:pass",
+		},
+	})
+
+	ctx := &goproxy.ProxyCtx{}
+	nonSimpleReq := httptest.NewRequest("GET", "https://pkgs.example.com/org/project/status", nil)
+	nonSimpleReq = handleRequestAndClose(handler, nonSimpleReq, ctx)
+	assertHasBasicAuth(t, nonSimpleReq, "user", "pass", "path-scoped python index request")
+
+	indexResp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/html"},
+		},
+		Body: io.NopCloser(strings.NewReader(`
+			<a href="https://pkgs.example.com/org/other-project/_packaging/feed/pypi/download/my-package/1.0.0/my-package-1.0.0.whl">
+				my-package-1.0.0.whl
+			</a>
+		`)),
+	}
+	handler.HandleResponse(indexResp, ctx)
+
+	downloadReq := httptest.NewRequest(
+		"GET",
+		"https://pkgs.example.com/org/other-project/_packaging/feed/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
+		nil,
+	)
+	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})
+	assertUnauthenticated(t, downloadReq, "non-Simple response should not be used for discovery")
+}
+
 func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixPort(t *testing.T) {
 	handler := NewPythonIndexHandler(config.Credentials{
 		config.Credential{

--- a/internal/handlers/python_index_test.go
+++ b/internal/handlers/python_index_test.go
@@ -299,6 +299,46 @@ func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixPort(t *testing.T) {
 	assertUnauthenticated(t, defaultPortReq, "download request on default port should not match custom port prefix")
 }
 
+func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixIPv6Host(t *testing.T) {
+	handler := NewPythonIndexHandler(config.Credentials{
+		config.Credential{
+			"type":      "python_index",
+			"index-url": "https://[2001:db8::1]/my-org/my-project/_packaging/my-feed/pypi/simple/",
+			"token":     "user:pass",
+		},
+	})
+
+	ctx := &goproxy.ProxyCtx{}
+	indexReq := httptest.NewRequest(
+		"GET",
+		"https://[2001:db8::1]/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
+		nil,
+	)
+	indexReq = handleRequestAndClose(handler, indexReq, ctx)
+	assertHasBasicAuth(t, indexReq, "user", "pass", "simple index request")
+
+	indexResp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/html"},
+		},
+		Body: io.NopCloser(strings.NewReader(`
+			<a href="https://[2001:db8::1]/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl">
+				my-package-1.0.0.whl
+			</a>
+		`)),
+	}
+	handler.HandleResponse(indexResp, ctx)
+
+	downloadReq := httptest.NewRequest(
+		"GET",
+		"https://[2001:db8::1]/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
+		nil,
+	)
+	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})
+	assertHasBasicAuth(t, downloadReq, "user", "pass", "discovered download request on IPv6 host")
+}
+
 func TestPythonIndexDownloadAuthStoreEvictsOldestEntryAtLimit(t *testing.T) {
 	store := newPythonIndexDownloadAuthStore()
 	auth := pythonIndexAuth{

--- a/internal/handlers/python_index_test.go
+++ b/internal/handlers/python_index_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -260,6 +261,53 @@ func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixPort(t *testing.T) {
 	)
 	defaultPortReq = handleRequestAndClose(handler, defaultPortReq, &goproxy.ProxyCtx{})
 	assertUnauthenticated(t, defaultPortReq, "download request on default port should not match custom port prefix")
+}
+
+func TestPythonIndexDownloadAuthStoreEvictsOldestEntryAtLimit(t *testing.T) {
+	store := newPythonIndexDownloadAuthStore()
+	auth := pythonIndexAuth{
+		basic:    pythonIndexCredentials{token: "user:pass"},
+		hasBasic: true,
+	}
+
+	for i := 0; i < maxPythonIndexDownloadAuthEntries+1; i++ {
+		prefix, err := url.Parse(fmt.Sprintf(
+			"https://pkgs.example.com/org/project/_packaging/feed-%d/pypi/download/",
+			i,
+		))
+		if err != nil {
+			t.Fatalf("failed to parse prefix URL: %v", err)
+		}
+		store.add(prefix, auth)
+	}
+
+	store.mutex.RLock()
+	entryCount := len(store.entries)
+	store.mutex.RUnlock()
+	if entryCount != maxPythonIndexDownloadAuthEntries {
+		t.Fatalf("expected %d stored prefixes, got %d", maxPythonIndexDownloadAuthEntries, entryCount)
+	}
+
+	evictedReq := httptest.NewRequest(
+		"GET",
+		"https://pkgs.example.com/org/project/_packaging/feed-0/pypi/download/pkg/1.0/pkg.whl",
+		nil,
+	)
+	if _, ok := store.authFor(evictedReq); ok {
+		t.Fatal("oldest discovered download prefix should be evicted")
+	}
+
+	retainedReq := httptest.NewRequest(
+		"GET",
+		fmt.Sprintf(
+			"https://pkgs.example.com/org/project/_packaging/feed-%d/pypi/download/pkg/1.0/pkg.whl",
+			maxPythonIndexDownloadAuthEntries,
+		),
+		nil,
+	)
+	if _, ok := store.authFor(retainedReq); !ok {
+		t.Fatal("newest discovered download prefix should be retained")
+	}
 }
 
 func TestPythonIndexHandlerSkipsDiscoveryForLargeSimpleResponse(t *testing.T) {

--- a/internal/oidc/oidc_registry.go
+++ b/internal/oidc/oidc_registry.go
@@ -97,6 +97,12 @@ func (r *OIDCRegistry) RegisterURL(url string, cred *OIDCCredential, registryTyp
 //
 // Returns true if the request was authenticated, false otherwise.
 func (r *OIDCRegistry) TryAuth(req *http.Request, ctx *goproxy.ProxyCtx) bool {
+	return r.TryAuthCredential(req, ctx, r.CredentialForRequest(req))
+}
+
+// CredentialForRequest returns the most specific OIDC credential matching the
+// request host, port, and path.
+func (r *OIDCRegistry) CredentialForRequest(req *http.Request) *OIDCCredential {
 	host := strings.ToLower(helpers.GetHost(req))
 	reqPort := req.URL.Port()
 	if reqPort == "" {
@@ -108,7 +114,7 @@ func (r *OIDCRegistry) TryAuth(req *http.Request, ctx *goproxy.ProxyCtx) bool {
 	r.mutex.RUnlock()
 
 	if len(entries) == 0 {
-		return false
+		return nil
 	}
 
 	// Find the most specific matching entry: host is already matched,
@@ -129,17 +135,25 @@ func (r *OIDCRegistry) TryAuth(req *http.Request, ctx *goproxy.ProxyCtx) bool {
 		}
 	}
 
-	if matched == nil {
+	return matched
+}
+
+// TryAuthCredential authenticates a request with a known OIDC credential.
+// Handlers use this when they have their own safe matching rule but want the
+// provider-specific OIDC header behavior to stay centralized here.
+func (r *OIDCRegistry) TryAuthCredential(req *http.Request, ctx *goproxy.ProxyCtx, credential *OIDCCredential) bool {
+	if credential == nil {
 		return false
 	}
 
-	token, err := GetOrRefreshOIDCToken(matched, req.Context())
+	host := strings.ToLower(helpers.GetHost(req))
+	token, err := GetOrRefreshOIDCToken(credential, req.Context())
 	if err != nil {
-		logging.RequestLogf(ctx, "* failed to get %s token via OIDC for %s: %v", matched.Provider(), host, err)
+		logging.RequestLogf(ctx, "* failed to get %s token via OIDC for %s: %v", credential.Provider(), host, err)
 		return false
 	}
 
-	switch matched.parameters.(type) {
+	switch credential.parameters.(type) {
 	case *CloudsmithOIDCParameters:
 		logging.RequestLogf(ctx, "* authenticating request with OIDC API key (host: %s)", host)
 		helpers.ReplaceAuthorization(req, "X-Api-Key", token)

--- a/internal/oidc/oidc_registry.go
+++ b/internal/oidc/oidc_registry.go
@@ -110,7 +110,7 @@ func (r *OIDCRegistry) CredentialForRequest(req *http.Request) *OIDCCredential {
 	}
 
 	r.mutex.RLock()
-	entries := r.byHost[host]
+	entries := append([]oidcEntry(nil), r.byHost[host]...)
 	r.mutex.RUnlock()
 
 	if len(entries) == 0 {

--- a/internal/oidc/oidc_registry_test.go
+++ b/internal/oidc/oidc_registry_test.go
@@ -5,7 +5,9 @@ import (
 	"log"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
@@ -249,6 +251,41 @@ func TestOIDCRegistry_TryAuth_WrongPathNoMatch(t *testing.T) {
 
 	assert.False(t, ok, "should not match different path")
 	assert.Empty(t, req.Header.Get("Authorization"))
+}
+
+func TestOIDCRegistry_CredentialForRequestConcurrentRegistration(t *testing.T) {
+	r := NewOIDCRegistry()
+	credential := &OIDCCredential{
+		parameters: &AzureOIDCParameters{
+			TenantID: "tenant-1",
+			ClientID: "client-1",
+		},
+	}
+	r.RegisterURL("https://registry.example.com/packages", credential, "test registry")
+
+	req := httptest.NewRequest("GET", "https://registry.example.com/packages/some-package", nil)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			r.RegisterURL(
+				"https://registry.example.com/packages/feed-"+strconv.Itoa(i),
+				credential,
+				"test registry",
+			)
+		}(i)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				_ = r.CredentialForRequest(req)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Same(t, credential, r.CredentialForRequest(req))
 }
 
 func TestOIDCRegistry_RegisterURL(t *testing.T) {

--- a/proxy.go
+++ b/proxy.go
@@ -99,6 +99,7 @@ func newProxy(envSettings config.ProxyEnvSettings, cfg *config.Config, blockedIp
 
 	pythonHandler := handlers.NewPythonIndexHandler(cfg.Credentials)
 	proxy.OnRequest().DoFunc(pythonHandler.HandleRequest)
+	proxy.OnResponse().DoFunc(pythonHandler.HandleResponse)
 
 	composerHandler := handlers.NewComposerHandler(cfg.Credentials)
 	proxy.OnRequest().DoFunc(composerHandler.HandleRequest)


### PR DESCRIPTION
### What are you trying to accomplish?

Allow the proxy to authenticate Python package file downloads when an authenticated Simple API response points to a different stable download path than the configured index URL.

This is needed for Azure Artifacts Python indexes. Dependabot authenticates requests to the configured Simple API path, such as `/pypi/simple/...`, but Azure can return package links under rewritten `/pypi/download/...` paths that include internal project/feed identifiers. Those download URLs no longer match the original credential path, so hosted Dependabot can reach the package listing but fail to download the package file.

This affects dependabot/dependabot-core#15207.

### Anything you want to highlight for special attention from reviewers?

The implementation intentionally keeps authentication scoped. It does not broaden Python index credentials to the whole host. Instead, the proxy only learns Azure Artifacts download prefixes from authenticated Python Simple API responses, then reuses the same basic or OIDC credential for later requests under those discovered prefixes.

Discovery is limited to successful Simple API HTML/JSON responses, bounded in memory, restricted to same-origin and same-organization download links, and capped so a long-running proxy cannot learn unbounded prefixes.

### How will you know you've accomplished your goal?

The proxy test coverage exercises Python Simple API download-prefix discovery for both static and OIDC-backed credentials, including scoped matching, oversized responses, custom ports, IPv6 hosts, and negative cases where discovery must not broaden auth.

Validation run:

- `go test ./internal/handlers ./internal/oidc`

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
