### PR TITLE
Modernize mechanical Go patterns

### DIFF
--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -160,7 +160,7 @@ func (c *Client) ReportMetrics(ctx context.Context, metricsData string) error {
 	return nil
 }
 
-func (c *Client) newURL(path string, args ...interface{}) string {
+func (c *Client) newURL(path string, args ...any) string {
 	return c.baseURL + fmt.Sprintf(path, args...)
 }
 

--- a/internal/apiclient/client_test.go
+++ b/internal/apiclient/client_test.go
@@ -31,7 +31,7 @@ const (
 func TestClient_ReportMetrics_Success(t *testing.T) {
 
 	// Define the expected metrics data
-	metricsData := []map[string]interface{}{
+	metricsData := []map[string]any{
 		{
 			"metric": "http_request_count",
 			"type":   "increment",
@@ -51,7 +51,7 @@ func TestClient_ReportMetrics_Success(t *testing.T) {
 			},
 		},
 	}
-	expectedBody, err := json.Marshal(map[string]interface{}{"data": metricsData})
+	expectedBody, err := json.Marshal(map[string]any{"data": metricsData})
 	require.NoError(t, err)
 
 	// Set up a test server
@@ -71,7 +71,7 @@ func TestClient_ReportMetrics_Success(t *testing.T) {
 	client := apiclient.New(s.URL, jobToken, jobID)
 
 	// Prepare and serialize the metrics data for sending
-	metricsDataStr, err := json.Marshal(map[string]interface{}{"data": metricsData})
+	metricsDataStr, err := json.Marshal(map[string]any{"data": metricsData})
 	require.NoError(t, err)
 
 	// Call the method under test
@@ -95,7 +95,7 @@ func TestClient_ReportMetrics_Error(t *testing.T) {
 	)
 
 	// Prepare and serialize the metrics data for sending
-	metricsData := map[string]interface{}{"data": []map[string]interface{}{{"metric": "test_metric", "value": 1}}}
+	metricsData := map[string]any{"data": []map[string]any{{"metric": "test_metric", "value": 1}}}
 	metricsDataStr, err := json.Marshal(metricsData)
 	require.NoError(t, err)
 
@@ -169,19 +169,19 @@ func TestClient_RequestJITAccess(t *testing.T) {
 	})
 
 	t.Run("concurrency limit", func(t *testing.T) {
-		var concurrencyCounter int32
+		var concurrencyCounter atomic.Int32
 		var totalCounter int32
 
 		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// use an atomic concurrencyCounter to limit concurrent requests for testing
-			atomic.AddInt32(&concurrencyCounter, 1)
+			concurrencyCounter.Add(1)
 			atomic.AddInt32(&totalCounter, 1)
-			if atomic.LoadInt32(&concurrencyCounter) > 1 {
+			if concurrencyCounter.Load() > 1 {
 				w.WriteHeader(http.StatusTooManyRequests)
 				w.Write([]byte("Too many requests"))
 				return
 			}
-			defer atomic.AddInt32(&concurrencyCounter, -1)
+			defer concurrencyCounter.Add(-1)
 
 			data, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
@@ -214,7 +214,7 @@ func TestClient_RequestJITAccess(t *testing.T) {
 			assert.Equal(t, "world-"+requestNumber, (*credential)["hello"], "Response should contain request number")
 		}
 
-		for i := 0; i < concurrentRequests; i++ {
+		for i := range concurrentRequests {
 			go makeRequest(fmt.Sprint(i + 1))
 		}
 		waitGroup.Wait()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,9 +24,9 @@ type Config struct {
 	ProxyAuth   BasicAuthCredentials `json:"proxy_auth"`
 }
 
-// Credential is a wrapper around map[string]interface{}, which is the format
+// Credential is a wrapper around map[string]any, which is the format
 // of credential entries
-type Credential map[string]interface{}
+type Credential map[string]any
 
 // Type returns the credential's type
 func (c Credential) Type() string {
@@ -62,7 +62,7 @@ func (c Credential) GetListOfStrings(key string) []string {
 	switch val := value.(type) {
 	case []string:
 		return val
-	case []interface{}:
+	case []any:
 		strings := make([]string, len(val))
 		for i, v := range val {
 			if str, ok := v.(string); ok {

--- a/internal/ctxdata/ctxdata.go
+++ b/internal/ctxdata/ctxdata.go
@@ -6,10 +6,10 @@ import (
 	"github.com/elazarl/goproxy"
 )
 
-type userData map[string]interface{}
+type userData map[string]any
 
 // GetValue retrieves a value from the user data store
-func GetValue(ctx *goproxy.ProxyCtx, key string) (interface{}, bool) {
+func GetValue(ctx *goproxy.ProxyCtx, key string) (any, bool) {
 	ud, ok := ctx.UserData.(userData)
 	if !ok {
 		return nil, false
@@ -42,7 +42,7 @@ func GetBuffer(ctx *goproxy.ProxyCtx, key string) (*bytes.Buffer, bool) {
 }
 
 // SetValue sets a value in the user data store
-func SetValue(ctx *goproxy.ProxyCtx, key string, value interface{}) {
+func SetValue(ctx *goproxy.ProxyCtx, key string, value any) {
 	var ud userData
 	ud, ok := ctx.UserData.(userData)
 	if !ok {

--- a/internal/gitproto/pktline.go
+++ b/internal/gitproto/pktline.go
@@ -27,7 +27,7 @@ const hexDigits = "0123456789abcdef"
 
 // parseHex4 decodes a 4-byte ASCII hex prefix without allocating a string.
 func parseHex4(b []byte) (n int, ok bool) {
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		c := b[i]
 		var v int
 		switch {

--- a/internal/handlers/azdo_api.go
+++ b/internal/handlers/azdo_api.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/elazarl/goproxy"
@@ -90,10 +91,5 @@ func (h *AzureDevOpsAPIHandler) isHandledAzureDevOpsAPIRequest(req *http.Request
 }
 
 func isAzureDevOpsAPIHost(host string) bool {
-	for _, adoHost := range AzureDevOpsAPIHosts {
-		if host == adoHost {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(AzureDevOpsAPIHosts, host)
 }

--- a/internal/handlers/docker_registry.go
+++ b/internal/handlers/docker_registry.go
@@ -146,7 +146,7 @@ func (h *DockerRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.Pr
 
 func defaultGetECRClient(region, keyID, secretKey string) (ecriface.ECRAPI, error) {
 	sess, err := session.NewSession(&aws.Config{
-		Region:      aws.String(region),
+		Region:      new(region),
 		Credentials: credentials.NewStaticCredentials(keyID, secretKey, ""),
 	})
 	if err != nil {

--- a/internal/handlers/docker_registry_test.go
+++ b/internal/handlers/docker_registry_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/aws/aws-sdk-go/service/ecr/ecriface"
 	"github.com/elazarl/goproxy"
@@ -160,7 +159,7 @@ func (c *mockECRClient) GetAuthorizationToken(*ecr.GetAuthorizationTokenInput) (
 	return &ecr.GetAuthorizationTokenOutput{
 		AuthorizationData: []*ecr.AuthorizationData{
 			{
-				AuthorizationToken: aws.String(authToken),
+				AuthorizationToken: new(authToken),
 			},
 		},
 	}, nil

--- a/internal/handlers/git_server_test.go
+++ b/internal/handlers/git_server_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestGitServerHandler_url(t *testing.T) {
-	cred := map[string]interface{}{
+	cred := map[string]any{
 		"type":     "git_source",
 		"url":      "https://github.com",
 		"username": "x-access-token",
@@ -47,7 +47,7 @@ func TestGitServerHandler(t *testing.T) {
 	gheCred := testGitSourceCred("ghe.some-corp.com", "x-access-token", "corp")
 	proximaCred := testGitSourceCred("github.com", "proxima-service-identity", "jwt")
 
-	rubygemsCred := map[string]interface{}{
+	rubygemsCred := map[string]any{
 		"type":     "rubygems",
 		"host":     "github.com",
 		"username": "user",

--- a/internal/handlers/python_index_test.go
+++ b/internal/handlers/python_index_test.go
@@ -383,7 +383,7 @@ func TestPythonIndexDownloadAuthStoreEvictsOldestEntryAtLimit(t *testing.T) {
 		hasBasic: true,
 	}
 
-	for i := 0; i < maxPythonIndexDownloadAuthEntries+1; i++ {
+	for i := range maxPythonIndexDownloadAuthEntries + 1 {
 		prefix, err := url.Parse(fmt.Sprintf(
 			"https://pkgs.example.com/org/project/_packaging/feed-%d/pypi/download/",
 			i,

--- a/internal/handlers/test_helpers.go
+++ b/internal/handlers/test_helpers.go
@@ -72,7 +72,7 @@ func withAccessibleRepos(allowedRepos []string) testGitSourceCredOption {
 }
 
 func testGitSourceCred(host, username, password string, opts ...testGitSourceCredOption) config.Credential {
-	cred := map[string]interface{}{
+	cred := map[string]any{
 		"type":     "git_source",
 		"host":     host,
 		"username": username,
@@ -87,7 +87,7 @@ func testGitSourceCred(host, username, password string, opts ...testGitSourceCre
 }
 
 func testJITAccessCred(credentialType, host, endpoint string) config.Credential {
-	return map[string]interface{}{
+	return map[string]any{
 		"type":            "jit_access",
 		"credential-type": credentialType,
 		"host":            host,

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"slices"
 	"strings"
 
 	"golang.org/x/net/idna"
@@ -58,12 +59,7 @@ func GetHost(r *http.Request) string {
 }
 
 func MethodPermitted(r *http.Request, methods ...string) bool {
-	for _, m := range methods {
-		if r.Method == m {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(methods, r.Method)
 }
 
 func UrlMatchesRequest(req *http.Request, urlStr string, pathMatch bool) bool {

--- a/internal/metrics/collector_client.go
+++ b/internal/metrics/collector_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -18,7 +19,7 @@ type CollectorClient struct {
 	APIEndpoint         string
 	DefaultTags         map[string]string
 	JobID               string
-	MetricsBuffer       []map[string]interface{}
+	MetricsBuffer       []map[string]any
 	BufferMutex         sync.Mutex
 	MaxBufferSize       int
 	FlushTicker         *time.Ticker
@@ -46,7 +47,7 @@ func New(envSettings config.ProxyEnvSettings, apiClient apiclient.ClientInterfac
 		APIEndpoint:         envSettings.APIEndpoint,
 		DefaultTags:         map[string]string{"package_manager": envSettings.PackageManager, "grouped_update": envSettings.GroupedUpdate},
 		JobID:               envSettings.JobID,
-		MetricsBuffer:       make([]map[string]interface{}, 0),
+		MetricsBuffer:       make([]map[string]any, 0),
 		MaxBufferSize:       1000,
 		FlushTicker:         time.NewTicker(1 * time.Minute),
 		estimatedBufferSize: 0,
@@ -99,7 +100,7 @@ func (c *CollectorClient) flushBuffer() {
 		c.BufferMutex.Unlock()
 		return
 	}
-	jsonData, err := json.Marshal(map[string]interface{}{"data": c.MetricsBuffer})
+	jsonData, err := json.Marshal(map[string]any{"data": c.MetricsBuffer})
 	c.MetricsBuffer = c.MetricsBuffer[:0] // Reset buffer
 	c.BufferMutex.Unlock()
 
@@ -127,12 +128,8 @@ func (c *CollectorClient) SendMetric(name string, metricType string, value float
 
 	// Combine tags without altering DefaultTags
 	combinedTags := make(map[string]string)
-	for k, v := range c.DefaultTags {
-		combinedTags[k] = v
-	}
-	for k, v := range additionalTags {
-		combinedTags[k] = v
-	}
+	maps.Copy(combinedTags, c.DefaultTags)
+	maps.Copy(combinedTags, additionalTags)
 
 	c.BufferMutex.Lock()
 	defer c.BufferMutex.Unlock()
@@ -160,7 +157,7 @@ func (c *CollectorClient) SendMetric(name string, metricType string, value float
 	}
 
 	// Create new metric data
-	metricData := map[string]interface{}{
+	metricData := map[string]any{
 		"metric": prefixedName,
 		"type":   metricType,
 		"tags":   combinedTags,

--- a/internal/metrics/collector_client_test.go
+++ b/internal/metrics/collector_client_test.go
@@ -41,7 +41,7 @@ func TestSendIncrementMetric(t *testing.T) {
 	client := createTestClient()
 
 	// Ensure that the buffer is empty at the start of the test
-	client.MetricsBuffer = make([]map[string]interface{}, 0)
+	client.MetricsBuffer = make([]map[string]any, 0)
 
 	// Send an increment metric
 	err := client.SendMetric("http_request_count", "increment", 1, map[string]string{"request_host": "example.com"})
@@ -63,7 +63,7 @@ func TestSendResponseCountMetric(t *testing.T) {
 	client := createTestClient()
 
 	// Ensure that the buffer is empty at the start of the test
-	client.MetricsBuffer = make([]map[string]interface{}, 0)
+	client.MetricsBuffer = make([]map[string]any, 0)
 
 	// Send a response count increment metric
 	err := client.SendMetric("http_response_count", "increment", 1, map[string]string{"response_code": "200", "request_host": "example.com"})
@@ -86,7 +86,7 @@ func TestFlushBuffer(t *testing.T) {
 	client := createTestClient()
 
 	// Ensure that the buffer is empty at the start of the test
-	client.MetricsBuffer = make([]map[string]interface{}, 0)
+	client.MetricsBuffer = make([]map[string]any, 0)
 
 	// Send a metric to the buffer
 	err := client.SendMetric("http_request_count", "increment", 1, map[string]string{"request_host": "example.com"})
@@ -120,7 +120,7 @@ func TestFlushBufferWithEmptyAPIEndpoint(t *testing.T) {
 	// Create a new CollectorClient instance for testing with an empty APIEndpoint
 	client := New(envSettings, &MockAPIClient{})
 
-	client.MetricsBuffer = append(client.MetricsBuffer, map[string]interface{}{
+	client.MetricsBuffer = append(client.MetricsBuffer, map[string]any{
 		"metric": "test_metric",
 		"value":  1,
 		"type":   "increment",

--- a/internal/oidc/oidc_registry_test.go
+++ b/internal/oidc/oidc_registry_test.go
@@ -266,7 +266,7 @@ func TestOIDCRegistry_CredentialForRequestConcurrentRegistration(t *testing.T) {
 	req := httptest.NewRequest("GET", "https://registry.example.com/packages/some-package", nil)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		wg.Add(2)
 		go func(i int) {
 			defer wg.Done()
@@ -278,7 +278,7 @@ func TestOIDCRegistry_CredentialForRequestConcurrentRegistration(t *testing.T) {
 		}(i)
 		go func() {
 			defer wg.Done()
-			for j := 0; j < 100; j++ {
+			for range 100 {
 				_ = r.CredentialForRequest(req)
 			}
 		}()


### PR DESCRIPTION
## Summary

- replace `interface{}` with its exact alias `any`
- replace ordered map-copy loops with `maps.Copy` while preserving additional-tag precedence
- replace direct string membership loops with `slices.Contains`
- use typed `atomic.Int32` operations in the concurrency test
- use integer range loops where bounds are literals or compile-time constants
- use Go 1.26 `new(expr)` in place of equivalent AWS pointer helpers

The two `slices.ContainsFunc` recommendations in the IP-blocking dialer are intentionally excluded. Their behavior is equivalent here, but the explicit loops keep the security-sensitive control flow clearer.

## Validation

- `go test ./...` (745 tests passed)
- `git diff --check`
- reran `modernize`; only the two intentionally excluded dialer findings remain