### PR TITLE
fix: add path-prefix matching for static npm registry credentials

### DIFF
--- a/internal/handlers/npm_registry.go
+++ b/internal/handlers/npm_registry.go
@@ -101,6 +101,14 @@ func (h *NPMRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.Proxy
 			continue
 		}
 
+		// Path-segment-aware matching prevents credentials configured for one
+		// path-scoped registry from being applied to sibling paths on the same
+		// host (e.g., /team-a-npm should not match /team-b-npm).
+		regPath := strings.TrimSuffix(regURL.Path, "/")
+		if regPath != "" && !strings.HasPrefix(req.URL.Path, regPath+"/") && req.URL.Path != regPath {
+			continue
+		}
+
 		if cred.token == "" && cred.password != "" {
 			cred.token = cred.username + ":" + cred.password
 		}

--- a/internal/handlers/npm_registry_test.go
+++ b/internal/handlers/npm_registry_test.go
@@ -59,9 +59,10 @@ func TestNPMRegistryHandler(t *testing.T) {
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", privateRegToken, "valid registry request with port and path")
 
+	// Sibling path on the same host should NOT receive credentials from /reg-path
 	req = httptest.NewRequest("GET", "https://example.com/other-path/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
-	assertHasTokenAuth(t, req, "Bearer", privateRegToken, "different path")
+	assertUnauthenticated(t, req, "sibling path should not match")
 
 	req = httptest.NewRequest("GET", "https://nexus.some-company.com/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
@@ -86,4 +87,37 @@ func TestNPMRegistryHandler(t *testing.T) {
 	req = httptest.NewRequest("GET", "https://PKGS.dev.azure.com/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, nexusUser, nexusPassword, "azure devops case insensitive registry request")
+}
+
+func TestNPMRegistryHandler_SameHostDifferentPaths(t *testing.T) {
+	teamAToken := "team-a-token"
+	teamBToken := "team-b-token"
+	credentials := config.Credentials{
+		config.Credential{
+			"type":     "npm_registry",
+			"registry": "https://artifactory.example.com/api/npm/team-a-npm",
+			"token":    teamAToken,
+		},
+		config.Credential{
+			"type":     "npm_registry",
+			"registry": "https://artifactory.example.com/api/npm/team-b-npm",
+			"token":    teamBToken,
+		},
+	}
+	handler := NewNPMRegistryHandler(credentials)
+
+	// Request to team-a path should use team-a token
+	req := httptest.NewRequest("GET", "https://artifactory.example.com/api/npm/team-a-npm/@scope/pkg", nil)
+	req = handleRequestAndClose(handler, req, nil)
+	assertHasTokenAuth(t, req, "Bearer", teamAToken, "team-a path should use team-a token")
+
+	// Request to team-b path should use team-b token, not team-a
+	req = httptest.NewRequest("GET", "https://artifactory.example.com/api/npm/team-b-npm/@scope/pkg", nil)
+	req = handleRequestAndClose(handler, req, nil)
+	assertHasTokenAuth(t, req, "Bearer", teamBToken, "team-b path should use team-b token")
+
+	// Request to unrelated path should not be authenticated
+	req = httptest.NewRequest("GET", "https://artifactory.example.com/api/npm/team-c-npm/@scope/pkg", nil)
+	req = handleRequestAndClose(handler, req, nil)
+	assertUnauthenticated(t, req, "unrelated path should not match any credential")
 }


### PR DESCRIPTION
Fixes #145

## What

Add path-segment-aware matching to the static credential loop in `NPMRegistryHandler.HandleRequest`, so that credentials configured for one path-scoped registry are not applied to sibling paths on the same host.

## Why

When multiple npm registries share the same hostname but use different URL paths (common with JFrog Artifactory, AWS CodeArtifact, and Azure DevOps), the proxy sends the first matching credential based on host+port only. If the tokens are scoped to their respective repos, the wrong token results in a 403.

The OIDC code path was already fixed via `OIDCRegistry` (#78, #87, #91), but the static token fallback was not updated.

## How

After the existing host+port check, compare the request URL path against the credential's registry path using segment-aware prefix matching:

```go
regPath := strings.TrimSuffix(regURL.Path, "/")
if regPath != "" && !strings.HasPrefix(req.URL.Path, regPath+"/") && req.URL.Path != regPath {
    continue
}
```

- Empty path (host-only registries like `registry.npmjs.org`) continues to match any path on that host — no behavior change.
- Non-empty paths require the request URL to be within the registry's path scope.
- Segment-aware: `/team-a-npm` does not match `/team-a-npm-evil`.

## Tests

- Updated existing test: sibling path on same host is now correctly rejected.
- Added `TestNPMRegistryHandler_SameHostDifferentPaths`: verifies two registries on the same host with different paths receive their respective tokens, and unrelated paths are unauthenticated.

All existing tests pass (`go test ./...`).

## Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.