### PR TITLE
Clarify proxy context naming

### DIFF
--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -100,10 +100,10 @@ func WithTransport(transport *http.Transport) ClientOpt {
 // RequestJITAccess asks the API to create a token with access to the specified repository.
 // If username and password are provided, they are used for basic auth; otherwise the client's
 // default token is used in the Authorization header.
-func (c *Client) RequestJITAccess(ctx *goproxy.ProxyCtx, endpoint string, username string, password string, account string, repo string) (*config.Credential, error) {
+func (c *Client) RequestJITAccess(proxyCtx *goproxy.ProxyCtx, endpoint string, username string, password string, account string, repo string) (*config.Credential, error) {
 	url := c.newURL("%s", endpoint)
 
-	if err := c.jitRateLimit.Acquire(ctx.Req.Context(), 1); err != nil {
+	if err := c.jitRateLimit.Acquire(proxyCtx.Req.Context(), 1); err != nil {
 		return nil, fmt.Errorf("failed to acquire rate limit lock: %w", err)
 	}
 	defer c.jitRateLimit.Release(1)
@@ -111,10 +111,10 @@ func (c *Client) RequestJITAccess(ctx *goproxy.ProxyCtx, endpoint string, userna
 	repoData := map[string]string{"account": account, "repository": repo}
 	payload, err := json.Marshal(repoData)
 	if err != nil {
-		logging.RequestLogf(ctx, "Failed marshalling scope request: %v", err)
+		logging.RequestLogf(proxyCtx, "Failed marshalling scope request: %v", err)
 		return nil, err
 	}
-	req, err := c.newRequest(ctx.Req.Context(), "POST", url, string(payload))
+	req, err := c.newRequest(proxyCtx.Req.Context(), "POST", url, string(payload))
 	if err != nil {
 		return nil, err
 	}
@@ -129,18 +129,18 @@ func (c *Client) RequestJITAccess(ctx *goproxy.ProxyCtx, endpoint string, userna
 	defer rsp.Body.Close()
 	data, err := io.ReadAll(rsp.Body)
 	if err != nil {
-		logging.RequestLogf(ctx, "Failed reading scope response: %v", err)
+		logging.RequestLogf(proxyCtx, "Failed reading scope response: %v", err)
 		return nil, err
 	}
 	if rsp.StatusCode != 200 {
-		logging.RequestLogf(ctx, "Failed to request additional scope: %d %v", rsp.StatusCode, string(data))
+		logging.RequestLogf(proxyCtx, "Failed to request additional scope: %d %v", rsp.StatusCode, string(data))
 		return nil, fmt.Errorf("failed to request additional scope %s", string(data))
 	}
 
 	credentials := &config.Credential{}
 	err = json.Unmarshal(data, &credentials)
 	if err != nil {
-		logging.RequestLogf(ctx, "Failed unmarshalling scope response: %v", err)
+		logging.RequestLogf(proxyCtx, "Failed unmarshalling scope response: %v", err)
 		return nil, err
 	}
 

--- a/internal/apiclient/client_test.go
+++ b/internal/apiclient/client_test.go
@@ -142,10 +142,10 @@ func TestClient_RequestJITAccess(t *testing.T) {
 
 		client := apiclient.New(testServer.URL, jobToken, jobID)
 
-		ctx := &goproxy.ProxyCtx{
+		proxyCtx := &goproxy.ProxyCtx{
 			Req: httptest.NewRequest("GET", "https://example.com", nil),
 		}
-		result, err := client.RequestJITAccess(ctx, jitAccessEndpoint, "", "", accountName, repoName)
+		result, err := client.RequestJITAccess(proxyCtx, jitAccessEndpoint, "", "", accountName, repoName)
 
 		assert.NoError(t, err)
 		assert.Equal(t, &config.Credential{"username": "username", "password": "password"}, result)
@@ -160,10 +160,10 @@ func TestClient_RequestJITAccess(t *testing.T) {
 
 		client := apiclient.New(testServer.URL, jobToken, jobID)
 
-		ctx := &goproxy.ProxyCtx{
+		proxyCtx := &goproxy.ProxyCtx{
 			Req: httptest.NewRequest("GET", "https://example.com", nil),
 		}
-		_, err := client.RequestJITAccess(ctx, "/endpoint", "", "", "this", "repo")
+		_, err := client.RequestJITAccess(proxyCtx, "/endpoint", "", "", "this", "repo")
 
 		assert.Equal(t, "failed to request additional scope Not Implemented", err.Error())
 	})
@@ -206,10 +206,10 @@ func TestClient_RequestJITAccess(t *testing.T) {
 		makeRequest := func(requestNumber string) {
 			defer waitGroup.Done()
 
-			ctx := &goproxy.ProxyCtx{
+			proxyCtx := &goproxy.ProxyCtx{
 				Req: httptest.NewRequest("GET", "https://example.com", nil),
 			}
-			credential, err := client.RequestJITAccess(ctx, "/endpoint", "", "", "account", "repo-"+requestNumber)
+			credential, err := client.RequestJITAccess(proxyCtx, "/endpoint", "", "", "account", "repo-"+requestNumber)
 			require.NoError(t, err)
 			assert.Equal(t, "world-"+requestNumber, (*credential)["hello"], "Response should contain request number")
 		}

--- a/internal/cache/handlers.go
+++ b/internal/cache/handlers.go
@@ -18,8 +18,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
-	"github.com/dependabot/proxy/internal/ctxdata"
 	"github.com/dependabot/proxy/internal/gitproto"
+	"github.com/dependabot/proxy/internal/proxyctx"
 )
 
 // DB contains the metadata of the disk cache
@@ -162,7 +162,7 @@ const (
 )
 
 // OnRequest checks to see if the response is cached, if so responds with the cached data.
-func (d *DB) OnRequest(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (d *DB) OnRequest(r *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if d == nil {
 		// caching disabled
 		return r, nil
@@ -183,14 +183,14 @@ func (d *DB) OnRequest(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *
 	d.calls++
 
 	key := key(r)
-	ctxdata.SetValue(ctx, keyValue, key)
+	proxyctx.SetValue(proxyCtx, keyValue, key)
 	if entry, ok := d.cacheDB[key]; ok {
 		f, err := os.Open(entry.FilePath)
 		if err != nil {
 			logrus.Errorln("failed to open cache file:", err)
 			return r, nil
 		}
-		ctxdata.SetValue(ctx, wasCached, true)
+		proxyctx.SetValue(proxyCtx, wasCached, true)
 		d.cached++
 		resp := &http.Response{}
 		resp.Request = r
@@ -204,7 +204,7 @@ func (d *DB) OnRequest(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *
 }
 
 // OnResponse caches the data in the DB and writes the data to disk.
-func (d *DB) OnResponse(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
+func (d *DB) OnResponse(resp *http.Response, proxyCtx *goproxy.ProxyCtx) *http.Response {
 	if d == nil {
 		// caching disabled
 		return resp
@@ -214,7 +214,7 @@ func (d *DB) OnResponse(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Respon
 		logrus.Warnln("Received nil response")
 		return resp
 	}
-	k, ok := ctxdata.GetValue(ctx, keyValue)
+	k, ok := proxyctx.GetValue(proxyCtx, keyValue)
 	if !ok {
 		// can't calculate key as response body is empty
 		// this happens when the OnRequest decides not to cache
@@ -350,8 +350,8 @@ func (t *teeReader) Close() error {
 }
 
 // WasResponseCached returns true if the response was cached.
-func WasResponseCached(ctx *goproxy.ProxyCtx) bool {
-	cached, ok := ctxdata.GetBool(ctx, wasCached)
+func WasResponseCached(proxyCtx *goproxy.ProxyCtx) bool {
+	cached, ok := proxyctx.GetBool(proxyCtx, wasCached)
 	if !ok {
 		return false
 	}

--- a/internal/cache/handlers_test.go
+++ b/internal/cache/handlers_test.go
@@ -32,13 +32,13 @@ func TestCache_Disabled(t *testing.T) {
 	}
 
 	req := httptest.NewRequest("GET", URL, nil)
-	ctx := &goproxy.ProxyCtx{
+	proxyCtx := &goproxy.ProxyCtx{
 		Req: req,
 	}
 
 	// OnRequest doesn't change the request, so we don't need to check that.
 	// If cached there will be a response.
-	_, resp := cacher.OnRequest(req, ctx)
+	_, resp := cacher.OnRequest(req, proxyCtx)
 	if resp != nil {
 		resp.Body.Close()
 		t.Error("Cache is not disabled")
@@ -47,8 +47,8 @@ func TestCache_Disabled(t *testing.T) {
 	// Verify that we didn't read the body of the response to cache it.
 	originalBody := io.NopCloser(bytes.NewBufferString(""))
 	resp2 := &http.Response{Body: originalBody}
-	ctx.Resp = resp2
-	resp3 := cacher.OnResponse(resp2, ctx)
+	proxyCtx.Resp = resp2
+	resp3 := cacher.OnResponse(resp2, proxyCtx)
 	defer resp3.Body.Close()
 	if originalBody != resp3.Body {
 		t.Error("Cache is not disabled")
@@ -71,11 +71,11 @@ func TestCache(t *testing.T) {
 
 	t.Run("Cache miss", func(t *testing.T) {
 		req := httptest.NewRequest("GET", URL, nil)
-		ctx := &goproxy.ProxyCtx{
+		proxyCtx := &goproxy.ProxyCtx{
 			Req: req,
 		}
 
-		_, resp := cacher.OnRequest(req, ctx)
+		_, resp := cacher.OnRequest(req, proxyCtx)
 		if resp != nil {
 			resp.Body.Close()
 			t.Error("No cache should exist yet")
@@ -87,7 +87,7 @@ func TestCache(t *testing.T) {
 			StatusCode: 200,
 			Body:       io.NopCloser(bytes.NewBufferString(body)),
 		}
-		resp = cacher.OnResponse(resp, ctx)
+		resp = cacher.OnResponse(resp, proxyCtx)
 		result, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if len(cacher.cacheDB) != 1 {
@@ -100,12 +100,12 @@ func TestCache(t *testing.T) {
 
 	t.Run("Cache hit", func(t *testing.T) {
 		req := httptest.NewRequest("GET", URL, nil)
-		ctx := &goproxy.ProxyCtx{
+		proxyCtx := &goproxy.ProxyCtx{
 			Req: req,
 		}
 
 		// a cached response means OnRequest returns a resp
-		_, resp := cacher.OnRequest(req, ctx)
+		_, resp := cacher.OnRequest(req, proxyCtx)
 		if resp == nil {
 			t.Error("Request should be cached")
 		} else {
@@ -117,7 +117,7 @@ func TestCache(t *testing.T) {
 			StatusCode: 200,
 			Body:       io.NopCloser(bytes.NewBufferString("")),
 		}
-		resp = cacher.OnResponse(resp, ctx)
+		resp = cacher.OnResponse(resp, proxyCtx)
 		resp.Body.Close()
 		if len(cacher.cacheDB) != 1 {
 			t.Error("cache should have 1 entry, got", len(cacher.cacheDB))

--- a/internal/handlers/azdo_api.go
+++ b/internal/handlers/azdo_api.go
@@ -56,7 +56,7 @@ func NewAzureDevOpsAPIHandler(creds config.Credentials) *AzureDevOpsAPIHandler {
 }
 
 // HandleRequest adds auth to an Azure DevOps API request
-func (h *AzureDevOpsAPIHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (h *AzureDevOpsAPIHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if !h.isHandledAzureDevOpsAPIRequest(req) {
 		return req, nil
 	}
@@ -71,14 +71,14 @@ func (h *AzureDevOpsAPIHandler) HandleRequest(req *http.Request, ctx *goproxy.Pr
 		return req, nil
 	}
 
-	logging.RequestLogf(ctx, "* authenticating azure devops api request with token for %s", host)
+	logging.RequestLogf(proxyCtx, "* authenticating azure devops api request with token for %s", host)
 	helpers.SetBasicAuthorization(req, creds[0].username, creds[0].password)
 
 	// Azure DevOps requires an api-version to be set for requests. Add it if it is not present.
 	var queryParams = req.URL.Query()
 	if !queryParams.Has("api-version") {
 		queryParams.Add("api-version", "7.2-preview")
-		logging.RequestLogf(ctx, "* added default api-version to query parameters for azure devops api request")
+		logging.RequestLogf(proxyCtx, "* added default api-version to query parameters for azure devops api request")
 	}
 
 	req.URL.RawQuery = queryParams.Encode()

--- a/internal/handlers/cargo_registry.go
+++ b/internal/handlers/cargo_registry.go
@@ -107,13 +107,13 @@ func NewCargoRegistryHandler(credentials config.Credentials) *CargoRegistryHandl
 	return &handler
 }
 
-func (h *CargoRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (h *CargoRegistryHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if req.URL.Scheme != "https" || !helpers.MethodPermitted(req, "GET", "HEAD") {
 		return req, nil
 	}
 
 	// Try OIDC credentials first
-	if h.oidcRegistry.TryAuth(req, ctx) {
+	if h.oidcRegistry.TryAuth(req, proxyCtx) {
 		return req, nil
 	}
 
@@ -127,19 +127,19 @@ func (h *CargoRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.Pro
 			continue
 		}
 
-		authenticateCargoRequest(req, cred, ctx)
+		authenticateCargoRequest(req, cred, proxyCtx)
 		return req, nil
 	}
 
 	return req, nil
 }
 
-func authenticateCargoRequest(req *http.Request, cred cargoRepositoryCredentials, ctx *goproxy.ProxyCtx) {
+func authenticateCargoRequest(req *http.Request, cred cargoRepositoryCredentials, proxyCtx *goproxy.ProxyCtx) {
 	if cred.token != "" {
-		logging.RequestLogf(ctx, "* authenticating cargo registry request (url: %s, host: %s, token auth)", cred.url, cred.host)
+		logging.RequestLogf(proxyCtx, "* authenticating cargo registry request (url: %s, host: %s, token auth)", cred.url, cred.host)
 		helpers.SetRawAuthorization(req, cred.token)
 	} else if cred.password != "" {
-		logging.RequestLogf(ctx, "* authenticating cargo registry request (url: %s, host: %s, basic auth)", cred.url, cred.host)
+		logging.RequestLogf(proxyCtx, "* authenticating cargo registry request (url: %s, host: %s, basic auth)", cred.url, cred.host)
 		helpers.SetBasicAuthorization(req, cred.username, cred.password)
 	}
 }

--- a/internal/handlers/composer.go
+++ b/internal/handlers/composer.go
@@ -59,13 +59,13 @@ func NewComposerHandler(creds config.Credentials) *ComposerHandler {
 }
 
 // HandleRequest adds auth to a composer registry request
-func (h *ComposerHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (h *ComposerHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if req.URL.Scheme != "https" || !helpers.MethodPermitted(req, "GET", "HEAD") {
 		return req, nil
 	}
 
 	// Try OIDC credentials first
-	if h.oidcRegistry.TryAuth(req, ctx) {
+	if h.oidcRegistry.TryAuth(req, proxyCtx) {
 		return req, nil
 	}
 
@@ -80,10 +80,10 @@ func (h *ComposerHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx
 		}
 
 		if cred.token != "" {
-			logging.RequestLogf(ctx, "* authenticating composer registry request (host: %s, token auth)", req.URL.Hostname())
+			logging.RequestLogf(proxyCtx, "* authenticating composer registry request (host: %s, token auth)", req.URL.Hostname())
 			helpers.SetBearerAuthorization(req, cred.token)
 		} else {
-			logging.RequestLogf(ctx, "* authenticating composer registry request (host: %s, basic auth)", req.URL.Hostname())
+			logging.RequestLogf(proxyCtx, "* authenticating composer registry request (host: %s, basic auth)", req.URL.Hostname())
 			helpers.SetBasicAuthorization(req, cred.username, cred.password)
 		}
 

--- a/internal/handlers/dependabot_api.go
+++ b/internal/handlers/dependabot_api.go
@@ -34,7 +34,7 @@ func NewDependabotAPIHandler(envSettings config.ProxyEnvSettings) *DependabotAPI
 }
 
 // HandleRequest adds auth if the request is to the API endpoint
-func (h *DependabotAPIHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (h *DependabotAPIHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if req.URL.Scheme != "https" {
 		return req, nil
 	}

--- a/internal/handlers/docker_registry.go
+++ b/internal/handlers/docker_registry.go
@@ -82,7 +82,7 @@ type dockerRegistryRoundTripper struct {
 	transport http.RoundTripper
 }
 
-func (rt *dockerRegistryRoundTripper) RoundTrip(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Response, error) {
+func (rt *dockerRegistryRoundTripper) RoundTrip(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Response, error) {
 	return rt.transport.RoundTrip(req)
 }
 
@@ -101,13 +101,13 @@ func (rt *dockerRegistryRoundTripper) RoundTrip(req *http.Request, ctx *goproxy.
 // Fortunately, the github.com/stackrox/docker-registry-client/registry library's
 // TokenTransport implements the bulk of this flow for us, so we just need to
 // set the request context's RoundTripper accordingly.
-func (h *DockerRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (h *DockerRegistryHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if req.URL.Scheme != "https" || !helpers.MethodPermitted(req, "GET", "HEAD") {
 		return req, nil
 	}
 
 	// Try OIDC credentials first
-	if h.oidcRegistry.TryAuth(req, ctx) {
+	if h.oidcRegistry.TryAuth(req, proxyCtx) {
 		return req, nil
 	}
 
@@ -121,11 +121,11 @@ func (h *DockerRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.Pr
 			continue
 		}
 
-		if cred.getECRCredentials(req.Context(), ctx) {
-			logging.RequestLogf(ctx, "* authenticating docker ecr request (host: %s)", req.URL.Hostname())
+		if cred.getECRCredentials(req.Context(), proxyCtx) {
+			logging.RequestLogf(proxyCtx, "* authenticating docker ecr request (host: %s)", req.URL.Hostname())
 			helpers.SetBasicAuthorization(req, cred.ecrUsername, cred.ecrPassword)
 		} else {
-			logging.RequestLogf(ctx, "* authenticating docker registry request (host: %s)", req.URL.Hostname())
+			logging.RequestLogf(proxyCtx, "* authenticating docker registry request (host: %s)", req.URL.Hostname())
 			transport := &registry.BasicTransport{
 				Transport: &registry.TokenTransport{
 					Transport: h.transport,
@@ -136,7 +136,7 @@ func (h *DockerRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.Pr
 				Username: cred.getUsername(),
 				Password: cred.getPassword(),
 			}
-			ctx.RoundTripper = &dockerRegistryRoundTripper{
+			proxyCtx.RoundTripper = &dockerRegistryRoundTripper{
 				transport: transport,
 			}
 		}

--- a/internal/handlers/docker_registry.go
+++ b/internal/handlers/docker_registry.go
@@ -100,7 +100,7 @@ func (rt *dockerRegistryRoundTripper) RoundTrip(req *http.Request, proxyCtx *gop
 //
 // Fortunately, the github.com/stackrox/docker-registry-client/registry library's
 // TokenTransport implements the bulk of this flow for us, so we just need to
-// set the request context's RoundTripper accordingly.
+// set the proxy context's RoundTripper accordingly.
 func (h *DockerRegistryHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if req.URL.Scheme != "https" || !helpers.MethodPermitted(req, "GET", "HEAD") {
 		return req, nil

--- a/internal/handlers/docker_registry_test.go
+++ b/internal/handlers/docker_registry_test.go
@@ -72,9 +72,9 @@ func TestDockerRegistryHandler(t *testing.T) {
 
 	// Regular private registry
 	req := httptest.NewRequest("GET", "https://registry.hub.docker.com/my-repo", nil)
-	ctx := &goproxy.ProxyCtx{}
-	_ = handleRequestAndClose(handler, req, ctx)
-	rt, ok := ctx.RoundTripper.(*dockerRegistryRoundTripper)
+	proxyCtx := &goproxy.ProxyCtx{}
+	_ = handleRequestAndClose(handler, req, proxyCtx)
+	rt, ok := proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
 	assert.True(t, ok, "request is assigned a docker registry transport")
 	trans := rt.transport.(*registry.BasicTransport)
 	assert.Equal(t, hubUser, trans.Username, "correct username is set")
@@ -82,9 +82,9 @@ func TestDockerRegistryHandler(t *testing.T) {
 
 	// Registry using URL not registry key
 	req = httptest.NewRequest("GET", "https://registry.hub.docker.com/my-repo", nil)
-	ctx = &goproxy.ProxyCtx{}
-	_ = handleRequestAndClose(handler, req, ctx)
-	rt, ok = ctx.RoundTripper.(*dockerRegistryRoundTripper)
+	proxyCtx = &goproxy.ProxyCtx{}
+	_ = handleRequestAndClose(handler, req, proxyCtx)
+	rt, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
 	assert.True(t, ok, "request is assigned a docker registry transport")
 	trans = rt.transport.(*registry.BasicTransport)
 	assert.Equal(t, hubUser, trans.Username, "correct username is set")
@@ -92,9 +92,9 @@ func TestDockerRegistryHandler(t *testing.T) {
 
 	// Different private registry
 	req = httptest.NewRequest("GET", "https://docker.bigco.com/their-repo", nil)
-	ctx = &goproxy.ProxyCtx{}
-	_ = handleRequestAndClose(handler, req, ctx)
-	rt, ok = ctx.RoundTripper.(*dockerRegistryRoundTripper)
+	proxyCtx = &goproxy.ProxyCtx{}
+	_ = handleRequestAndClose(handler, req, proxyCtx)
+	rt, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
 	assert.True(t, ok, "request is assigned a docker registry transport")
 	trans = rt.transport.(*registry.BasicTransport)
 	assert.Equal(t, bigCoUser, trans.Username, "correct username is set")
@@ -103,9 +103,9 @@ func TestDockerRegistryHandler(t *testing.T) {
 	// ECR
 	req = httptest.NewRequest("GET", "https://123456789123.dkr.ecr.us-east-2.amazonaws.com", nil)
 	req = req.WithContext(context.WithValue(req.Context(), ecrContextKey{}, "ecr-request"))
-	ctx = &goproxy.ProxyCtx{}
-	req = handleRequestAndClose(handler, req, ctx)
-	_, ok = ctx.RoundTripper.(*dockerRegistryRoundTripper)
+	proxyCtx = &goproxy.ProxyCtx{}
+	req = handleRequestAndClose(handler, req, proxyCtx)
+	_, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
 	assert.False(t, ok, "ecr request isn't assigned a docker registry transport")
 	assertHasBasicAuth(t, req, ecrDockerUser, ecrDockerPassword, "has ecr credentials")
 	if assert.NotNil(t, factoryContext, "client factory receives a context") {
@@ -117,46 +117,46 @@ func TestDockerRegistryHandler(t *testing.T) {
 
 	// ECR, again
 	req = httptest.NewRequest("GET", "https://123456789123.dkr.ecr.us-east-2.amazonaws.com", nil)
-	ctx = &goproxy.ProxyCtx{}
-	req = handleRequestAndClose(handler, req, ctx)
-	_, ok = ctx.RoundTripper.(*dockerRegistryRoundTripper)
+	proxyCtx = &goproxy.ProxyCtx{}
+	req = handleRequestAndClose(handler, req, proxyCtx)
+	_, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
 	assert.False(t, ok, "ecr request isn't assigned a docker registry transport")
 	assertHasBasicAuth(t, req, ecrDockerUser, ecrDockerPassword, "has ecr credentials")
 
 	// ECR, mismatch:
 	req = httptest.NewRequest("GET", "https://123456789123.dkr.ecr.us-east-2Xamazonaws.com", nil)
-	ctx = &goproxy.ProxyCtx{}
-	req = handleRequestAndClose(handler, req, ctx)
-	_, ok = ctx.RoundTripper.(*dockerRegistryRoundTripper)
+	proxyCtx = &goproxy.ProxyCtx{}
+	req = handleRequestAndClose(handler, req, proxyCtx)
+	_, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
 	assert.False(t, ok, "ecr request isn't assigned a docker registry transport")
 	assertUnauthenticated(t, req, "leaked ecr credentials")
 
 	// Missing repo subdomain
 	req = httptest.NewRequest("GET", "https://bigco.com/their-repo", nil)
-	ctx = &goproxy.ProxyCtx{}
-	_ = handleRequestAndClose(handler, req, ctx)
-	_, ok = ctx.RoundTripper.(*dockerRegistryRoundTripper)
+	proxyCtx = &goproxy.ProxyCtx{}
+	_ = handleRequestAndClose(handler, req, proxyCtx)
+	_, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
 	assert.False(t, ok, "different subdomain request isn't assigned a docker registry transport")
 
 	// HTTP, not HTTPS
 	req = httptest.NewRequest("GET", "http://docker.bigco.com/their-repo", nil)
-	ctx = &goproxy.ProxyCtx{}
-	_ = handleRequestAndClose(handler, req, ctx)
-	_, ok = ctx.RoundTripper.(*dockerRegistryRoundTripper)
+	proxyCtx = &goproxy.ProxyCtx{}
+	_ = handleRequestAndClose(handler, req, proxyCtx)
+	_, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
 	assert.False(t, ok, "request isn't assigned a docker registry transport")
 
 	// Not a GET request
 	req = httptest.NewRequest("POST", "https://docker.bigco.com/their-repo", nil)
-	ctx = &goproxy.ProxyCtx{}
-	_ = handleRequestAndClose(handler, req, ctx)
-	_, ok = ctx.RoundTripper.(*dockerRegistryRoundTripper)
+	proxyCtx = &goproxy.ProxyCtx{}
+	_ = handleRequestAndClose(handler, req, proxyCtx)
+	_, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
 	assert.False(t, ok, "request isn't assigned a docker registry transport")
 
 	// Nexus, BasicAuth
 	req = httptest.NewRequest("GET", "https://nexus.someco.com/a-repo", nil)
-	ctx = &goproxy.ProxyCtx{}
-	_ = handleRequestAndClose(handler, req, ctx)
-	rt, ok = ctx.RoundTripper.(*dockerRegistryRoundTripper)
+	proxyCtx = &goproxy.ProxyCtx{}
+	_ = handleRequestAndClose(handler, req, proxyCtx)
+	rt, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
 	assert.True(t, ok, "request is assigned a docker registry transport")
 	trans = rt.transport.(*registry.BasicTransport)
 	assert.Equal(t, hubUser, trans.Username, "correct username is set")

--- a/internal/handlers/git_server.go
+++ b/internal/handlers/git_server.go
@@ -11,9 +11,9 @@ import (
 	"github.com/elazarl/goproxy"
 
 	"github.com/dependabot/proxy/internal/config"
-	"github.com/dependabot/proxy/internal/ctxdata"
 	"github.com/dependabot/proxy/internal/helpers"
 	"github.com/dependabot/proxy/internal/logging"
+	"github.com/dependabot/proxy/internal/proxyctx"
 	"github.com/dependabot/proxy/internal/threadsafe"
 )
 
@@ -219,7 +219,7 @@ const (
 )
 
 type ScopeRequester interface {
-	RequestJITAccess(ctx *goproxy.ProxyCtx, endpoint string, username string, password string, account string, repo string) (*config.Credential, error)
+	RequestJITAccess(proxyCtx *goproxy.ProxyCtx, endpoint string, username string, password string, account string, repo string) (*config.Credential, error)
 }
 
 // NewGitServerHandler returns a new GitServerHandler, adding basic auth to
@@ -266,7 +266,7 @@ func (h *GitServerHandler) addJITAccess(cred config.Credential) {
 }
 
 // HandleRequest adds auth to a git server request
-func (h *GitServerHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (h *GitServerHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if req.URL.Scheme != "https" {
 		return req, nil
 	}
@@ -280,11 +280,11 @@ func (h *GitServerHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCt
 		return req, nil
 	}
 
-	logging.RequestLogf(ctx, "* authenticating git server request (host: %s)", helpers.GetHost(req))
+	logging.RequestLogf(proxyCtx, "* authenticating git server request (host: %s)", helpers.GetHost(req))
 	credsToUse := creds[0]
 	helpers.SetBasicAuthorization(req, credsToUse.username, credsToUse.password)
-	if ctx != nil {
-		ctxdata.SetValue(ctx, addedAuthCtxKey, credsToUse)
+	if proxyCtx != nil {
+		proxyctx.SetValue(proxyCtx, addedAuthCtxKey, credsToUse)
 	}
 	if h.isGitUploadPackPost(req) && len(creds) > 1 {
 		// set up cloning of the req body in case we need to retry this request
@@ -297,8 +297,8 @@ func (h *GitServerHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCt
 			req.Body,
 		}
 		req.Body = cloner
-		if ctx != nil {
-			ctxdata.SetValue(ctx, reqBodyCtxKey, &bodyClone)
+		if proxyCtx != nil {
+			proxyctx.SetValue(proxyCtx, reqBodyCtxKey, &bodyClone)
 		}
 	}
 	return req, nil
@@ -368,21 +368,21 @@ func getCredentialsForRequest(r *http.Request, credentials *gitCredentialsMap, e
 // Here, we try to detect those responses, and retry the request without the
 // injected auth. If we get a 401 back, we use that response rather than the
 // original.
-func (h *GitServerHandler) HandleResponse(rsp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
+func (h *GitServerHandler) HandleResponse(rsp *http.Response, proxyCtx *goproxy.ProxyCtx) *http.Response {
 	if rsp == nil {
 		return rsp
 	}
 
 	// Make sure we treat GHES requests like GitHub API requests. Do not retry
-	if h.isGitHubAPIRequest(ctx.Req) {
+	if h.isGitHubAPIRequest(proxyCtx.Req) {
 		return rsp
 	}
 
 	if isPotentialAuthFailure(rsp.StatusCode) {
-		rsp = h.retryWithAlternateAuth(rsp, ctx)
+		rsp = h.retryWithAlternateAuth(rsp, proxyCtx)
 	}
 
-	if authUsed, ok := ctxdata.GetValue(ctx, addedAuthCtxKey); !ok || authUsed == nil {
+	if authUsed, ok := proxyctx.GetValue(proxyCtx, addedAuthCtxKey); !ok || authUsed == nil {
 		return rsp
 	}
 
@@ -391,57 +391,57 @@ func (h *GitServerHandler) HandleResponse(rsp *http.Response, ctx *goproxy.Proxy
 	}
 
 	// Retrying mutatative requests could be risky
-	if ctx.Req.Method != "GET" {
+	if proxyCtx.Req.Method != "GET" {
 		return rsp
 	}
 
-	logging.RequestLogf(ctx, "* auth'd git request returned 404, retrying without auth")
-	newReq := ctx.Req.Clone(ctx.Req.Context())
+	logging.RequestLogf(proxyCtx, "* auth'd git request returned 404, retrying without auth")
+	newReq := proxyCtx.Req.Clone(proxyCtx.Req.Context())
 	newReq.Header.Del("Authorization")
 
-	newRsp, err := ctx.RoundTrip(newReq)
+	newRsp, err := proxyCtx.RoundTrip(newReq)
 	if err != nil {
 		return rsp
 	}
 
 	if newRsp.StatusCode == 401 {
-		logging.RequestLogf(ctx, "* de-auth'd request returned 401, replacing response")
+		logging.RequestLogf(proxyCtx, "* de-auth'd request returned 401, replacing response")
 		helpers.DrainAndClose(rsp)
 		return newRsp
 	}
 
-	logging.RequestLogf(ctx, "* de-auth'd request returned %d, ignoring response", newRsp.StatusCode)
+	logging.RequestLogf(proxyCtx, "* de-auth'd request returned %d, ignoring response", newRsp.StatusCode)
 	helpers.DrainAndClose(newRsp)
 	return rsp
 }
 
-func (h *GitServerHandler) retryWithAlternateAuth(rsp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
+func (h *GitServerHandler) retryWithAlternateAuth(rsp *http.Response, proxyCtx *goproxy.ProxyCtx) *http.Response {
 	// We don't expect mutation requests to the git server except when cloning
-	if ctx.Req.Method != "GET" && !h.isGitUploadPackPost(ctx.Req) {
+	if proxyCtx.Req.Method != "GET" && !h.isGitUploadPackPost(proxyCtx.Req) {
 		return rsp
 	}
 
 	// If this request url was previously tried and failed after trying all auth methods,
 	// then consider it a failure and don't retry again.
-	if _, ok := h.reposAlreadyTried.Get(ctx.Req.URL.String()); ok {
-		logging.RequestLogf(ctx, "* auth'd git request previously retried, won't retry again.")
+	if _, ok := h.reposAlreadyTried.Get(proxyCtx.Req.URL.String()); ok {
+		logging.RequestLogf(proxyCtx, "* auth'd git request previously retried, won't retry again.")
 		return rsp
 	}
 
 	var body []byte
-	bodyClone, _ := ctxdata.GetBuffer(ctx, reqBodyCtxKey)
+	bodyClone, _ := proxyctx.GetBuffer(proxyCtx, reqBodyCtxKey)
 	if bodyClone != nil {
 		body = bodyClone.Bytes()
 	}
 
-	username, password, reqWasAuthed := ctx.Req.BasicAuth()
-	for _, creds := range getCredentialsForRequest(ctx.Req, h.credentials, gitExtractOrgAndRepo) {
+	username, password, reqWasAuthed := proxyCtx.Req.BasicAuth()
+	for _, creds := range getCredentialsForRequest(proxyCtx.Req, h.credentials, gitExtractOrgAndRepo) {
 		// don't retry the request with the same auth that was previously used
 		if reqWasAuthed && creds.username == username && creds.password == password {
 			continue
 		}
 
-		newRsp := h.requestWithAlternativeAuth(ctx, body, creds)
+		newRsp := h.requestWithAlternativeAuth(proxyCtx, body, creds)
 		if newRsp != nil {
 			helpers.DrainAndClose(rsp)
 			return newRsp
@@ -450,9 +450,9 @@ func (h *GitServerHandler) retryWithAlternateAuth(rsp *http.Response, ctx *gopro
 
 	// All known credentials have been tried, try to JIT create access credentials
 	// to access the git repository.
-	jitCreds := h.getJITCredentialsForRequest(ctx)
+	jitCreds := h.getJITCredentialsForRequest(proxyCtx)
 	if jitCreds != nil {
-		newRsp := h.requestWithAlternativeAuth(ctx, body, jitCreds)
+		newRsp := h.requestWithAlternativeAuth(proxyCtx, body, jitCreds)
 		if newRsp != nil {
 			helpers.DrainAndClose(rsp)
 			return newRsp
@@ -461,50 +461,50 @@ func (h *GitServerHandler) retryWithAlternateAuth(rsp *http.Response, ctx *gopro
 
 	// The repo has failed all authentication attempts, mark the url
 	// as failed so we don't retry it again later
-	h.reposAlreadyTried.Set(ctx.Req.URL.String(), struct{}{})
+	h.reposAlreadyTried.Set(proxyCtx.Req.URL.String(), struct{}{})
 	return rsp
 }
 
-func (h *GitServerHandler) requestWithAlternativeAuth(ctx *goproxy.ProxyCtx, body []byte, creds *gitCredentials) *http.Response {
-	logging.RequestLogf(ctx, "* auth'd git request failed authentication, retrying with alternate provided auth")
-	newReq := ctx.Req.Clone(ctx.Req.Context())
+func (h *GitServerHandler) requestWithAlternativeAuth(proxyCtx *goproxy.ProxyCtx, body []byte, creds *gitCredentials) *http.Response {
+	logging.RequestLogf(proxyCtx, "* auth'd git request failed authentication, retrying with alternate provided auth")
+	newReq := proxyCtx.Req.Clone(proxyCtx.Req.Context())
 	if body != nil {
 		newReq.Body = io.NopCloser(bytes.NewReader(body))
 	}
 
 	helpers.SetBasicAuthorization(newReq, creds.username, creds.password)
-	newRsp, err := ctx.RoundTrip(newReq)
+	newRsp, err := proxyCtx.RoundTrip(newReq)
 	if err != nil {
 		return nil
 	}
 
 	if isPotentialAuthFailure(newRsp.StatusCode) {
-		logging.RequestLogf(ctx, "* re-auth'd request returned %d, ignoring response", newRsp.StatusCode)
+		logging.RequestLogf(proxyCtx, "* re-auth'd request returned %d, ignoring response", newRsp.StatusCode)
 		helpers.DrainAndClose(newRsp)
 		return nil
 	}
 
-	logging.RequestLogf(ctx, "* re-auth'd request returned %d, replacing response", newRsp.StatusCode)
+	logging.RequestLogf(proxyCtx, "* re-auth'd request returned %d, replacing response", newRsp.StatusCode)
 	return newRsp
 }
 
-func (h *GitServerHandler) getJITCredentialsForRequest(ctx *goproxy.ProxyCtx) *gitCredentials {
-	host := helpers.GetHost(ctx.Req)
+func (h *GitServerHandler) getJITCredentialsForRequest(proxyCtx *goproxy.ProxyCtx) *gitCredentials {
+	host := helpers.GetHost(proxyCtx.Req)
 	jitConfig := h.jitAccessByHost[host]
 	if jitConfig.endpoint == "" {
 		return nil
 	}
 
-	org, repo, ok := gitExtractOrgAndRepo(ctx.Req.URL.Path)
+	org, repo, ok := gitExtractOrgAndRepo(proxyCtx.Req.URL.Path)
 	if !ok {
 		return nil
 	}
 
-	logging.RequestLogf(ctx, "* requesting JIT access for git server request")
+	logging.RequestLogf(proxyCtx, "* requesting JIT access for git server request")
 	if h.client == nil {
 		return nil
 	}
-	credential, err := h.client.RequestJITAccess(ctx, jitConfig.endpoint, jitConfig.username, jitConfig.password, org, repo)
+	credential, err := h.client.RequestJITAccess(proxyCtx, jitConfig.endpoint, jitConfig.username, jitConfig.password, org, repo)
 	if credential == nil || err != nil {
 		return nil
 	}

--- a/internal/handlers/git_server_test.go
+++ b/internal/handlers/git_server_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/dependabot/proxy/internal/apiclient"
 	"github.com/dependabot/proxy/internal/config"
-	"github.com/dependabot/proxy/internal/ctxdata"
+	"github.com/dependabot/proxy/internal/proxyctx"
 )
 
 func TestGitServerHandler_url(t *testing.T) {
@@ -208,22 +208,22 @@ func TestGitServerHandler404Retry(t *testing.T) {
 		t.Errorf("parsing url: %v", err)
 	}
 
-	roundTripper := goproxy.RoundTripperFunc(func(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Response, error) {
+	roundTripper := goproxy.RoundTripperFunc(func(r *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Response, error) {
 		assert.Equal(t, "", r.Header.Get("Authorization"), "auth should be removed")
 		return &http.Response{StatusCode: 401, Body: io.NopCloser(strings.NewReader(""))}, nil
 	})
 	req := &http.Request{Method: "GET", URL: url, Header: http.Header{}}
 	req.SetBasicAuth("user", "pass")
-	ctx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
+	proxyCtx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
 
-	newRsp := handler.HandleResponse(rsp, ctx)
+	newRsp := handler.HandleResponse(rsp, proxyCtx)
 	assert.Equal(t, 404, newRsp.StatusCode, "no retry without addedAuthCtxKey")
 
-	ctxdata.SetValue(ctx, addedAuthCtxKey, &gitCredentials{username: "x-access-token", password: "v1.token"})
+	proxyctx.SetValue(proxyCtx, addedAuthCtxKey, &gitCredentials{username: "x-access-token", password: "v1.token"})
 	if newRsp.Body != nil {
 		newRsp.Body.Close()
 	}
-	newRsp = handler.HandleResponse(rsp, ctx)
+	newRsp = handler.HandleResponse(rsp, proxyCtx)
 	if newRsp != nil && newRsp.Body != nil {
 		defer newRsp.Body.Close()
 	}
@@ -242,17 +242,17 @@ func TestGitServerHandlerNoRetry(t *testing.T) {
 	})
 	req := httptest.NewRequest("GET", url, nil)
 	req.SetBasicAuth("x-access-token", "v1.token")
-	ctx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
+	proxyCtx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
 
-	newRsp := handler.HandleResponse(rsp, ctx)
+	newRsp := handler.HandleResponse(rsp, proxyCtx)
 	assert.Equal(t, 404, newRsp.StatusCode, "")
 
 	// Ensure we _don't_ retry
-	ctxdata.SetValue(ctx, addedAuthCtxKey, &gitCredentials{username: "x-access-token", password: "v1.token"})
+	proxyctx.SetValue(proxyCtx, addedAuthCtxKey, &gitCredentials{username: "x-access-token", password: "v1.token"})
 	if newRsp.Body != nil {
 		newRsp.Body.Close()
 	}
-	newRsp = handler.HandleResponse(rsp, ctx)
+	newRsp = handler.HandleResponse(rsp, proxyCtx)
 	if newRsp != nil && newRsp.Body != nil {
 		defer newRsp.Body.Close()
 	}
@@ -325,7 +325,7 @@ func TestGitServerHandler_TokenFallback(t *testing.T) {
 			handler := NewGitServerHandler(credentials, nil)
 
 			var capturedTokens []string
-			roundTripper := goproxy.RoundTripperFunc(func(r *http.Request, c *goproxy.ProxyCtx) (*http.Response, error) {
+			roundTripper := goproxy.RoundTripperFunc(func(r *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Response, error) {
 				_, token, _ := r.BasicAuth()
 				capturedTokens = append(capturedTokens, token)
 				if token == tt.authToken {
@@ -336,11 +336,11 @@ func TestGitServerHandler_TokenFallback(t *testing.T) {
 
 			req, err := http.NewRequestWithContext(context.Background(), "GET", "https://github.com/github/dependabot-action/info/refs?service=git-upload-pack", nil)
 			require.NoError(t, err, "failed to create request")
-			ctx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
+			proxyCtx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
 			rsp := &http.Response{StatusCode: tt.respCode, Body: io.NopCloser(strings.NewReader("hello"))}
 
-			_ = handleRequestAndClose(handler, req, ctx)
-			newRsp := handler.HandleResponse(rsp, ctx)
+			_ = handleRequestAndClose(handler, req, proxyCtx)
+			newRsp := handler.HandleResponse(rsp, proxyCtx)
 			defer newRsp.Body.Close()
 			assert.Equal(t, tt.expectRespCode, newRsp.StatusCode, "expected status code")
 			assert.Equal(t, tt.expectTokens, capturedTokens, "attempted tokens")
@@ -409,7 +409,7 @@ func TestGitServerHandler_TokenFallbackWithPost(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var capturedTokens []string
-			roundTripper := goproxy.RoundTripperFunc(func(r *http.Request, c *goproxy.ProxyCtx) (*http.Response, error) {
+			roundTripper := goproxy.RoundTripperFunc(func(r *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Response, error) {
 				body, err := io.ReadAll(r.Body)
 				require.NoError(t, err, "failed to read req body")
 				assert.Equal(t, "test body", string(body), "request body mismatch")
@@ -425,17 +425,17 @@ func TestGitServerHandler_TokenFallbackWithPost(t *testing.T) {
 
 			req, err := http.NewRequestWithContext(context.Background(), "POST", tt.url, io.NopCloser(strings.NewReader("test body")))
 			require.NoError(t, err, "failed to create request")
-			ctx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
+			proxyCtx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
 			rsp := &http.Response{StatusCode: tt.respCode, Body: io.NopCloser(strings.NewReader(""))}
 
-			req = handleRequestAndClose(handler, req, ctx)
+			req = handleRequestAndClose(handler, req, proxyCtx)
 			// trigger cloning body
-			rtResp, err := roundTripper(req, ctx)
+			rtResp, err := roundTripper(req, proxyCtx)
 			if rtResp != nil && rtResp.Body != nil {
 				rtResp.Body.Close()
 			}
 			require.NoError(t, err, "first request err")
-			newRsp := handler.HandleResponse(rsp, ctx)
+			newRsp := handler.HandleResponse(rsp, proxyCtx)
 			defer newRsp.Body.Close()
 			assert.Equal(t, tt.expectRespCode, newRsp.StatusCode, "expected status code")
 			assert.Equal(t, tt.expectTokens, capturedTokens, "attempted tokens")
@@ -452,9 +452,9 @@ func TestGitServerHandler_NoCloneWithSingleCredPost(t *testing.T) {
 
 	req, err := http.NewRequestWithContext(context.Background(), "POST", "https://github.com/github/dependabot-action/git-upload-pack", io.NopCloser(strings.NewReader("test body")))
 	require.NoError(t, err, "failed to create request")
-	ctx := &goproxy.ProxyCtx{Req: req}
-	_ = handleRequestAndClose(handler, req, ctx)
-	_, found := ctxdata.GetBuffer(ctx, reqBodyCtxKey)
+	proxyCtx := &goproxy.ProxyCtx{Req: req}
+	_ = handleRequestAndClose(handler, req, proxyCtx)
+	_, found := proxyctx.GetBuffer(proxyCtx, reqBodyCtxKey)
 
 	assert.False(t, found, "expect clone buffer not present")
 }
@@ -485,17 +485,17 @@ func TestGitServerHandler_RepositoryScopedCredentials(t *testing.T) {
 	for name, url := range tests {
 		t.Run(name, func(t *testing.T) {
 			var capturedTokens []string
-			roundTripper := goproxy.RoundTripperFunc(func(r *http.Request, c *goproxy.ProxyCtx) (*http.Response, error) {
+			roundTripper := goproxy.RoundTripperFunc(func(r *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Response, error) {
 				_, token, _ := r.BasicAuth()
 				capturedTokens = append(capturedTokens, token)
 				return &http.Response{StatusCode: 401, Body: io.NopCloser(strings.NewReader(""))}, nil
 			})
 
 			req := httptest.NewRequest("GET", url, nil)
-			ctx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
+			proxyCtx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
 			rsp := &http.Response{StatusCode: 401, Body: io.NopCloser(strings.NewReader(""))}
 
-			newRsp := handler.HandleResponse(rsp, ctx)
+			newRsp := handler.HandleResponse(rsp, proxyCtx)
 			defer newRsp.Body.Close()
 			assert.Equal(t, []string{
 				otherGitHubCred.GetString("password"),
@@ -513,7 +513,7 @@ type TestScopeRequester struct {
 
 const jitToken = "newToken"
 
-func (t *TestScopeRequester) RequestJITAccess(ctx *goproxy.ProxyCtx, endpoint string, username string, password string, account string, repo string) (*config.Credential, error) {
+func (t *TestScopeRequester) RequestJITAccess(proxyCtx *goproxy.ProxyCtx, endpoint string, username string, password string, account string, repo string) (*config.Credential, error) {
 	t.receivedRequest = true
 
 	return &config.Credential{
@@ -547,7 +547,7 @@ func TestGitServerHandler_RequestJITAccess(t *testing.T) {
 				t.Errorf("parsing url: %v", err)
 			}
 
-			roundTripper := goproxy.RoundTripperFunc(func(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Response, error) {
+			roundTripper := goproxy.RoundTripperFunc(func(r *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Response, error) {
 				_, pass, ok := r.BasicAuth()
 				if !ok {
 					return &http.Response{StatusCode: 401, Body: io.NopCloser(strings.NewReader(""))}, nil
@@ -559,10 +559,10 @@ func TestGitServerHandler_RequestJITAccess(t *testing.T) {
 			})
 			req := &http.Request{Method: "GET", URL: url, Header: http.Header{}}
 			req.SetBasicAuth("user", "pass")
-			ctx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
+			proxyCtx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
 
-			ctxdata.SetValue(ctx, addedAuthCtxKey, &gitCredentials{username: "x-access-token", password: "v1.token"})
-			newRsp := handler.HandleResponse(rsp, ctx)
+			proxyctx.SetValue(proxyCtx, addedAuthCtxKey, &gitCredentials{username: "x-access-token", password: "v1.token"})
+			newRsp := handler.HandleResponse(rsp, proxyCtx)
 			defer newRsp.Body.Close()
 			assert.Equal(t, test.jitAccessEndpoint != "", testClient.receivedRequest, "request more scope unexpected")
 			if test.jitAccessEndpoint != "" {
@@ -648,7 +648,7 @@ func TestJITEndpointUsesExplicitAuthWhenProvided(t *testing.T) {
 	require.NoError(t, err)
 
 	// RoundTripper delegates to http.DefaultTransport so retries go through httpmock
-	roundTripper := goproxy.RoundTripperFunc(func(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Response, error) {
+	roundTripper := goproxy.RoundTripperFunc(func(r *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Response, error) {
 		return http.DefaultTransport.RoundTrip(r)
 	})
 	proxyCtx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}

--- a/internal/handlers/github_api.go
+++ b/internal/handlers/github_api.go
@@ -10,9 +10,9 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/dependabot/proxy/internal/config"
-	"github.com/dependabot/proxy/internal/ctxdata"
 	"github.com/dependabot/proxy/internal/helpers"
 	"github.com/dependabot/proxy/internal/logging"
+	"github.com/dependabot/proxy/internal/proxyctx"
 )
 
 // GitHubAPIHandler handles requests destined for the GitHub API, adding auth
@@ -51,7 +51,7 @@ func NewGitHubAPIHandler(creds config.Credentials) *GitHubAPIHandler {
 }
 
 // HandleRequest adds auth to a GitHub API request
-func (h *GitHubAPIHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (h *GitHubAPIHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if !h.isHandledGitHubAPIRequest(req) {
 		return req, nil
 	}
@@ -66,59 +66,59 @@ func (h *GitHubAPIHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCt
 	}
 
 	if creds[0].username == reservedProximaIdentity {
-		logging.RequestLogf(ctx, "* accessing github api with alternate identity %s", host)
+		logging.RequestLogf(proxyCtx, "* accessing github api with alternate identity %s", host)
 		req.Header.Set("X-GitHub-PSI-JWT", creds[0].password)
 	} else {
-		logging.RequestLogf(ctx, "* authenticating github api request with token for %s", host)
+		logging.RequestLogf(proxyCtx, "* authenticating github api request with token for %s", host)
 		req.Header.Set("Authorization", "token "+creds[0].password)
 	}
-	if ctx != nil {
-		ctxdata.SetValue(ctx, ghAPIAddedAuthCtxKey, true)
+	if proxyCtx != nil {
+		proxyctx.SetValue(proxyCtx, ghAPIAddedAuthCtxKey, true)
 	}
 	return req, nil
 }
 
 // HandleResponse handles retrying failed auth responses with alternate credentials
 // when there are multiple tokens configured for the github api.
-func (h *GitHubAPIHandler) HandleResponse(rsp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
+func (h *GitHubAPIHandler) HandleResponse(rsp *http.Response, proxyCtx *goproxy.ProxyCtx) *http.Response {
 	if rsp == nil {
 		return rsp
 	}
-	if addedAuth, ok := ctxdata.GetBool(ctx, ghAPIAddedAuthCtxKey); !ok || !addedAuth {
+	if addedAuth, ok := proxyctx.GetBool(proxyCtx, ghAPIAddedAuthCtxKey); !ok || !addedAuth {
 		return rsp
 	}
-	if !h.isHandledGitHubAPIRequest(ctx.Req) {
+	if !h.isHandledGitHubAPIRequest(proxyCtx.Req) {
 		return rsp
 	}
 	if !isPotentialAuthFailure(rsp.StatusCode) {
 		return rsp
 	}
 
-	username, password, reqWasAuthed := ctx.Req.BasicAuth()
-	for _, creds := range getCredentialsForRequest(ctx.Req, h.credentials, gitHubAPIExtractOrgAndRepo) {
+	username, password, reqWasAuthed := proxyCtx.Req.BasicAuth()
+	for _, creds := range getCredentialsForRequest(proxyCtx.Req, h.credentials, gitHubAPIExtractOrgAndRepo) {
 		// don't retry the request with the same auth that was previously used
 		if reqWasAuthed && creds.username == username && creds.password == password {
 			continue
 		}
 
-		newReq := ctx.Req.Clone(ctx.Req.Context())
+		newReq := proxyCtx.Req.Clone(proxyCtx.Req.Context())
 		if creds.username == reservedProximaIdentity {
-			logging.RequestLogf(ctx, "* auth'd github api request failed authentication, retrying with alternate identity")
+			logging.RequestLogf(proxyCtx, "* auth'd github api request failed authentication, retrying with alternate identity")
 			newReq.Header.Set("X-GitHub-PSI-JWT", creds.password)
 		} else {
-			logging.RequestLogf(ctx, "* auth'd github api request failed authentication, retrying with alternate provided auth")
+			logging.RequestLogf(proxyCtx, "* auth'd github api request failed authentication, retrying with alternate provided auth")
 			newReq.Header.Set("Authorization", "token "+creds.password)
 		}
-		newRsp, err := ctx.RoundTrip(newReq)
+		newRsp, err := proxyCtx.RoundTrip(newReq)
 		if err != nil {
 			return rsp
 		}
 		if !isPotentialAuthFailure(newRsp.StatusCode) {
 			helpers.DrainAndClose(rsp)
-			logging.RequestLogf(ctx, "* re-auth'd request returned %d, replacing response", newRsp.StatusCode)
+			logging.RequestLogf(proxyCtx, "* re-auth'd request returned %d, replacing response", newRsp.StatusCode)
 			return newRsp
 		}
-		logging.RequestLogf(ctx, "* re-auth'd request returned %d, ignoring response", newRsp.StatusCode)
+		logging.RequestLogf(proxyCtx, "* re-auth'd request returned %d, ignoring response", newRsp.StatusCode)
 		helpers.DrainAndClose(newRsp)
 	}
 	return rsp

--- a/internal/handlers/github_api_test.go
+++ b/internal/handlers/github_api_test.go
@@ -391,7 +391,7 @@ func TestGitHubAPIHandler_TokenFallback(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var capturedTokens []string
-			roundTripper := goproxy.RoundTripperFunc(func(r *http.Request, c *goproxy.ProxyCtx) (*http.Response, error) {
+			roundTripper := goproxy.RoundTripperFunc(func(r *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Response, error) {
 				token := strings.TrimPrefix(r.Header.Get("Authorization"), "token ")
 				capturedTokens = append(capturedTokens, token)
 				if token == tt.authToken {
@@ -402,13 +402,13 @@ func TestGitHubAPIHandler_TokenFallback(t *testing.T) {
 
 			parsedUrl, _ := url.Parse(tt.url)
 			req := &http.Request{Method: "GET", URL: parsedUrl, Header: http.Header{}}
-			ctx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
+			proxyCtx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
 			rsp := &http.Response{StatusCode: tt.respCode, Body: io.NopCloser(strings.NewReader("hello"))}
 
 			// tag request with auth so we'll handle retries
-			_ = handleRequestAndClose(handler, req, ctx)
+			_ = handleRequestAndClose(handler, req, proxyCtx)
 
-			newRsp := handler.HandleResponse(rsp, ctx)
+			newRsp := handler.HandleResponse(rsp, proxyCtx)
 			defer newRsp.Body.Close()
 			assert.Equal(t, tt.expectRespCode, newRsp.StatusCode, "expected status code")
 			assert.Equal(t, tt.expectTokens, capturedTokens, "attempted tokens")
@@ -497,7 +497,7 @@ func TestGitHubAPIHandler_TokenFallback_In_Proxima(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var capturedTokens []string
-			roundTripper := goproxy.RoundTripperFunc(func(r *http.Request, c *goproxy.ProxyCtx) (*http.Response, error) {
+			roundTripper := goproxy.RoundTripperFunc(func(r *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Response, error) {
 				token := strings.TrimPrefix(r.Header.Get("Authorization"), "token ")
 				capturedTokens = append(capturedTokens, token)
 				if token == tt.authToken {
@@ -507,13 +507,13 @@ func TestGitHubAPIHandler_TokenFallback_In_Proxima(t *testing.T) {
 			})
 
 			req := &http.Request{Method: "GET", URL: url, Header: http.Header{}}
-			ctx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
+			proxyCtx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
 			rsp := &http.Response{StatusCode: tt.respCode, Body: io.NopCloser(strings.NewReader("hello"))}
 
 			// tag request with auth so we'll handle retries
-			_ = handleRequestAndClose(handler, req, ctx)
+			_ = handleRequestAndClose(handler, req, proxyCtx)
 
-			newRsp := handler.HandleResponse(rsp, ctx)
+			newRsp := handler.HandleResponse(rsp, proxyCtx)
 			defer newRsp.Body.Close()
 			assert.Equal(t, tt.expectRespCode, newRsp.StatusCode, "expected status code")
 			assert.Equal(t, tt.expectTokens, capturedTokens, "attempted tokens")

--- a/internal/handlers/goproxy_server_handler.go
+++ b/internal/handlers/goproxy_server_handler.go
@@ -60,13 +60,13 @@ func NewGoProxyServerHandler(creds config.Credentials) *GoProxyServerHandler {
 }
 
 // HandleRequest adds auth to a goproxy request
-func (h *GoProxyServerHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (h *GoProxyServerHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if !helpers.MethodPermitted(req, "GET", "HEAD") {
 		return req, nil
 	}
 
 	// Try OIDC credentials first
-	if h.oidcRegistry.TryAuth(req, ctx) {
+	if h.oidcRegistry.TryAuth(req, proxyCtx) {
 		return req, nil
 	}
 
@@ -76,7 +76,7 @@ func (h *GoProxyServerHandler) HandleRequest(req *http.Request, ctx *goproxy.Pro
 			continue
 		}
 
-		logging.RequestLogf(ctx, "* authenticating goproxy request (host: %s)", req.URL.Hostname())
+		logging.RequestLogf(proxyCtx, "* authenticating goproxy request (host: %s)", req.URL.Hostname())
 		helpers.SetBasicAuthorization(req, cred.username, cred.password)
 
 		return req, nil

--- a/internal/handlers/helm_registry.go
+++ b/internal/handlers/helm_registry.go
@@ -57,13 +57,13 @@ func NewHelmRegistryHandler(creds config.Credentials) *HelmRegistryHandler {
 }
 
 // HandleRequest adds auth to a helm registry request
-func (h *HelmRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (h *HelmRegistryHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if req.URL.Scheme != "https" || !helpers.MethodPermitted(req, "GET", "HEAD") {
 		return req, nil
 	}
 
 	// Try OIDC credentials first
-	if h.oidcRegistry.TryAuth(req, ctx) {
+	if h.oidcRegistry.TryAuth(req, proxyCtx) {
 		return req, nil
 	}
 
@@ -73,7 +73,7 @@ func (h *HelmRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.Prox
 			continue
 		}
 
-		logging.RequestLogf(ctx, "* authenticating helm registry request (host: %s)", req.URL.Hostname())
+		logging.RequestLogf(proxyCtx, "* authenticating helm registry request (host: %s)", req.URL.Hostname())
 		helpers.SetBasicAuthorization(req, cred.username, cred.password)
 
 		return req, nil

--- a/internal/handlers/hex_organization.go
+++ b/internal/handlers/hex_organization.go
@@ -51,7 +51,7 @@ func NewHexOrganizationHandler(creds config.Credentials) *HexOrganizationHandler
 }
 
 // HandleRequest adds auth to an npm registry request
-func (h *HexOrganizationHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (h *HexOrganizationHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if req.URL.Scheme != "https" || !helpers.MethodPermitted(req, "GET", "HEAD") || !helpers.CheckHost(req, "repo.hex.pm") {
 		return req, nil
 	}
@@ -68,7 +68,7 @@ func (h *HexOrganizationHandler) HandleRequest(req *http.Request, ctx *goproxy.P
 	reqOrg := pathParts[1]
 	for _, cred := range h.credentials {
 		if cred.organization == reqOrg {
-			logging.RequestLogf(ctx, "* authenticating hex request (org: %s)", reqOrg)
+			logging.RequestLogf(proxyCtx, "* authenticating hex request (org: %s)", reqOrg)
 			helpers.SetRawAuthorization(req, cred.key)
 			return req, nil
 		}

--- a/internal/handlers/hex_repository.go
+++ b/internal/handlers/hex_repository.go
@@ -64,13 +64,13 @@ func NewHexRepositoryHandler(creds config.Credentials) *HexRepositoryHandler {
 }
 
 // HandleRequest adds auth to a registry request
-func (h *HexRepositoryHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (h *HexRepositoryHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if req.URL.Scheme != "https" || !helpers.MethodPermitted(req, "GET", "HEAD") {
 		return req, nil
 	}
 
 	// Try OIDC credentials first
-	if h.oidcRegistry.TryAuth(req, ctx) {
+	if h.oidcRegistry.TryAuth(req, proxyCtx) {
 		return req, nil
 	}
 
@@ -84,7 +84,7 @@ func (h *HexRepositoryHandler) HandleRequest(req *http.Request, ctx *goproxy.Pro
 			continue
 		}
 
-		logging.RequestLogf(ctx, "* authenticating hex repository request (host: %s)", req.URL.Hostname())
+		logging.RequestLogf(proxyCtx, "* authenticating hex repository request (host: %s)", req.URL.Hostname())
 		helpers.SetRawAuthorization(req, cred.authKey)
 
 		return req, nil

--- a/internal/handlers/maven_repository.go
+++ b/internal/handlers/maven_repository.go
@@ -62,13 +62,13 @@ func NewMavenRepositoryHandler(creds config.Credentials) *MavenRepositoryHandler
 }
 
 // HandleRequest adds auth to a maven repository request
-func (h *MavenRepositoryHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (h *MavenRepositoryHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if (req.URL.Scheme != "http" && req.URL.Scheme != "https") || !helpers.MethodPermitted(req, "GET", "HEAD") {
 		return req, nil
 	}
 
 	// Try OIDC credentials first
-	if h.oidcRegistry.TryAuth(req, ctx) {
+	if h.oidcRegistry.TryAuth(req, proxyCtx) {
 		return req, nil
 	}
 
@@ -78,7 +78,7 @@ func (h *MavenRepositoryHandler) HandleRequest(req *http.Request, ctx *goproxy.P
 			continue
 		}
 
-		logging.RequestLogf(ctx, "* authenticating maven repository request (host: %s)", req.URL.Hostname())
+		logging.RequestLogf(proxyCtx, "* authenticating maven repository request (host: %s)", req.URL.Hostname())
 		helpers.SetBasicAuthorization(req, cred.username, cred.password)
 
 		return req, nil

--- a/internal/handlers/npm_registry.go
+++ b/internal/handlers/npm_registry.go
@@ -60,7 +60,7 @@ func NewNPMRegistryHandler(creds config.Credentials) *NPMRegistryHandler {
 }
 
 // HandleRequest adds auth to an npm registry request
-func (h *NPMRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (h *NPMRegistryHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if req.URL.Scheme != "https" || !helpers.MethodPermitted(req, "GET", "HEAD") {
 		return req, nil
 	}
@@ -72,7 +72,7 @@ func (h *NPMRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.Proxy
 	}
 
 	// Try OIDC credentials first
-	if h.oidcRegistry.TryAuth(req, ctx) {
+	if h.oidcRegistry.TryAuth(req, proxyCtx) {
 		return req, nil
 	}
 
@@ -115,10 +115,10 @@ func (h *NPMRegistryHandler) HandleRequest(req *http.Request, ctx *goproxy.Proxy
 
 		username, password, found := strings.Cut(cred.token, ":")
 		if found {
-			logging.RequestLogf(ctx, "* authenticating npm registry request (host: %s, basic auth)", reqHost)
+			logging.RequestLogf(proxyCtx, "* authenticating npm registry request (host: %s, basic auth)", reqHost)
 			helpers.SetBasicAuthorization(req, username, password)
 		} else {
-			logging.RequestLogf(ctx, "* authenticating npm registry request (host: %s, token auth)", reqHost)
+			logging.RequestLogf(proxyCtx, "* authenticating npm registry request (host: %s, token auth)", reqHost)
 			helpers.SetBearerAuthorization(req, cred.token)
 		}
 		return req, nil

--- a/internal/handlers/nuget_feed.go
+++ b/internal/handlers/nuget_feed.go
@@ -268,13 +268,13 @@ func handleV3Response(body io.Reader, url string) (v3Urls []string) {
 }
 
 // HandleRequest adds auth to an nuget feed request
-func (h *NugetFeedHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (h *NugetFeedHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if (req.URL.Scheme != "http" && req.URL.Scheme != "https") || !helpers.MethodPermitted(req, "GET", "HEAD") {
 		return req, nil
 	}
 
 	// Try OIDC credentials first (HTTPS only to avoid leaking tokens over plaintext)
-	if req.URL.Scheme == "https" && h.oidcRegistry.TryAuth(req, ctx) {
+	if req.URL.Scheme == "https" && h.oidcRegistry.TryAuth(req, proxyCtx) {
 		return req, nil
 	}
 
@@ -284,7 +284,7 @@ func (h *NugetFeedHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCt
 			continue
 		}
 
-		authenticateNugetRequest(req, cred, ctx)
+		authenticateNugetRequest(req, cred, proxyCtx)
 
 		return req, nil
 	}
@@ -292,21 +292,21 @@ func (h *NugetFeedHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCt
 	return req, nil
 }
 
-func authenticateNugetRequest(req *http.Request, cred nugetFeedCredentials, ctx *goproxy.ProxyCtx) {
+func authenticateNugetRequest(req *http.Request, cred nugetFeedCredentials, proxyCtx *goproxy.ProxyCtx) {
 	token := cred.token
 	if token == "" && cred.password != "" {
 		token = cred.username + ":" + cred.password
 	}
 	username, password, found := strings.Cut(token, ":")
 	if found {
-		logging.RequestLogf(ctx, "* authenticating nuget feed request (host: %s, basic auth)", req.URL.Hostname())
+		logging.RequestLogf(proxyCtx, "* authenticating nuget feed request (host: %s, basic auth)", req.URL.Hostname())
 		helpers.SetBasicAuthorization(req, username, password)
 	} else if token != "" {
 		if shouldTreatTokenAsPassword(req.URL) {
-			logging.RequestLogf(ctx, "* authenticating nuget feed request (host: %s, basic auth for Azure DevOps)", req.URL.Hostname())
+			logging.RequestLogf(proxyCtx, "* authenticating nuget feed request (host: %s, basic auth for Azure DevOps)", req.URL.Hostname())
 			helpers.SetBasicAuthorization(req, "", token)
 		} else {
-			logging.RequestLogf(ctx, "* authenticating nuget feed request (host: %s, bearer auth)", req.URL.Hostname())
+			logging.RequestLogf(proxyCtx, "* authenticating nuget feed request (host: %s, bearer auth)", req.URL.Hostname())
 			helpers.SetBearerAuthorization(req, token)
 		}
 	}

--- a/internal/handlers/oidc_handling_test.go
+++ b/internal/handlers/oidc_handling_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 type oidcHandler interface {
-	HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response)
+	HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response)
 }
 
 type mockHttpRequest struct {
@@ -1767,13 +1767,13 @@ func TestPythonOIDCAuthenticatesDiscoveredDownloadPrefix(t *testing.T) {
 		},
 	})
 
-	ctx := &goproxy.ProxyCtx{}
+	proxyCtx := &goproxy.ProxyCtx{}
 	indexReq := httptest.NewRequest(
 		"GET",
 		"https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
 		nil,
 	)
-	indexReq = handleRequestAndClose(handler, indexReq, ctx)
+	indexReq = handleRequestAndClose(handler, indexReq, proxyCtx)
 	assertHasTokenAuth(t, indexReq, "Bearer", "__oidc_token__", "simple index request should use OIDC token")
 
 	indexResp := &http.Response{
@@ -1789,7 +1789,7 @@ func TestPythonOIDCAuthenticatesDiscoveredDownloadPrefix(t *testing.T) {
 			</body></html>
 		`)),
 	}
-	handler.HandleResponse(indexResp, ctx)
+	handler.HandleResponse(indexResp, proxyCtx)
 
 	downloadReq := httptest.NewRequest(
 		"HEAD",

--- a/internal/handlers/opentofu_registry.go
+++ b/internal/handlers/opentofu_registry.go
@@ -70,13 +70,13 @@ func NewOpenTofuRegistryHandler(credentials config.Credentials) *OpenTofuRegistr
 	return &handler
 }
 
-func (h *OpenTofuRegistryHandler) HandleRequest(request *http.Request, context *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (h *OpenTofuRegistryHandler) HandleRequest(request *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if request.URL.Scheme != "https" || !helpers.MethodPermitted(request, "GET", "HEAD") {
 		return request, nil
 	}
 
 	// Try OIDC credentials first
-	if h.oidcRegistry.TryAuth(request, context) {
+	if h.oidcRegistry.TryAuth(request, proxyCtx) {
 		return request, nil
 	}
 
@@ -86,7 +86,7 @@ func (h *OpenTofuRegistryHandler) HandleRequest(request *http.Request, context *
 			continue
 		}
 
-		logging.RequestLogf(context, "* authenticating opentofu registry request (host: %s)", request.URL.Hostname())
+		logging.RequestLogf(proxyCtx, "* authenticating opentofu registry request (host: %s)", request.URL.Hostname())
 		request.Header.Set("Authorization", "Bearer "+cred.token)
 		return request, nil
 	}

--- a/internal/handlers/pub_repository.go
+++ b/internal/handlers/pub_repository.go
@@ -66,13 +66,13 @@ func NewPubRepositoryHandler(credentials config.Credentials) *PubRepositoryHandl
 	return &handler
 }
 
-func (h *PubRepositoryHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (h *PubRepositoryHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if req.URL.Scheme != "https" || !helpers.MethodPermitted(req, "GET", "HEAD") {
 		return req, nil
 	}
 
 	// Try OIDC credentials first
-	if h.oidcRegistry.TryAuth(req, ctx) {
+	if h.oidcRegistry.TryAuth(req, proxyCtx) {
 		return req, nil
 	}
 
@@ -82,7 +82,7 @@ func (h *PubRepositoryHandler) HandleRequest(req *http.Request, ctx *goproxy.Pro
 			continue
 		}
 
-		logging.RequestLogf(ctx, "* authenticating pub repository request (url: %s)", cred.url)
+		logging.RequestLogf(proxyCtx, "* authenticating pub repository request (url: %s)", cred.url)
 		helpers.SetBearerAuthorization(req, cred.token)
 
 		return req, nil

--- a/internal/handlers/python_index.go
+++ b/internal/handlers/python_index.go
@@ -82,18 +82,18 @@ func NewPythonIndexHandler(creds config.Credentials) *PythonIndexHandler {
 }
 
 // HandleRequest adds auth to a python index request
-func (h *PythonIndexHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (h *PythonIndexHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if req.URL.Scheme != "https" || !helpers.MethodPermitted(req, "GET", "HEAD") {
 		return req, nil
 	}
 
-	if auth, ok := h.downloadAuth.authFor(req); ok && h.applyAuth(req, ctx, auth) {
+	if auth, ok := h.downloadAuth.authFor(req); ok && h.applyAuth(req, proxyCtx, auth) {
 		return req, nil
 	}
 
 	// Try OIDC credentials first
-	if credential := h.oidcRegistry.CredentialForRequest(req); h.oidcRegistry.TryAuthCredential(req, ctx, credential) {
-		rememberPythonIndexResponseAuth(ctx, req.URL, pythonIndexAuth{oidc: credential})
+	if credential := h.oidcRegistry.CredentialForRequest(req); h.oidcRegistry.TryAuthCredential(req, proxyCtx, credential) {
+		rememberPythonIndexResponseAuth(proxyCtx, req.URL, pythonIndexAuth{oidc: credential})
 		return req, nil
 	}
 
@@ -105,8 +105,8 @@ func (h *PythonIndexHandler) HandleRequest(req *http.Request, ctx *goproxy.Proxy
 		}
 
 		auth := pythonIndexAuth{basic: cred, hasBasic: true}
-		h.applyAuth(req, ctx, auth)
-		rememberPythonIndexResponseAuth(ctx, req.URL, auth)
+		h.applyAuth(req, proxyCtx, auth)
+		rememberPythonIndexResponseAuth(proxyCtx, req.URL, auth)
 
 		return req, nil
 	}

--- a/internal/handlers/python_index_auth.go
+++ b/internal/handlers/python_index_auth.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/elazarl/goproxy"
 
-	"github.com/dependabot/proxy/internal/ctxdata"
 	"github.com/dependabot/proxy/internal/helpers"
 	"github.com/dependabot/proxy/internal/logging"
 	"github.com/dependabot/proxy/internal/oidc"
+	"github.com/dependabot/proxy/internal/proxyctx"
 )
 
 const (
@@ -97,15 +97,15 @@ func (s *pythonIndexDownloadAuthStore) authFor(req *http.Request) (pythonIndexAu
 	return matched, true
 }
 
-func (h *PythonIndexHandler) applyAuth(req *http.Request, ctx *goproxy.ProxyCtx, auth pythonIndexAuth) bool {
+func (h *PythonIndexHandler) applyAuth(req *http.Request, proxyCtx *goproxy.ProxyCtx, auth pythonIndexAuth) bool {
 	if auth.oidc != nil {
-		return h.oidcRegistry.TryAuthCredential(req, ctx, auth.oidc)
+		return h.oidcRegistry.TryAuthCredential(req, proxyCtx, auth.oidc)
 	}
 	if !auth.hasBasic {
 		return false
 	}
 
-	logging.RequestLogf(ctx, "* authenticating python index request (host: %s)", req.URL.Hostname())
+	logging.RequestLogf(proxyCtx, "* authenticating python index request (host: %s)", req.URL.Hostname())
 
 	token := auth.basic.token
 	if token == "" && auth.basic.password != "" {
@@ -118,23 +118,23 @@ func (h *PythonIndexHandler) applyAuth(req *http.Request, ctx *goproxy.ProxyCtx,
 	return true
 }
 
-func rememberPythonIndexResponseAuth(ctx *goproxy.ProxyCtx, baseURL *url.URL, auth pythonIndexAuth) {
-	if ctx == nil || baseURL == nil {
+func rememberPythonIndexResponseAuth(proxyCtx *goproxy.ProxyCtx, baseURL *url.URL, auth pythonIndexAuth) {
+	if proxyCtx == nil || baseURL == nil {
 		return
 	}
 
-	ctxdata.SetValue(ctx, pythonIndexResponseAuthKey, pythonIndexResponseAuth{
+	proxyctx.SetValue(proxyCtx, pythonIndexResponseAuthKey, pythonIndexResponseAuth{
 		auth:    auth,
 		baseURL: *baseURL,
 	})
 }
 
-func pythonIndexResponseAuthFromContext(ctx *goproxy.ProxyCtx) (pythonIndexResponseAuth, bool) {
-	if ctx == nil {
+func pythonIndexResponseAuthFromContext(proxyCtx *goproxy.ProxyCtx) (pythonIndexResponseAuth, bool) {
+	if proxyCtx == nil {
 		return pythonIndexResponseAuth{}, false
 	}
 
-	value, ok := ctxdata.GetValue(ctx, pythonIndexResponseAuthKey)
+	value, ok := proxyctx.GetValue(proxyCtx, pythonIndexResponseAuthKey)
 	if !ok {
 		return pythonIndexResponseAuth{}, false
 	}

--- a/internal/handlers/python_index_download_prefixes.go
+++ b/internal/handlers/python_index_download_prefixes.go
@@ -28,12 +28,12 @@ type simpleJSONResponse struct {
 // authenticated Simple API responses. Some indexes return file URLs outside
 // the configured /simple/ prefix (for example, /pypi/download/...), so the
 // request matcher needs one extra prefix learned from the registry response.
-func (h *PythonIndexHandler) HandleResponse(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
+func (h *PythonIndexHandler) HandleResponse(resp *http.Response, proxyCtx *goproxy.ProxyCtx) *http.Response {
 	if resp == nil || resp.Body == nil || resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return resp
 	}
 
-	responseAuth, ok := pythonIndexResponseAuthFromContext(ctx)
+	responseAuth, ok := pythonIndexResponseAuthFromContext(proxyCtx)
 	if !ok || !isPythonSimpleAPIPath(responseAuth.baseURL.Path) || !isSimpleAPIResponse(resp) {
 		return resp
 	}

--- a/internal/handlers/python_index_test.go
+++ b/internal/handlers/python_index_test.go
@@ -121,13 +121,13 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromHTML(t *test
 		},
 	})
 
-	ctx := &goproxy.ProxyCtx{}
+	proxyCtx := &goproxy.ProxyCtx{}
 	indexReq := httptest.NewRequest(
 		"GET",
 		"https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
 		nil,
 	)
-	indexReq = handleRequestAndClose(handler, indexReq, ctx)
+	indexReq = handleRequestAndClose(handler, indexReq, proxyCtx)
 	assertHasBasicAuth(t, indexReq, "user", "pass", "simple index request")
 
 	indexResp := &http.Response{
@@ -146,7 +146,7 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromHTML(t *test
 			</body></html>
 		`)),
 	}
-	handler.HandleResponse(indexResp, ctx)
+	handler.HandleResponse(indexResp, proxyCtx)
 
 	downloadReq := httptest.NewRequest(
 		"HEAD",
@@ -182,13 +182,13 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromJSON(t *test
 		},
 	})
 
-	ctx := &goproxy.ProxyCtx{}
+	proxyCtx := &goproxy.ProxyCtx{}
 	indexReq := httptest.NewRequest(
 		"GET",
 		"https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
 		nil,
 	)
-	indexReq = handleRequestAndClose(handler, indexReq, ctx)
+	indexReq = handleRequestAndClose(handler, indexReq, proxyCtx)
 	assertHasBasicAuth(t, indexReq, "user", "pass", "simple index request")
 
 	indexResp := &http.Response{
@@ -204,7 +204,7 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromJSON(t *test
 			]
 		}`)),
 	}
-	handler.HandleResponse(indexResp, ctx)
+	handler.HandleResponse(indexResp, proxyCtx)
 
 	downloadReq := httptest.NewRequest(
 		"GET",
@@ -261,9 +261,9 @@ func TestPythonIndexHandlerSkipsDiscoveryForAuthenticatedNonSimpleResponse(t *te
 		},
 	})
 
-	ctx := &goproxy.ProxyCtx{}
+	proxyCtx := &goproxy.ProxyCtx{}
 	nonSimpleReq := httptest.NewRequest("GET", "https://pkgs.example.com/org/project/status", nil)
-	nonSimpleReq = handleRequestAndClose(handler, nonSimpleReq, ctx)
+	nonSimpleReq = handleRequestAndClose(handler, nonSimpleReq, proxyCtx)
 	assertHasBasicAuth(t, nonSimpleReq, "user", "pass", "path-scoped python index request")
 
 	indexResp := &http.Response{
@@ -277,7 +277,7 @@ func TestPythonIndexHandlerSkipsDiscoveryForAuthenticatedNonSimpleResponse(t *te
 			</a>
 		`)),
 	}
-	handler.HandleResponse(indexResp, ctx)
+	handler.HandleResponse(indexResp, proxyCtx)
 
 	downloadReq := httptest.NewRequest(
 		"GET",
@@ -297,13 +297,13 @@ func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixPort(t *testing.T) {
 		},
 	})
 
-	ctx := &goproxy.ProxyCtx{}
+	proxyCtx := &goproxy.ProxyCtx{}
 	indexReq := httptest.NewRequest(
 		"GET",
 		"https://pkgs.example.com:8443/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
 		nil,
 	)
-	indexReq = handleRequestAndClose(handler, indexReq, ctx)
+	indexReq = handleRequestAndClose(handler, indexReq, proxyCtx)
 	assertHasBasicAuth(t, indexReq, "user", "pass", "simple index request")
 
 	indexResp := &http.Response{
@@ -317,7 +317,7 @@ func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixPort(t *testing.T) {
 			</a>
 		`)),
 	}
-	handler.HandleResponse(indexResp, ctx)
+	handler.HandleResponse(indexResp, proxyCtx)
 
 	downloadReq := httptest.NewRequest(
 		"GET",
@@ -345,13 +345,13 @@ func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixIPv6Host(t *testing.
 		},
 	})
 
-	ctx := &goproxy.ProxyCtx{}
+	proxyCtx := &goproxy.ProxyCtx{}
 	indexReq := httptest.NewRequest(
 		"GET",
 		"https://[2001:db8::1]/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
 		nil,
 	)
-	indexReq = handleRequestAndClose(handler, indexReq, ctx)
+	indexReq = handleRequestAndClose(handler, indexReq, proxyCtx)
 	assertHasBasicAuth(t, indexReq, "user", "pass", "simple index request")
 
 	indexResp := &http.Response{
@@ -365,7 +365,7 @@ func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixIPv6Host(t *testing.
 			</a>
 		`)),
 	}
-	handler.HandleResponse(indexResp, ctx)
+	handler.HandleResponse(indexResp, proxyCtx)
 
 	downloadReq := httptest.NewRequest(
 		"GET",
@@ -432,13 +432,13 @@ func TestPythonIndexHandlerSkipsDiscoveryForLargeSimpleResponse(t *testing.T) {
 		},
 	})
 
-	ctx := &goproxy.ProxyCtx{}
+	proxyCtx := &goproxy.ProxyCtx{}
 	indexReq := httptest.NewRequest(
 		"GET",
 		"https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
 		nil,
 	)
-	indexReq = handleRequestAndClose(handler, indexReq, ctx)
+	indexReq = handleRequestAndClose(handler, indexReq, proxyCtx)
 	assertHasBasicAuth(t, indexReq, "user", "pass", "simple index request")
 
 	downloadURL := "https://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl"
@@ -450,7 +450,7 @@ func TestPythonIndexHandlerSkipsDiscoveryForLargeSimpleResponse(t *testing.T) {
 		},
 		Body: io.NopCloser(strings.NewReader(responseBody)),
 	}
-	handler.HandleResponse(indexResp, ctx)
+	handler.HandleResponse(indexResp, proxyCtx)
 
 	replayedBody, err := io.ReadAll(indexResp.Body)
 	if err != nil {

--- a/internal/handlers/rubygems_server.go
+++ b/internal/handlers/rubygems_server.go
@@ -56,13 +56,13 @@ func NewRubyGemsServerHandler(creds config.Credentials) *RubyGemsServerHandler {
 }
 
 // HandleRequest adds auth to a rubygems server request
-func (h *RubyGemsServerHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (h *RubyGemsServerHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if req.URL.Scheme != "https" || !helpers.MethodPermitted(req, "GET", "HEAD") {
 		return req, nil
 	}
 
 	// Try OIDC credentials first
-	if h.oidcRegistry.TryAuth(req, ctx) {
+	if h.oidcRegistry.TryAuth(req, proxyCtx) {
 		return req, nil
 	}
 
@@ -76,7 +76,7 @@ func (h *RubyGemsServerHandler) HandleRequest(req *http.Request, ctx *goproxy.Pr
 			continue
 		}
 
-		logging.RequestLogf(ctx, "* authenticating rubygems server request (host: %s)", req.URL.Hostname())
+		logging.RequestLogf(proxyCtx, "* authenticating rubygems server request (host: %s)", req.URL.Hostname())
 
 		// ignore `found` because it's okay for the password to be an empty string
 		username, password, _ := strings.Cut(cred.token, ":")

--- a/internal/handlers/terraform_registry.go
+++ b/internal/handlers/terraform_registry.go
@@ -71,13 +71,13 @@ func NewTerraformRegistryHandler(credentials config.Credentials) *TerraformRegis
 	return &handler
 }
 
-func (h *TerraformRegistryHandler) HandleRequest(request *http.Request, context *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (h *TerraformRegistryHandler) HandleRequest(request *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if request.URL.Scheme != "https" || !helpers.MethodPermitted(request, "GET", "HEAD") {
 		return request, nil
 	}
 
 	// Try OIDC credentials first
-	if h.oidcRegistry.TryAuth(request, context) {
+	if h.oidcRegistry.TryAuth(request, proxyCtx) {
 		return request, nil
 	}
 
@@ -87,7 +87,7 @@ func (h *TerraformRegistryHandler) HandleRequest(request *http.Request, context 
 			continue
 		}
 
-		logging.RequestLogf(context, "* authenticating terraform registry request (host: %s)", request.URL.Hostname())
+		logging.RequestLogf(proxyCtx, "* authenticating terraform registry request (host: %s)", request.URL.Hostname())
 		helpers.SetBearerAuthorization(request, cred.token)
 		return request, nil
 	}

--- a/internal/handlers/test_helpers.go
+++ b/internal/handlers/test_helpers.go
@@ -15,8 +15,8 @@ import (
 // Most handlers return nil responses, but the linter can't prove that.
 func handleRequestAndClose(handler interface {
 	HandleRequest(*http.Request, *goproxy.ProxyCtx) (*http.Request, *http.Response)
-}, req *http.Request, ctx *goproxy.ProxyCtx) *http.Request {
-	req, resp := handler.HandleRequest(req, ctx)
+}, req *http.Request, proxyCtx *goproxy.ProxyCtx) *http.Request {
+	req, resp := handler.HandleRequest(req, proxyCtx)
 	if resp != nil && resp.Body != nil {
 		resp.Body.Close()
 	}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -19,10 +19,10 @@ import (
 // spaces are removed, and the entry is logged with a single trailing newline.
 // If p is given, the logged line is prefixed with a three-digit representation
 // of p.Session.
-func RequestLogf(ctx *goproxy.ProxyCtx, format string, v ...any) {
+func RequestLogf(proxyCtx *goproxy.ProxyCtx, format string, v ...any) {
 	formatted := fmt.Sprintf(format, v...)
 	message := replaceNewLines(formatted, " ")
-	requestLog(ctx, message)
+	requestLog(proxyCtx, message)
 }
 
 // RequestMultilineLogf builds a log entry from format and v according to the
@@ -31,22 +31,22 @@ func RequestLogf(ctx *goproxy.ProxyCtx, format string, v ...any) {
 // entry is truncated to 1024 bytes and it is logged with a single trailing
 // newline. If p is given, the first line logged is prefixed with a three-digit
 // representation of p.Session.
-func RequestMultilineLogf(ctx *goproxy.ProxyCtx, format string, v ...any) {
+func RequestMultilineLogf(proxyCtx *goproxy.ProxyCtx, format string, v ...any) {
 	formatted := fmt.Sprintf(format, v...)
 	message := replaceNewLines(formatted, "\n")
-	requestLog(ctx, message)
+	requestLog(proxyCtx, message)
 }
 
-func requestLog(ctx *goproxy.ProxyCtx, message string) {
+func requestLog(proxyCtx *goproxy.ProxyCtx, message string) {
 	format := "%s"
 	argv := []any{trimSpace(message)}
-	if ctx != nil {
+	if proxyCtx != nil {
 		// Log the request number as a 3-digit number
-		reqId := ctx.Session % 1000
+		reqId := proxyCtx.Session % 1000
 		format = "[%03d] " + format
 		argv = append([]any{reqId}, argv...)
 
-		if cache.WasResponseCached(ctx) {
+		if cache.WasResponseCached(proxyCtx) {
 			format += " (cached)"
 		}
 	}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -17,8 +17,8 @@ import (
 // of fmt.Sprintf and logs it. All sequences of newlines and/or carriage
 // returns in the resulting entry are replaced with a space, any trailing
 // spaces are removed, and the entry is logged with a single trailing newline.
-// If p is given, the logged line is prefixed with a three-digit representation
-// of p.Session.
+// If proxyCtx is given, the logged line is prefixed with a three-digit
+// representation of proxyCtx.Session.
 func RequestLogf(proxyCtx *goproxy.ProxyCtx, format string, v ...any) {
 	formatted := fmt.Sprintf(format, v...)
 	message := replaceNewLines(formatted, " ")
@@ -29,8 +29,8 @@ func RequestLogf(proxyCtx *goproxy.ProxyCtx, format string, v ...any) {
 // semantics of fmt.Sprintf and logs it. If the resulting entry contains
 // newlines and/or carriage returns, they are preserved. The resulting
 // entry is truncated to 1024 bytes and it is logged with a single trailing
-// newline. If p is given, the first line logged is prefixed with a three-digit
-// representation of p.Session.
+// newline. If proxyCtx is given, the first line logged is prefixed with a
+// three-digit representation of proxyCtx.Session.
 func RequestMultilineLogf(proxyCtx *goproxy.ProxyCtx, format string, v ...any) {
 	formatted := fmt.Sprintf(format, v...)
 	message := replaceNewLines(formatted, "\n")

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestRequestLogf(t *testing.T) {
-	p := &goproxy.ProxyCtx{Session: 128}
+	proxyCtx := &goproxy.ProxyCtx{Session: 128}
 
 	testCases := map[string]struct {
 		format   string
@@ -62,7 +62,7 @@ func TestRequestLogf(t *testing.T) {
 			var buf bytes.Buffer
 			log.SetOutput(&buf)
 
-			RequestLogf(p, tc.format, tc.argv...)
+			RequestLogf(proxyCtx, tc.format, tc.argv...)
 
 			actual := buf.String()
 			assert.True(t, strings.HasSuffix(actual, tc.expected))
@@ -71,7 +71,7 @@ func TestRequestLogf(t *testing.T) {
 }
 
 func TestRequestMultilineLogf(t *testing.T) {
-	p := &goproxy.ProxyCtx{Session: 128}
+	proxyCtx := &goproxy.ProxyCtx{Session: 128}
 
 	testCases := map[string]struct {
 		format   string
@@ -121,7 +121,7 @@ func TestRequestMultilineLogf(t *testing.T) {
 			var buf bytes.Buffer
 			log.SetOutput(&buf)
 
-			RequestMultilineLogf(p, tc.format, tc.argv...)
+			RequestMultilineLogf(proxyCtx, tc.format, tc.argv...)
 
 			actual := buf.String()
 			assert.True(t, strings.HasSuffix(actual, tc.expected))

--- a/internal/metrics/handler.go
+++ b/internal/metrics/handler.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/elazarl/goproxy"
 
-	"github.com/dependabot/proxy/internal/ctxdata"
+	"github.com/dependabot/proxy/internal/proxyctx"
 )
 
 const (
@@ -50,30 +50,30 @@ func NewHandler(client Client) *Handler {
 }
 
 // HandleRequest sets up a request for metrics
-func (h *Handler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-	ctxdata.SetValue(ctx, startTimeCtxKey, time.Now())
-	tags := map[string]string{"request_host": h.hostTag(ctx)}
+func (h *Handler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+	proxyctx.SetValue(proxyCtx, startTimeCtxKey, time.Now())
+	tags := map[string]string{"request_host": h.hostTag(proxyCtx)}
 	// For count metrics, the "increment" type is utilized and the passed value of 1 doesn't carry significance for type increment.
 	_ = h.client.SendMetric("http_request_count", "increment", 1, tags)
 	return req, nil
 }
 
 // HandleResponse records metrics for a response
-func (h *Handler) HandleResponse(rsp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
+func (h *Handler) HandleResponse(rsp *http.Response, proxyCtx *goproxy.ProxyCtx) *http.Response {
 	if rsp == nil {
 		return rsp
 	}
 	tags := map[string]string{
 		"response_code": fmt.Sprintf("%d", rsp.StatusCode),
-		"request_host":  h.hostTag(ctx),
+		"request_host":  h.hostTag(proxyCtx),
 	}
 
 	_ = h.client.SendMetric("http_response_count", "increment", 1, tags)
 	return rsp
 }
 
-func (h *Handler) hostTag(ctx *goproxy.ProxyCtx) string {
-	reqHost := ctx.Req.URL.Hostname()
+func (h *Handler) hostTag(proxyCtx *goproxy.ProxyCtx) string {
+	reqHost := proxyCtx.Req.URL.Hostname()
 	for _, host := range metricsHostList {
 		if reqHost == host || strings.HasSuffix(reqHost, "."+host) {
 			return host

--- a/internal/metrics/handler_test.go
+++ b/internal/metrics/handler_test.go
@@ -51,13 +51,13 @@ func TestHandlerMetrics(t *testing.T) {
 		"single request": {
 			generateRequestMetrics: func(h *Handler) {
 				req := httptest.NewRequest("GET", "https://example.com/", nil)
-				ctx := &goproxy.ProxyCtx{Req: req}
-				_, resp := h.HandleRequest(req, ctx)
+				proxyCtx := &goproxy.ProxyCtx{Req: req}
+				_, resp := h.HandleRequest(req, proxyCtx)
 				if resp != nil && resp.Body != nil {
 					resp.Body.Close()
 				}
 				time.Sleep(200 * time.Millisecond)
-				rsp := h.HandleResponse(&http.Response{StatusCode: 201}, ctx)
+				rsp := h.HandleResponse(&http.Response{StatusCode: 201}, proxyCtx)
 				if rsp != nil && rsp.Body != nil {
 					rsp.Body.Close()
 				}
@@ -80,14 +80,14 @@ func TestHandlerMetrics(t *testing.T) {
 		"single request to subdomain api.github.com": {
 			generateRequestMetrics: func(h *Handler) {
 				req := httptest.NewRequest("GET", "https://api.github.com/", nil)
-				ctx := &goproxy.ProxyCtx{Req: req}
-				_, resp := h.HandleRequest(req, ctx)
+				proxyCtx := &goproxy.ProxyCtx{Req: req}
+				_, resp := h.HandleRequest(req, proxyCtx)
 				if resp != nil && resp.Body != nil {
 					resp.Body.Close()
 				}
 				// Simulate a delay to test the timing metric
 				time.Sleep(200 * time.Millisecond)
-				rsp := h.HandleResponse(&http.Response{StatusCode: 200}, ctx)
+				rsp := h.HandleResponse(&http.Response{StatusCode: 200}, proxyCtx)
 				if rsp != nil && rsp.Body != nil {
 					rsp.Body.Close()
 				}
@@ -109,12 +109,12 @@ func TestHandlerMetrics(t *testing.T) {
 			generateRequestMetrics: func(h *Handler) {
 				for _, host := range []string{"https://thing.pypi.org/", "https://pypi.org/"} {
 					req := httptest.NewRequest("GET", host, nil)
-					ctx := &goproxy.ProxyCtx{Req: req}
-					_, resp := h.HandleRequest(req, ctx)
+					proxyCtx := &goproxy.ProxyCtx{Req: req}
+					_, resp := h.HandleRequest(req, proxyCtx)
 					if resp != nil && resp.Body != nil {
 						resp.Body.Close()
 					}
-					rsp := h.HandleResponse(&http.Response{StatusCode: 200}, ctx)
+					rsp := h.HandleResponse(&http.Response{StatusCode: 200}, proxyCtx)
 					if rsp != nil && rsp.Body != nil {
 						rsp.Body.Close()
 					}
@@ -137,12 +137,12 @@ func TestHandlerMetrics(t *testing.T) {
 			generateRequestMetrics: func(h *Handler) {
 				for _, host := range []string{"https://foo.github.com/", "https://github.com/"} {
 					req := httptest.NewRequest("GET", host, nil)
-					ctx := &goproxy.ProxyCtx{Req: req}
-					_, resp := h.HandleRequest(req, ctx)
+					proxyCtx := &goproxy.ProxyCtx{Req: req}
+					_, resp := h.HandleRequest(req, proxyCtx)
 					if resp != nil && resp.Body != nil {
 						resp.Body.Close()
 					}
-					rsp := h.HandleResponse(&http.Response{StatusCode: 200}, ctx)
+					rsp := h.HandleResponse(&http.Response{StatusCode: 200}, proxyCtx)
 					if rsp != nil && rsp.Body != nil {
 						rsp.Body.Close()
 					}
@@ -165,12 +165,12 @@ func TestHandlerMetrics(t *testing.T) {
 			generateRequestMetrics: func(h *Handler) {
 				for _, host := range []string{"https://foo.pkg.github.com/", "https://bar.pkg.github.com/"} {
 					req := httptest.NewRequest("GET", host, nil)
-					ctx := &goproxy.ProxyCtx{Req: req}
-					_, resp := h.HandleRequest(req, ctx)
+					proxyCtx := &goproxy.ProxyCtx{Req: req}
+					_, resp := h.HandleRequest(req, proxyCtx)
 					if resp != nil && resp.Body != nil {
 						resp.Body.Close()
 					}
-					rsp := h.HandleResponse(&http.Response{StatusCode: 200}, ctx)
+					rsp := h.HandleResponse(&http.Response{StatusCode: 200}, proxyCtx)
 					if rsp != nil && rsp.Body != nil {
 						rsp.Body.Close()
 					}

--- a/internal/oidc/oidc_registry.go
+++ b/internal/oidc/oidc_registry.go
@@ -96,8 +96,8 @@ func (r *OIDCRegistry) RegisterURL(url string, cred *OIDCCredential, registryTyp
 //     prefix of the request path
 //
 // Returns true if the request was authenticated, false otherwise.
-func (r *OIDCRegistry) TryAuth(req *http.Request, ctx *goproxy.ProxyCtx) bool {
-	return r.TryAuthCredential(req, ctx, r.CredentialForRequest(req))
+func (r *OIDCRegistry) TryAuth(req *http.Request, proxyCtx *goproxy.ProxyCtx) bool {
+	return r.TryAuthCredential(req, proxyCtx, r.CredentialForRequest(req))
 }
 
 // CredentialForRequest returns the most specific OIDC credential matching the
@@ -141,7 +141,7 @@ func (r *OIDCRegistry) CredentialForRequest(req *http.Request) *OIDCCredential {
 // TryAuthCredential authenticates a request with a known OIDC credential.
 // Handlers use this when they have their own safe matching rule but want the
 // provider-specific OIDC header behavior to stay centralized here.
-func (r *OIDCRegistry) TryAuthCredential(req *http.Request, ctx *goproxy.ProxyCtx, credential *OIDCCredential) bool {
+func (r *OIDCRegistry) TryAuthCredential(req *http.Request, proxyCtx *goproxy.ProxyCtx, credential *OIDCCredential) bool {
 	if credential == nil {
 		return false
 	}
@@ -149,24 +149,24 @@ func (r *OIDCRegistry) TryAuthCredential(req *http.Request, ctx *goproxy.ProxyCt
 	host := strings.ToLower(helpers.GetHost(req))
 	token, err := GetOrRefreshOIDCToken(credential, req.Context())
 	if err != nil {
-		logging.RequestLogf(ctx, "* failed to get %s token via OIDC for %s: %v", credential.Provider(), host, err)
+		logging.RequestLogf(proxyCtx, "* failed to get %s token via OIDC for %s: %v", credential.Provider(), host, err)
 		return false
 	}
 
 	switch credential.parameters.(type) {
 	case *CloudsmithOIDCParameters:
-		logging.RequestLogf(ctx, "* authenticating request with OIDC API key (host: %s)", host)
+		logging.RequestLogf(proxyCtx, "* authenticating request with OIDC API key (host: %s)", host)
 		helpers.ReplaceAuthorization(req, "X-Api-Key", token)
 	case *GCPOIDCParameters:
 		if strings.HasSuffix(host, "-docker.pkg.dev") {
-			logging.RequestLogf(ctx, "* authenticating request with OIDC oauth2accesstoken (host: %s)", host)
+			logging.RequestLogf(proxyCtx, "* authenticating request with OIDC oauth2accesstoken (host: %s)", host)
 			helpers.SetBasicAuthorization(req, "oauth2accesstoken", token)
 		} else {
-			logging.RequestLogf(ctx, "* authenticating request with OIDC token (host: %s)", host)
+			logging.RequestLogf(proxyCtx, "* authenticating request with OIDC token (host: %s)", host)
 			helpers.SetBearerAuthorization(req, token)
 		}
 	default:
-		logging.RequestLogf(ctx, "* authenticating request with OIDC token (host: %s)", host)
+		logging.RequestLogf(proxyCtx, "* authenticating request with OIDC token (host: %s)", host)
 		helpers.SetBearerAuthorization(req, token)
 	}
 

--- a/internal/proxyctx/userdata.go
+++ b/internal/proxyctx/userdata.go
@@ -1,4 +1,4 @@
-package ctxdata
+package proxyctx
 
 import (
 	"bytes"
@@ -9,8 +9,8 @@ import (
 type userData map[string]any
 
 // GetValue retrieves a value from the user data store
-func GetValue(ctx *goproxy.ProxyCtx, key string) (any, bool) {
-	ud, ok := ctx.UserData.(userData)
+func GetValue(proxyCtx *goproxy.ProxyCtx, key string) (any, bool) {
+	ud, ok := proxyCtx.UserData.(userData)
 	if !ok {
 		return nil, false
 	}
@@ -20,8 +20,8 @@ func GetValue(ctx *goproxy.ProxyCtx, key string) (any, bool) {
 }
 
 // GetBool retrieves a boolean value from the user data store
-func GetBool(ctx *goproxy.ProxyCtx, key string) (bool, bool) {
-	val, ok := GetValue(ctx, key)
+func GetBool(proxyCtx *goproxy.ProxyCtx, key string) (bool, bool) {
+	val, ok := GetValue(proxyCtx, key)
 	if !ok {
 		return false, false
 	}
@@ -31,8 +31,8 @@ func GetBool(ctx *goproxy.ProxyCtx, key string) (bool, bool) {
 }
 
 // GetBuffer retrieves a bytes.Buffer value from the user data store
-func GetBuffer(ctx *goproxy.ProxyCtx, key string) (*bytes.Buffer, bool) {
-	val, ok := GetValue(ctx, key)
+func GetBuffer(proxyCtx *goproxy.ProxyCtx, key string) (*bytes.Buffer, bool) {
+	val, ok := GetValue(proxyCtx, key)
 	if !ok {
 		return nil, false
 	}
@@ -42,12 +42,12 @@ func GetBuffer(ctx *goproxy.ProxyCtx, key string) (*bytes.Buffer, bool) {
 }
 
 // SetValue sets a value in the user data store
-func SetValue(ctx *goproxy.ProxyCtx, key string, value any) {
+func SetValue(proxyCtx *goproxy.ProxyCtx, key string, value any) {
 	var ud userData
-	ud, ok := ctx.UserData.(userData)
+	ud, ok := proxyCtx.UserData.(userData)
 	if !ok {
 		ud = userData{}
-		ctx.UserData = ud
+		proxyCtx.UserData = ud
 	}
 
 	ud[key] = value

--- a/logging.go
+++ b/logging.go
@@ -23,31 +23,31 @@ func NewRequestLogger() *requestLogger {
 	return &requestLogger{}
 }
 
-func (l *requestLogger) logRequest(req *http.Request, p *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-	logging.RequestLogf(p, "%s %s", req.Method, urlWithoutCredentials(req.URL))
+func (l *requestLogger) logRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+	logging.RequestLogf(proxyCtx, "%s %s", req.Method, urlWithoutCredentials(req.URL))
 	return req, nil
 }
 
-func (l *requestLogger) logResponse(rsp *http.Response, p *goproxy.ProxyCtx) *http.Response {
+func (l *requestLogger) logResponse(rsp *http.Response, proxyCtx *goproxy.ProxyCtx) *http.Response {
 	if rsp == nil {
-		logging.RequestLogf(p, "No response from server")
+		logging.RequestLogf(proxyCtx, "No response from server")
 		return rsp
 	}
 
 	if rsp.Request == nil {
-		logging.RequestLogf(p, "%d (No request on response object)", rsp.StatusCode)
+		logging.RequestLogf(proxyCtx, "%d (No request on response object)", rsp.StatusCode)
 		return rsp
 	}
 
 	if rsp.Request.URL == nil {
-		logging.RequestLogf(p, "%d (No URL on response.Request object)", rsp.StatusCode)
+		logging.RequestLogf(proxyCtx, "%d (No URL on response.Request object)", rsp.StatusCode)
 		return rsp
 	}
 
-	logging.RequestLogf(p, "%d %s", rsp.StatusCode, urlWithoutCredentials(rsp.Request.URL))
+	logging.RequestLogf(proxyCtx, "%d %s", rsp.StatusCode, urlWithoutCredentials(rsp.Request.URL))
 
 	if _, logForStatusCode := responseBodyLoggingStatusCodes[rsp.StatusCode]; logForStatusCode {
-		logResponseBody(rsp, p, 1024)
+		logResponseBody(rsp, proxyCtx, 1024)
 	}
 
 	return rsp
@@ -99,12 +99,12 @@ func newMultiReadCloser(rcs ...io.ReadCloser) io.ReadCloser {
 	}
 }
 
-func logResponseBody(rsp *http.Response, p *goproxy.ProxyCtx, maxBytes int) {
+func logResponseBody(rsp *http.Response, proxyCtx *goproxy.ProxyCtx, maxBytes int) {
 	if maxBytes > 0 {
 		bodyBytes := make([]byte, maxBytes)
 		n, err := io.ReadFull(rsp.Body, bodyBytes)
 		if n > 0 {
-			logging.RequestMultilineLogf(p, "Remote response: %s", string(bodyBytes[:n]))
+			logging.RequestMultilineLogf(proxyCtx, "Remote response: %s", string(bodyBytes[:n]))
 
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
 				rsp.Body.Close()
@@ -117,7 +117,7 @@ func logResponseBody(rsp *http.Response, p *goproxy.ProxyCtx, maxBytes int) {
 		bodyBytes, _ := io.ReadAll(rsp.Body)
 		rsp.Body.Close()
 
-		logging.RequestMultilineLogf(p, "Remote response: %s", string(bodyBytes))
+		logging.RequestMultilineLogf(proxyCtx, "Remote response: %s", string(bodyBytes))
 		rsp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 	}
 }

--- a/logging_test.go
+++ b/logging_test.go
@@ -77,7 +77,7 @@ func TestURLWithoutCredentials(t *testing.T) {
 func TestRequestLogger(t *testing.T) {
 	req, err := http.NewRequestWithContext(context.Background(), "GET", "https://github.com:443", nil)
 	require.NoError(t, err)
-	p := &goproxy.ProxyCtx{Session: 128}
+	proxyCtx := &goproxy.ProxyCtx{Session: 128}
 
 	cases := map[string]struct {
 		setup     func(l *requestLogger)
@@ -90,7 +90,7 @@ func TestRequestLogger(t *testing.T) {
 		},
 		"request": {
 			setup: func(l *requestLogger) {
-				_, resp := l.logRequest(req, p)
+				_, resp := l.logRequest(req, proxyCtx)
 				if resp != nil && resp.Body != nil {
 					resp.Body.Close()
 				}
@@ -99,11 +99,11 @@ func TestRequestLogger(t *testing.T) {
 		},
 		"requests": {
 			setup: func(l *requestLogger) {
-				_, resp := l.logRequest(req, p)
+				_, resp := l.logRequest(req, proxyCtx)
 				if resp != nil && resp.Body != nil {
 					resp.Body.Close()
 				}
-				_, resp = l.logRequest(req, p)
+				_, resp = l.logRequest(req, proxyCtx)
 				if resp != nil && resp.Body != nil {
 					resp.Body.Close()
 				}
@@ -131,7 +131,7 @@ func TestRequestLogger(t *testing.T) {
 }`,
 					)),
 				}
-				resp = l.logResponse(resp, p)
+				resp = l.logResponse(resp, proxyCtx)
 				if resp != nil && resp.Body != nil {
 					resp.Body.Close()
 				}

--- a/proxy.go
+++ b/proxy.go
@@ -150,14 +150,14 @@ func newProxy(envSettings config.ProxyEnvSettings, cfg *config.Config, blockedIp
 	}
 }
 
-func handleForbidden(rsp *http.Response, p *goproxy.ProxyCtx) *http.Response {
-	if errors.Is(p.Error, dialer.ErrForbiddenRequest) {
-		return goproxy.NewResponse(p.Req, goproxy.ContentTypeText, http.StatusForbidden, "")
+func handleForbidden(rsp *http.Response, proxyCtx *goproxy.ProxyCtx) *http.Response {
+	if errors.Is(proxyCtx.Error, dialer.ErrForbiddenRequest) {
+		return goproxy.NewResponse(proxyCtx.Req, goproxy.ContentTypeText, http.StatusForbidden, "")
 	}
 	return rsp
 }
 
-func normaliseHost(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func normaliseHost(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	req.URL.Host = strings.ToLower(req.URL.Host)
 	req.Host = strings.ToLower(req.Host)
 	return req, nil
@@ -167,7 +167,7 @@ const (
 	metadataAPIHost = "metadata.google.internal"
 )
 
-func blockMetadataAPIHosts(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func blockMetadataAPIHosts(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if req.Host == metadataAPIHost || req.URL.Host == metadataAPIHost {
 		return req, goproxy.NewResponse(req, goproxy.ContentTypeText, http.StatusForbidden, "Forbidden")
 	}


### PR DESCRIPTION
## What are you trying to accomplish?

Reserve the idiomatic `ctx` name for `context.Context` values and make goproxy's distinct request state explicit throughout the proxy.

In Go, readers conventionally understand `ctx` to mean a `context.Context` carrying cancellation, deadlines, and request-scoped values. A `*goproxy.ProxyCtx` instead holds mutable proxy state such as `UserData`, the request, response, and round tripper. Calling both values `ctx` makes signatures and call sites harder to scan, especially in code such as the ECR authentication flow where both context types appear together. Naming the latter `proxyCtx` lets readers identify its role without repeatedly checking its type and makes it clearer which context should be passed to standard Go APIs.

This renames first-party `*goproxy.ProxyCtx` parameters and variables to `proxyCtx`. It also moves the user-data helpers from `internal/ctxdata/ctxdata.go` to `internal/proxyctx/userdata.go`, so calls such as `proxyctx.SetValue(proxyCtx, ...)` clearly describe which context they operate on.

Follow-up to the discussion in #195: https://github.com/dependabot/proxy/pull/195#discussion_r3753864077

## Anything you want to highlight for special attention from reviewers?

This is a mechanical, behavior-neutral rename. Vendored goproxy code is intentionally unchanged.

## How will you know you've accomplished your goal?

- `go test ./...`
- `go vet ./...`