### PR TITLE
Use explicit contexts for network requests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,9 +52,8 @@ script/test          # Run tests in Docker with race detection (-race -count=2)
 go test ./...        # Run tests locally
 ```
 
-**Test pattern**: Handler tests use `newTestRequest(t, method, target, body)` and test helper functions from [test_helpers.go](../internal/handlers/test_helpers.go):
+**Test pattern**: Handler tests use `httptest.NewRequestWithContext(t.Context(), method, target, body)` and test helper functions from [test_helpers.go](../internal/handlers/test_helpers.go):
 
-- `newTestRequest(t, method, target, body)` - create a request using `t.Context()`
 - `testGitSourceCred(host, username, password, opts...)` - create test credentials
 - `assertHasTokenAuth(t, req, "Bearer", token, "msg")` - verify auth header
 - `assertHasBasicAuth(t, req, user, pass, "msg")` - verify basic auth

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,8 +52,9 @@ script/test          # Run tests in Docker with race detection (-race -count=2)
 go test ./...        # Run tests locally
 ```
 
-**Test pattern**: Tests use `httptest.NewRequest()` and test helper functions from [test_helpers.go](../internal/handlers/test_helpers.go):
+**Test pattern**: Handler tests use `newTestRequest(t, method, target, body)` and test helper functions from [test_helpers.go](../internal/handlers/test_helpers.go):
 
+- `newTestRequest(t, method, target, body)` - create a request using `t.Context()`
 - `testGitSourceCred(host, username, password, opts...)` - create test credentials
 - `assertHasTokenAuth(t, req, "Bearer", token, "msg")` - verify auth header
 - `assertHasBasicAuth(t, req, user, pass, "msg")` - verify basic auth

--- a/internal/apiclient/client_test.go
+++ b/internal/apiclient/client_test.go
@@ -143,7 +143,7 @@ func TestClient_RequestJITAccess(t *testing.T) {
 		client := apiclient.New(testServer.URL, jobToken, jobID)
 
 		proxyCtx := &goproxy.ProxyCtx{
-			Req: httptest.NewRequest("GET", "https://example.com", nil),
+			Req: httptest.NewRequestWithContext(t.Context(), "GET", "https://example.com", nil),
 		}
 		result, err := client.RequestJITAccess(proxyCtx, jitAccessEndpoint, "", "", accountName, repoName)
 
@@ -161,7 +161,7 @@ func TestClient_RequestJITAccess(t *testing.T) {
 		client := apiclient.New(testServer.URL, jobToken, jobID)
 
 		proxyCtx := &goproxy.ProxyCtx{
-			Req: httptest.NewRequest("GET", "https://example.com", nil),
+			Req: httptest.NewRequestWithContext(t.Context(), "GET", "https://example.com", nil),
 		}
 		_, err := client.RequestJITAccess(proxyCtx, "/endpoint", "", "", "this", "repo")
 
@@ -207,7 +207,7 @@ func TestClient_RequestJITAccess(t *testing.T) {
 			defer waitGroup.Done()
 
 			proxyCtx := &goproxy.ProxyCtx{
-				Req: httptest.NewRequest("GET", "https://example.com", nil),
+				Req: httptest.NewRequestWithContext(t.Context(), "GET", "https://example.com", nil),
 			}
 			credential, err := client.RequestJITAccess(proxyCtx, "/endpoint", "", "", "account", "repo-"+requestNumber)
 			require.NoError(t, err)

--- a/internal/cache/handlers_test.go
+++ b/internal/cache/handlers_test.go
@@ -31,7 +31,7 @@ func TestCache_Disabled(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", URL, nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", URL, nil)
 	proxyCtx := &goproxy.ProxyCtx{
 		Req: req,
 	}
@@ -70,7 +70,7 @@ func TestCache(t *testing.T) {
 	}
 
 	t.Run("Cache miss", func(t *testing.T) {
-		req := httptest.NewRequest("GET", URL, nil)
+		req := httptest.NewRequestWithContext(t.Context(), "GET", URL, nil)
 		proxyCtx := &goproxy.ProxyCtx{
 			Req: req,
 		}
@@ -99,7 +99,7 @@ func TestCache(t *testing.T) {
 	})
 
 	t.Run("Cache hit", func(t *testing.T) {
-		req := httptest.NewRequest("GET", URL, nil)
+		req := httptest.NewRequestWithContext(t.Context(), "GET", URL, nil)
 		proxyCtx := &goproxy.ProxyCtx{
 			Req: req,
 		}
@@ -142,7 +142,7 @@ func Test_sanitize(t *testing.T) {
 }
 
 func Test_key(t *testing.T) {
-	req := httptest.NewRequest("GET", "https://github.com", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://github.com", nil)
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("User-Agent", "cli")
 	req.Header.Add("Connection", "keep-alive")
@@ -239,7 +239,7 @@ func Test_key(t *testing.T) {
 	})
 
 	t.Run("A request with no headers should result in a blank headerHash", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "https://github.com", nil)
+		req := httptest.NewRequestWithContext(t.Context(), "GET", "https://github.com", nil)
 		key := key(req)
 		if key.HeaderHash != "" {
 			t.Error("headerHash should be blank, got", key.HeaderHash)
@@ -251,7 +251,7 @@ func Test_key(t *testing.T) {
 	const upUrl = "https://github.com/octocat/Hello-World.git/git-upload-pack"
 	const upCT = "application/x-git-upload-pack-request"
 	mkUpReq := func(url, ct, body string) *http.Request {
-		r := httptest.NewRequest("POST", url, strings.NewReader(body))
+		r := httptest.NewRequestWithContext(t.Context(), "POST", url, strings.NewReader(body))
 		if ct != "" {
 			r.Header.Set("Content-Type", ct)
 		}
@@ -286,8 +286,8 @@ func Test_key(t *testing.T) {
 
 	t.Run("non-git POST is not normalized even with similar substrings", func(t *testing.T) {
 		const u = "https://api.github.com/graphql"
-		k1 := key(httptest.NewRequest("POST", u, strings.NewReader(`{"q":"have stuff agent=foo"}`)))
-		k2 := key(httptest.NewRequest("POST", u, strings.NewReader(`{"q":"have other agent=bar"}`)))
+		k1 := key(httptest.NewRequestWithContext(t.Context(), "POST", u, strings.NewReader(`{"q":"have stuff agent=foo"}`)))
+		k2 := key(httptest.NewRequestWithContext(t.Context(), "POST", u, strings.NewReader(`{"q":"have other agent=bar"}`)))
 		if k1 == k2 {
 			t.Error("non-git POSTs must not be normalized")
 		}

--- a/internal/dialer/dialer.go
+++ b/internal/dialer/dialer.go
@@ -180,7 +180,8 @@ func checkConnectivity(network, address string) bool {
 	// A connected UDP dial sends no packets; it just asks the kernel to pick a
 	// route. That returns fast when the address family is disabled or has no
 	// route, as in single-stack Docker environments.
-	conn, err := net.DialTimeout(network, address, 100*time.Millisecond)
+	dialer := net.Dialer{Timeout: 100 * time.Millisecond}
+	conn, err := dialer.DialContext(context.Background(), network, address)
 	if err != nil {
 		return false
 	}

--- a/internal/gitproto/upload_pack_test.go
+++ b/internal/gitproto/upload_pack_test.go
@@ -35,7 +35,7 @@ func TestIsUploadPackRequest(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest(tc.method, tc.url, nil)
+			req := httptest.NewRequestWithContext(t.Context(), tc.method, tc.url, nil)
 			if tc.contentType != "" {
 				req.Header.Set("Content-Type", tc.contentType)
 			}

--- a/internal/handlers/azdo_api_test.go
+++ b/internal/handlers/azdo_api_test.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,27 +19,27 @@ func TestAzureDevOpsAPIHandler(t *testing.T) {
 	handler := NewAzureDevOpsAPIHandler(credentials)
 
 	// Valid ADO hostname API request
-	req := httptest.NewRequest("GET", "https://dpdbot.dev.azure.com/", nil)
+	req := newTestRequest(t, "GET", "https://dpdbot.dev.azure.com/", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, adoDependabotCred.GetString("username"), adoDependabotCred.GetString("password"), "valid api request")
 
 	// Valid VS hostname API request
-	req = httptest.NewRequest("GET", "https://dpdbot.visualstudio.com/", nil)
+	req = newTestRequest(t, "GET", "https://dpdbot.visualstudio.com/", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, adoVsDependabotCred.GetString("username"), adoVsDependabotCred.GetString("password"), "valid api request")
 
 	// Valid API request with port
-	req = httptest.NewRequest("GET", "https://dpdbot.dev.azure.com:443/", nil)
+	req = newTestRequest(t, "GET", "https://dpdbot.dev.azure.com:443/", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, adoDependabotCred.GetString("username"), adoDependabotCred.GetString("password"), "valid api request with port")
 
 	// Different subdomain - not the AzureDevOps Dependabot API
-	req = httptest.NewRequest("GET", "https://dev.azure.com/", nil)
+	req = newTestRequest(t, "GET", "https://dev.azure.com/", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = httptest.NewRequest("GET", "http://dpdbot.dev.azure.com/", nil)
+	req = newTestRequest(t, "GET", "http://dpdbot.dev.azure.com/", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "http, not https")
 }
@@ -53,12 +52,12 @@ func TestAzureDevOpsAPIHandler_WorksAgainstDevFabric(t *testing.T) {
 	handler := NewAzureDevOpsAPIHandler(credentials)
 
 	// Valid DevFabric hostname API request
-	req := httptest.NewRequest("GET", "https://dpdbot.codedev.ms/", nil)
+	req := newTestRequest(t, "GET", "https://dpdbot.codedev.ms/", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, adoDevFabricDependabotCred.GetString("username"), adoDevFabricDependabotCred.GetString("password"), "valid codedev.ms api request")
 
 	// Valid VS DevFabric hostname API request
-	req = httptest.NewRequest("GET", "https://dpdbot.vsts.me/", nil)
+	req = newTestRequest(t, "GET", "https://dpdbot.vsts.me/", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, adoVsDevFabricDependabotCred.GetString("username"), adoVsDevFabricDependabotCred.GetString("password"), "valid vsts.me api request")
 }
@@ -69,7 +68,7 @@ func TestAzureDevOpsAPIHandler_DoesNotHandleUnknownHostname(t *testing.T) {
 	credentials := config.Credentials{notAdoCreds}
 	handler := NewAzureDevOpsAPIHandler(credentials)
 
-	req := httptest.NewRequest("GET", "https://not.azuredevops.ms/", nil)
+	req := newTestRequest(t, "GET", "https://not.azuredevops.ms/", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "does not put credentials in unknown host")
 }
@@ -82,17 +81,17 @@ func TestAzureDevOpsAPIHandler_AddsApiVersionIfMissing(t *testing.T) {
 	handler := NewAzureDevOpsAPIHandler(credentials)
 
 	// Valid API request, adds a default api-version
-	req := httptest.NewRequest("GET", "https://dpdbot.dev.azure.com/", nil)
+	req := newTestRequest(t, "GET", "https://dpdbot.dev.azure.com/", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasQueryParam(t, req, "api-version", "7.2-preview", "adds a default api-version query param")
 
 	// Valid API request, does not override existing query param
-	req = httptest.NewRequest("GET", "https://dpdbot.dev.azure.com/?api-version=7.0", nil)
+	req = newTestRequest(t, "GET", "https://dpdbot.dev.azure.com/?api-version=7.0", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasQueryParam(t, req, "api-version", "7.0", "adds a default api-version query param")
 
 	// Valid API request, maintains existing query params when adding api-version
-	req = httptest.NewRequest("GET", "https://dpdbot.dev.azure.com/?param1=test", nil)
+	req = newTestRequest(t, "GET", "https://dpdbot.dev.azure.com/?param1=test", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasQueryParam(t, req, "api-version", "7.2-preview", "adds a default api-version query param")
 	assertHasQueryParam(t, req, "param1", "test", "maintains existing query params")

--- a/internal/handlers/azdo_api_test.go
+++ b/internal/handlers/azdo_api_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,27 +20,27 @@ func TestAzureDevOpsAPIHandler(t *testing.T) {
 	handler := NewAzureDevOpsAPIHandler(credentials)
 
 	// Valid ADO hostname API request
-	req := newTestRequest(t, "GET", "https://dpdbot.dev.azure.com/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://dpdbot.dev.azure.com/", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, adoDependabotCred.GetString("username"), adoDependabotCred.GetString("password"), "valid api request")
 
 	// Valid VS hostname API request
-	req = newTestRequest(t, "GET", "https://dpdbot.visualstudio.com/", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://dpdbot.visualstudio.com/", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, adoVsDependabotCred.GetString("username"), adoVsDependabotCred.GetString("password"), "valid api request")
 
 	// Valid API request with port
-	req = newTestRequest(t, "GET", "https://dpdbot.dev.azure.com:443/", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://dpdbot.dev.azure.com:443/", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, adoDependabotCred.GetString("username"), adoDependabotCred.GetString("password"), "valid api request with port")
 
 	// Different subdomain - not the AzureDevOps Dependabot API
-	req = newTestRequest(t, "GET", "https://dev.azure.com/", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://dev.azure.com/", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = newTestRequest(t, "GET", "http://dpdbot.dev.azure.com/", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "http://dpdbot.dev.azure.com/", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "http, not https")
 }
@@ -52,12 +53,12 @@ func TestAzureDevOpsAPIHandler_WorksAgainstDevFabric(t *testing.T) {
 	handler := NewAzureDevOpsAPIHandler(credentials)
 
 	// Valid DevFabric hostname API request
-	req := newTestRequest(t, "GET", "https://dpdbot.codedev.ms/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://dpdbot.codedev.ms/", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, adoDevFabricDependabotCred.GetString("username"), adoDevFabricDependabotCred.GetString("password"), "valid codedev.ms api request")
 
 	// Valid VS DevFabric hostname API request
-	req = newTestRequest(t, "GET", "https://dpdbot.vsts.me/", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://dpdbot.vsts.me/", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, adoVsDevFabricDependabotCred.GetString("username"), adoVsDevFabricDependabotCred.GetString("password"), "valid vsts.me api request")
 }
@@ -68,7 +69,7 @@ func TestAzureDevOpsAPIHandler_DoesNotHandleUnknownHostname(t *testing.T) {
 	credentials := config.Credentials{notAdoCreds}
 	handler := NewAzureDevOpsAPIHandler(credentials)
 
-	req := newTestRequest(t, "GET", "https://not.azuredevops.ms/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://not.azuredevops.ms/", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "does not put credentials in unknown host")
 }
@@ -81,17 +82,17 @@ func TestAzureDevOpsAPIHandler_AddsApiVersionIfMissing(t *testing.T) {
 	handler := NewAzureDevOpsAPIHandler(credentials)
 
 	// Valid API request, adds a default api-version
-	req := newTestRequest(t, "GET", "https://dpdbot.dev.azure.com/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://dpdbot.dev.azure.com/", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasQueryParam(t, req, "api-version", "7.2-preview", "adds a default api-version query param")
 
 	// Valid API request, does not override existing query param
-	req = newTestRequest(t, "GET", "https://dpdbot.dev.azure.com/?api-version=7.0", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://dpdbot.dev.azure.com/?api-version=7.0", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasQueryParam(t, req, "api-version", "7.0", "adds a default api-version query param")
 
 	// Valid API request, maintains existing query params when adding api-version
-	req = newTestRequest(t, "GET", "https://dpdbot.dev.azure.com/?param1=test", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://dpdbot.dev.azure.com/?param1=test", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasQueryParam(t, req, "api-version", "7.2-preview", "adds a default api-version query param")
 	assertHasQueryParam(t, req, "param1", "test", "maintains existing query params")

--- a/internal/handlers/cargo_registry_test.go
+++ b/internal/handlers/cargo_registry_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -49,49 +50,49 @@ func TestCargoRegistryHandler(t *testing.T) {
 
 	// valid request, should authenticate
 	url := validURL
-	req := newTestRequest(t, "GET", url, nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", token, "valid url request")
 
 	// valid request plus a sub-path, should authenticate
 	url = validURL + "/path"
-	req = newTestRequest(t, "GET", url, nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", token, "valid url with sub-path request")
 
 	// valid request for registry without protocol, should authenticate
 	url = "https://" + validNoProtocolURL
-	req = newTestRequest(t, "GET", url, nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", token, "valid url without protocol request")
 
 	// valid request scoped to path, should authenticate
 	url = validURLWithPath
-	req = newTestRequest(t, "GET", url, nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", token, "valid path url request")
 
 	// wrong path, shouldn't authenticate
 	url = validURLWithPathBase + "/wrong_path"
-	req = newTestRequest(t, "GET", url, nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "requests to a mismatched path should not be authenticated")
 
 	url = noTokenURL
-	req = newTestRequest(t, "GET", url, nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "should not authenticate when missing token")
 
 	// HTTP, not HTTPS
 	httpURL := strings.Replace(validURL, "https", "http", 1)
 	url = httpURL
-	req = newTestRequest(t, "GET", url, nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "HTTP, not HTTPS request")
 
 	// Non-GET request
 	url = validURL
-	req = newTestRequest(t, "POST", url, nil)
+	req = httptest.NewRequestWithContext(t.Context(), "POST", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "non-GET request")
 }
@@ -110,17 +111,17 @@ func TestCargoRegistryHandlerWithHost(t *testing.T) {
 	handler := NewCargoRegistryHandler(credentials)
 
 	// matching host should authenticate
-	req := newTestRequest(t, "GET", "https://cargo.example.com/some/path", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://cargo.example.com/some/path", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", token, "host-matched request")
 
 	// non-matching host should not authenticate
-	req = newTestRequest(t, "GET", "https://other.example.com/some/path", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://other.example.com/some/path", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "non-matching host request")
 
 	// HTTP should not authenticate
-	req = newTestRequest(t, "GET", "http://cargo.example.com/some/path", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "http://cargo.example.com/some/path", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "HTTP request to matching host")
 }
@@ -141,12 +142,12 @@ func TestCargoRegistryHandlerWithUsernamePassword(t *testing.T) {
 	handler := NewCargoRegistryHandler(credentials)
 
 	// matching url should authenticate with basic auth
-	req := newTestRequest(t, "GET", "https://cargo.example.com/registry/crate", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://cargo.example.com/registry/crate", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, username, password, "basic auth via username/password")
 
 	// non-matching url should not authenticate
-	req = newTestRequest(t, "GET", "https://other.example.com/registry/crate", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://other.example.com/registry/crate", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "non-matching url should not authenticate")
 }
@@ -167,12 +168,12 @@ func TestCargoRegistryHandlerWithHostAndUsernamePassword(t *testing.T) {
 	handler := NewCargoRegistryHandler(credentials)
 
 	// matching host should authenticate with basic auth
-	req := newTestRequest(t, "GET", "https://cargo.example.com/any/path", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://cargo.example.com/any/path", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, username, password, "host-matched basic auth")
 
 	// non-matching host should not authenticate
-	req = newTestRequest(t, "GET", "https://other.example.com/any/path", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://other.example.com/any/path", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "non-matching host should not authenticate")
 }
@@ -193,7 +194,7 @@ func TestCargoRegistryHandlerTokenTakesPrecedenceOverPassword(t *testing.T) {
 	handler := NewCargoRegistryHandler(credentials)
 
 	// token should take precedence over username/password
-	req := newTestRequest(t, "GET", "https://cargo.example.com/registry/crate", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://cargo.example.com/registry/crate", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", token, "token takes precedence over password")
 }
@@ -209,7 +210,7 @@ func TestCargoRegistryHandlerIgnoresNoUrlOrHost(t *testing.T) {
 	handler := NewCargoRegistryHandler(credentials)
 
 	// should not authenticate any request since no url or host was provided
-	req := newTestRequest(t, "GET", "https://anything.example.com/path", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://anything.example.com/path", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "credential with no url or host should be ignored")
 }
@@ -229,12 +230,12 @@ func TestCargoRegistryHandlerUrlScopingNotBypassedByHost(t *testing.T) {
 	handler := NewCargoRegistryHandler(credentials)
 
 	// in-scope path should authenticate
-	req := newTestRequest(t, "GET", "https://cargo.example.com/myorg/crate", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://cargo.example.com/myorg/crate", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", token, "in-scope path request")
 
 	// different path on the same host must NOT authenticate
-	req = newTestRequest(t, "GET", "https://cargo.example.com/otherorg/crate", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://cargo.example.com/otherorg/crate", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "host must not bypass url path scoping")
 }

--- a/internal/handlers/cargo_registry_test.go
+++ b/internal/handlers/cargo_registry_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -50,49 +49,49 @@ func TestCargoRegistryHandler(t *testing.T) {
 
 	// valid request, should authenticate
 	url := validURL
-	req := httptest.NewRequest("GET", url, nil)
+	req := newTestRequest(t, "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", token, "valid url request")
 
 	// valid request plus a sub-path, should authenticate
 	url = validURL + "/path"
-	req = httptest.NewRequest("GET", url, nil)
+	req = newTestRequest(t, "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", token, "valid url with sub-path request")
 
 	// valid request for registry without protocol, should authenticate
 	url = "https://" + validNoProtocolURL
-	req = httptest.NewRequest("GET", url, nil)
+	req = newTestRequest(t, "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", token, "valid url without protocol request")
 
 	// valid request scoped to path, should authenticate
 	url = validURLWithPath
-	req = httptest.NewRequest("GET", url, nil)
+	req = newTestRequest(t, "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", token, "valid path url request")
 
 	// wrong path, shouldn't authenticate
 	url = validURLWithPathBase + "/wrong_path"
-	req = httptest.NewRequest("GET", url, nil)
+	req = newTestRequest(t, "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "requests to a mismatched path should not be authenticated")
 
 	url = noTokenURL
-	req = httptest.NewRequest("GET", url, nil)
+	req = newTestRequest(t, "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "should not authenticate when missing token")
 
 	// HTTP, not HTTPS
 	httpURL := strings.Replace(validURL, "https", "http", 1)
 	url = httpURL
-	req = httptest.NewRequest("GET", url, nil)
+	req = newTestRequest(t, "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "HTTP, not HTTPS request")
 
 	// Non-GET request
 	url = validURL
-	req = httptest.NewRequest("POST", url, nil)
+	req = newTestRequest(t, "POST", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "non-GET request")
 }
@@ -111,17 +110,17 @@ func TestCargoRegistryHandlerWithHost(t *testing.T) {
 	handler := NewCargoRegistryHandler(credentials)
 
 	// matching host should authenticate
-	req := httptest.NewRequest("GET", "https://cargo.example.com/some/path", nil)
+	req := newTestRequest(t, "GET", "https://cargo.example.com/some/path", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", token, "host-matched request")
 
 	// non-matching host should not authenticate
-	req = httptest.NewRequest("GET", "https://other.example.com/some/path", nil)
+	req = newTestRequest(t, "GET", "https://other.example.com/some/path", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "non-matching host request")
 
 	// HTTP should not authenticate
-	req = httptest.NewRequest("GET", "http://cargo.example.com/some/path", nil)
+	req = newTestRequest(t, "GET", "http://cargo.example.com/some/path", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "HTTP request to matching host")
 }
@@ -142,12 +141,12 @@ func TestCargoRegistryHandlerWithUsernamePassword(t *testing.T) {
 	handler := NewCargoRegistryHandler(credentials)
 
 	// matching url should authenticate with basic auth
-	req := httptest.NewRequest("GET", "https://cargo.example.com/registry/crate", nil)
+	req := newTestRequest(t, "GET", "https://cargo.example.com/registry/crate", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, username, password, "basic auth via username/password")
 
 	// non-matching url should not authenticate
-	req = httptest.NewRequest("GET", "https://other.example.com/registry/crate", nil)
+	req = newTestRequest(t, "GET", "https://other.example.com/registry/crate", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "non-matching url should not authenticate")
 }
@@ -168,12 +167,12 @@ func TestCargoRegistryHandlerWithHostAndUsernamePassword(t *testing.T) {
 	handler := NewCargoRegistryHandler(credentials)
 
 	// matching host should authenticate with basic auth
-	req := httptest.NewRequest("GET", "https://cargo.example.com/any/path", nil)
+	req := newTestRequest(t, "GET", "https://cargo.example.com/any/path", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, username, password, "host-matched basic auth")
 
 	// non-matching host should not authenticate
-	req = httptest.NewRequest("GET", "https://other.example.com/any/path", nil)
+	req = newTestRequest(t, "GET", "https://other.example.com/any/path", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "non-matching host should not authenticate")
 }
@@ -194,7 +193,7 @@ func TestCargoRegistryHandlerTokenTakesPrecedenceOverPassword(t *testing.T) {
 	handler := NewCargoRegistryHandler(credentials)
 
 	// token should take precedence over username/password
-	req := httptest.NewRequest("GET", "https://cargo.example.com/registry/crate", nil)
+	req := newTestRequest(t, "GET", "https://cargo.example.com/registry/crate", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", token, "token takes precedence over password")
 }
@@ -210,7 +209,7 @@ func TestCargoRegistryHandlerIgnoresNoUrlOrHost(t *testing.T) {
 	handler := NewCargoRegistryHandler(credentials)
 
 	// should not authenticate any request since no url or host was provided
-	req := httptest.NewRequest("GET", "https://anything.example.com/path", nil)
+	req := newTestRequest(t, "GET", "https://anything.example.com/path", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "credential with no url or host should be ignored")
 }
@@ -230,12 +229,12 @@ func TestCargoRegistryHandlerUrlScopingNotBypassedByHost(t *testing.T) {
 	handler := NewCargoRegistryHandler(credentials)
 
 	// in-scope path should authenticate
-	req := httptest.NewRequest("GET", "https://cargo.example.com/myorg/crate", nil)
+	req := newTestRequest(t, "GET", "https://cargo.example.com/myorg/crate", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", token, "in-scope path request")
 
 	// different path on the same host must NOT authenticate
-	req = httptest.NewRequest("GET", "https://cargo.example.com/otherorg/crate", nil)
+	req = newTestRequest(t, "GET", "https://cargo.example.com/otherorg/crate", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "host must not bypass url path scoping")
 }

--- a/internal/handlers/composer_test.go
+++ b/internal/handlers/composer_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"net/http/httptest"
 	"testing"
 
 	"github.com/dependabot/proxy/internal/config"
@@ -66,54 +65,54 @@ func TestComposerHandler(t *testing.T) {
 	}
 	handler := NewComposerHandler(credentials)
 
-	req := httptest.NewRequest("GET", "https://phpreg.bigco.com/somepkg", nil)
+	req := newTestRequest(t, "GET", "https://phpreg.bigco.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, bigCoUser, bigCoPassword, "valid registry request")
 
-	req = httptest.NewRequest("GET", "https://example.com/php/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://example.com/php/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, bigCoUser, bigCoPassword, "valid registry request")
 
-	req = httptest.NewRequest("GET", "https://example.com/path/to/php/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://example.com/path/to/php/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, smallCoUser, smallCoPassword, "path-specific registry request")
 
-	req = httptest.NewRequest("GET", "https://phpreg.smallco.com/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://phpreg.smallco.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, smallCoToken, "", "valid registry request")
 
-	req = httptest.NewRequest("GET", "https://phpreg.tokenco.com/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://phpreg.tokenco.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", bearerToken, "valid registry request with token")
 
-	req = httptest.NewRequest("GET", "https://packages.tokenco.com/php/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://packages.tokenco.com/php/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", bearerToken, "valid path request with token")
 
-	req = httptest.NewRequest("GET", "https://packages.tokenco.com/other/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://packages.tokenco.com/other/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "path token request outside configured path")
 
-	req = httptest.NewRequest("GET", "https://phpreg.precedence.com/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://phpreg.precedence.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", bearerToken, "token takes precedence over basic auth")
 
-	req = httptest.NewRequest("GET", "https://phpreg.emptytoken.com/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://phpreg.emptytoken.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, smallCoUser, smallCoPassword, "empty token falls back to basic auth")
 
 	// Missing repo subdomain
-	req = httptest.NewRequest("GET", "https://bigco.com/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://bigco.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = httptest.NewRequest("GET", "http://phpreg.bigco.com/somepkg", nil)
+	req = newTestRequest(t, "GET", "http://phpreg.bigco.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "http, not https")
 
 	// Not a GET request
-	req = httptest.NewRequest("POST", "https://phpreg.bigco.com/somepkg", nil)
+	req = newTestRequest(t, "POST", "https://phpreg.bigco.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "post request")
 }

--- a/internal/handlers/composer_test.go
+++ b/internal/handlers/composer_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/dependabot/proxy/internal/config"
@@ -65,54 +66,54 @@ func TestComposerHandler(t *testing.T) {
 	}
 	handler := NewComposerHandler(credentials)
 
-	req := newTestRequest(t, "GET", "https://phpreg.bigco.com/somepkg", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://phpreg.bigco.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, bigCoUser, bigCoPassword, "valid registry request")
 
-	req = newTestRequest(t, "GET", "https://example.com/php/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://example.com/php/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, bigCoUser, bigCoPassword, "valid registry request")
 
-	req = newTestRequest(t, "GET", "https://example.com/path/to/php/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://example.com/path/to/php/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, smallCoUser, smallCoPassword, "path-specific registry request")
 
-	req = newTestRequest(t, "GET", "https://phpreg.smallco.com/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://phpreg.smallco.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, smallCoToken, "", "valid registry request")
 
-	req = newTestRequest(t, "GET", "https://phpreg.tokenco.com/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://phpreg.tokenco.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", bearerToken, "valid registry request with token")
 
-	req = newTestRequest(t, "GET", "https://packages.tokenco.com/php/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://packages.tokenco.com/php/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", bearerToken, "valid path request with token")
 
-	req = newTestRequest(t, "GET", "https://packages.tokenco.com/other/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://packages.tokenco.com/other/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "path token request outside configured path")
 
-	req = newTestRequest(t, "GET", "https://phpreg.precedence.com/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://phpreg.precedence.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", bearerToken, "token takes precedence over basic auth")
 
-	req = newTestRequest(t, "GET", "https://phpreg.emptytoken.com/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://phpreg.emptytoken.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, smallCoUser, smallCoPassword, "empty token falls back to basic auth")
 
 	// Missing repo subdomain
-	req = newTestRequest(t, "GET", "https://bigco.com/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://bigco.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = newTestRequest(t, "GET", "http://phpreg.bigco.com/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "http://phpreg.bigco.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "http, not https")
 
 	// Not a GET request
-	req = newTestRequest(t, "POST", "https://phpreg.bigco.com/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "POST", "https://phpreg.bigco.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "post request")
 }

--- a/internal/handlers/dependabot_api_test.go
+++ b/internal/handlers/dependabot_api_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/dependabot/proxy/internal/config"
@@ -14,17 +15,17 @@ func TestDependabotAPIHandler_HandleRequest(t *testing.T) {
 		JobToken:    dependabotPassword,
 	})
 
-	req := newTestRequest(t, "GET", "https://api.dependabot.com/update_jobs/123/create_pull_request", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://api.dependabot.com/update_jobs/123/create_pull_request", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", dependabotPassword, "dependabot repository request")
 
 	// HTTP, not HTTPS
-	req = newTestRequest(t, "GET", "http://api.dependabot.com/packages/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "http://api.dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "we always use HTTPS")
 
 	// missing subdomain
-	req = newTestRequest(t, "GET", "https://dependabot.com/packages/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 }
@@ -38,7 +39,7 @@ func TestDependabotAPIHandler_CaseInsensitiveHostname(t *testing.T) {
 	})
 
 	// Request with lowercase hostname should still match uppercase endpoint
-	req := newTestRequest(t, "GET", "https://api.dependabot.com/update_jobs/123/create_pull_request", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://api.dependabot.com/update_jobs/123/create_pull_request", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", dependabotPassword, "case-insensitive hostname matching")
 }

--- a/internal/handlers/dependabot_api_test.go
+++ b/internal/handlers/dependabot_api_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"net/http/httptest"
 	"testing"
 
 	"github.com/dependabot/proxy/internal/config"
@@ -15,17 +14,17 @@ func TestDependabotAPIHandler_HandleRequest(t *testing.T) {
 		JobToken:    dependabotPassword,
 	})
 
-	req := httptest.NewRequest("GET", "https://api.dependabot.com/update_jobs/123/create_pull_request", nil)
+	req := newTestRequest(t, "GET", "https://api.dependabot.com/update_jobs/123/create_pull_request", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", dependabotPassword, "dependabot repository request")
 
 	// HTTP, not HTTPS
-	req = httptest.NewRequest("GET", "http://api.dependabot.com/packages/somepkg", nil)
+	req = newTestRequest(t, "GET", "http://api.dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "we always use HTTPS")
 
 	// missing subdomain
-	req = httptest.NewRequest("GET", "https://dependabot.com/packages/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 }
@@ -39,7 +38,7 @@ func TestDependabotAPIHandler_CaseInsensitiveHostname(t *testing.T) {
 	})
 
 	// Request with lowercase hostname should still match uppercase endpoint
-	req := httptest.NewRequest("GET", "https://api.dependabot.com/update_jobs/123/create_pull_request", nil)
+	req := newTestRequest(t, "GET", "https://api.dependabot.com/update_jobs/123/create_pull_request", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", dependabotPassword, "case-insensitive hostname matching")
 }

--- a/internal/handlers/docker_registry_test.go
+++ b/internal/handlers/docker_registry_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
@@ -71,7 +70,7 @@ func TestDockerRegistryHandler(t *testing.T) {
 	handler := NewDockerRegistryHandler(credentials, &http.Transport{}, getECRClient)
 
 	// Regular private registry
-	req := httptest.NewRequest("GET", "https://registry.hub.docker.com/my-repo", nil)
+	req := newTestRequest(t, "GET", "https://registry.hub.docker.com/my-repo", nil)
 	proxyCtx := &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	rt, ok := proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
@@ -81,7 +80,7 @@ func TestDockerRegistryHandler(t *testing.T) {
 	assert.Equal(t, hubPassword, trans.Password, "correct password is set")
 
 	// Registry using URL not registry key
-	req = httptest.NewRequest("GET", "https://registry.hub.docker.com/my-repo", nil)
+	req = newTestRequest(t, "GET", "https://registry.hub.docker.com/my-repo", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	rt, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
@@ -91,7 +90,7 @@ func TestDockerRegistryHandler(t *testing.T) {
 	assert.Equal(t, hubPassword, trans.Password, "correct password is set")
 
 	// Different private registry
-	req = httptest.NewRequest("GET", "https://docker.bigco.com/their-repo", nil)
+	req = newTestRequest(t, "GET", "https://docker.bigco.com/their-repo", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	rt, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
@@ -101,7 +100,7 @@ func TestDockerRegistryHandler(t *testing.T) {
 	assert.Equal(t, bigCoPassword, trans.Password, "correct password is set")
 
 	// ECR
-	req = httptest.NewRequest("GET", "https://123456789123.dkr.ecr.us-east-2.amazonaws.com", nil)
+	req = newTestRequest(t, "GET", "https://123456789123.dkr.ecr.us-east-2.amazonaws.com", nil)
 	req = req.WithContext(context.WithValue(req.Context(), ecrContextKey{}, "ecr-request"))
 	proxyCtx = &goproxy.ProxyCtx{}
 	req = handleRequestAndClose(handler, req, proxyCtx)
@@ -116,7 +115,7 @@ func TestDockerRegistryHandler(t *testing.T) {
 	}
 
 	// ECR, again
-	req = httptest.NewRequest("GET", "https://123456789123.dkr.ecr.us-east-2.amazonaws.com", nil)
+	req = newTestRequest(t, "GET", "https://123456789123.dkr.ecr.us-east-2.amazonaws.com", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	req = handleRequestAndClose(handler, req, proxyCtx)
 	_, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
@@ -124,7 +123,7 @@ func TestDockerRegistryHandler(t *testing.T) {
 	assertHasBasicAuth(t, req, ecrDockerUser, ecrDockerPassword, "has ecr credentials")
 
 	// ECR, mismatch:
-	req = httptest.NewRequest("GET", "https://123456789123.dkr.ecr.us-east-2Xamazonaws.com", nil)
+	req = newTestRequest(t, "GET", "https://123456789123.dkr.ecr.us-east-2Xamazonaws.com", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	req = handleRequestAndClose(handler, req, proxyCtx)
 	_, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
@@ -132,28 +131,28 @@ func TestDockerRegistryHandler(t *testing.T) {
 	assertUnauthenticated(t, req, "leaked ecr credentials")
 
 	// Missing repo subdomain
-	req = httptest.NewRequest("GET", "https://bigco.com/their-repo", nil)
+	req = newTestRequest(t, "GET", "https://bigco.com/their-repo", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	_, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
 	assert.False(t, ok, "different subdomain request isn't assigned a docker registry transport")
 
 	// HTTP, not HTTPS
-	req = httptest.NewRequest("GET", "http://docker.bigco.com/their-repo", nil)
+	req = newTestRequest(t, "GET", "http://docker.bigco.com/their-repo", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	_, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
 	assert.False(t, ok, "request isn't assigned a docker registry transport")
 
 	// Not a GET request
-	req = httptest.NewRequest("POST", "https://docker.bigco.com/their-repo", nil)
+	req = newTestRequest(t, "POST", "https://docker.bigco.com/their-repo", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	_, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
 	assert.False(t, ok, "request isn't assigned a docker registry transport")
 
 	// Nexus, BasicAuth
-	req = httptest.NewRequest("GET", "https://nexus.someco.com/a-repo", nil)
+	req = newTestRequest(t, "GET", "https://nexus.someco.com/a-repo", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	rt, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)

--- a/internal/handlers/docker_registry_test.go
+++ b/internal/handlers/docker_registry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
@@ -70,7 +71,7 @@ func TestDockerRegistryHandler(t *testing.T) {
 	handler := NewDockerRegistryHandler(credentials, &http.Transport{}, getECRClient)
 
 	// Regular private registry
-	req := newTestRequest(t, "GET", "https://registry.hub.docker.com/my-repo", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.hub.docker.com/my-repo", nil)
 	proxyCtx := &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	rt, ok := proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
@@ -80,7 +81,7 @@ func TestDockerRegistryHandler(t *testing.T) {
 	assert.Equal(t, hubPassword, trans.Password, "correct password is set")
 
 	// Registry using URL not registry key
-	req = newTestRequest(t, "GET", "https://registry.hub.docker.com/my-repo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.hub.docker.com/my-repo", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	rt, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
@@ -90,7 +91,7 @@ func TestDockerRegistryHandler(t *testing.T) {
 	assert.Equal(t, hubPassword, trans.Password, "correct password is set")
 
 	// Different private registry
-	req = newTestRequest(t, "GET", "https://docker.bigco.com/their-repo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://docker.bigco.com/their-repo", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	rt, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
@@ -100,7 +101,7 @@ func TestDockerRegistryHandler(t *testing.T) {
 	assert.Equal(t, bigCoPassword, trans.Password, "correct password is set")
 
 	// ECR
-	req = newTestRequest(t, "GET", "https://123456789123.dkr.ecr.us-east-2.amazonaws.com", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://123456789123.dkr.ecr.us-east-2.amazonaws.com", nil)
 	req = req.WithContext(context.WithValue(req.Context(), ecrContextKey{}, "ecr-request"))
 	proxyCtx = &goproxy.ProxyCtx{}
 	req = handleRequestAndClose(handler, req, proxyCtx)
@@ -115,7 +116,7 @@ func TestDockerRegistryHandler(t *testing.T) {
 	}
 
 	// ECR, again
-	req = newTestRequest(t, "GET", "https://123456789123.dkr.ecr.us-east-2.amazonaws.com", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://123456789123.dkr.ecr.us-east-2.amazonaws.com", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	req = handleRequestAndClose(handler, req, proxyCtx)
 	_, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
@@ -123,7 +124,7 @@ func TestDockerRegistryHandler(t *testing.T) {
 	assertHasBasicAuth(t, req, ecrDockerUser, ecrDockerPassword, "has ecr credentials")
 
 	// ECR, mismatch:
-	req = newTestRequest(t, "GET", "https://123456789123.dkr.ecr.us-east-2Xamazonaws.com", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://123456789123.dkr.ecr.us-east-2Xamazonaws.com", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	req = handleRequestAndClose(handler, req, proxyCtx)
 	_, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
@@ -131,28 +132,28 @@ func TestDockerRegistryHandler(t *testing.T) {
 	assertUnauthenticated(t, req, "leaked ecr credentials")
 
 	// Missing repo subdomain
-	req = newTestRequest(t, "GET", "https://bigco.com/their-repo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://bigco.com/their-repo", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	_, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
 	assert.False(t, ok, "different subdomain request isn't assigned a docker registry transport")
 
 	// HTTP, not HTTPS
-	req = newTestRequest(t, "GET", "http://docker.bigco.com/their-repo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "http://docker.bigco.com/their-repo", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	_, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
 	assert.False(t, ok, "request isn't assigned a docker registry transport")
 
 	// Not a GET request
-	req = newTestRequest(t, "POST", "https://docker.bigco.com/their-repo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "POST", "https://docker.bigco.com/their-repo", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	_, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
 	assert.False(t, ok, "request isn't assigned a docker registry transport")
 
 	// Nexus, BasicAuth
-	req = newTestRequest(t, "GET", "https://nexus.someco.com/a-repo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://nexus.someco.com/a-repo", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	rt, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)

--- a/internal/handlers/git_server_test.go
+++ b/internal/handlers/git_server_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -31,7 +32,7 @@ func TestGitServerHandler_url(t *testing.T) {
 	handler := NewGitServerHandler(config.Credentials{cred}, nil)
 
 	// Valid github git request, prioritises non-installation token
-	req := newTestRequest(t, "GET", "https://github.com/account/repo", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://github.com/account/repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req,
 		cred["username"].(string),
@@ -64,7 +65,7 @@ func TestGitServerHandler(t *testing.T) {
 	handler := NewGitServerHandler(credentials, nil)
 
 	// Valid github git request, prioritises non-installation token
-	req := newTestRequest(t, "GET", "https://github.com/account/repo", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://github.com/account/repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req,
 		otherGitHubCred.GetString("username"),
@@ -72,7 +73,7 @@ func TestGitServerHandler(t *testing.T) {
 		"valid github request")
 
 	// Valid github git request, git user included but no password
-	req = newTestRequest(t, "GET", "https://git@github.com/account/repo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://git@github.com/account/repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req,
 		otherGitHubCred.GetString("username"),
@@ -80,7 +81,7 @@ func TestGitServerHandler(t *testing.T) {
 		"valid github request")
 
 	// Valid bitbucket git request, prioritises non-installation token
-	req = newTestRequest(t, "GET", "https://bitbucket.org:443/account/repo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://bitbucket.org:443/account/repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req,
 		bitBucketCred.GetString("username"),
@@ -88,7 +89,7 @@ func TestGitServerHandler(t *testing.T) {
 		"valid bitbucket request")
 
 	// Valid GHE request
-	req = newTestRequest(t, "GET", "https://ghe.some-corp.com/account/_dependabot", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://ghe.some-corp.com/account/_dependabot", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req,
 		gheCred.GetString("username"),
@@ -96,17 +97,17 @@ func TestGitServerHandler(t *testing.T) {
 		"valid ghe request")
 
 	// Special GHE dependabot-api endpoint
-	req = newTestRequest(t, "GET", "https://ghe.some-corp.com/_dependabot/update_jobs/123/details", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://ghe.some-corp.com/_dependabot/update_jobs/123/details", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "_dependabot api URL prefix")
 
 	// Different subdomain - not the GitHub API
-	req = newTestRequest(t, "GET", "https://api.github.com/account/repo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://api.github.com/account/repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = newTestRequest(t, "GET", "http://github.com/account/repo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "http://github.com/account/repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "http, not https")
 
@@ -118,7 +119,7 @@ func TestGitServerHandler(t *testing.T) {
 	handler = NewGitServerHandler(credentials, nil)
 
 	// Valid github git request, uses installation token
-	req = newTestRequest(t, "GET", "https://github.com/account/repo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://github.com/account/repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req,
 		installationCred.GetString("username"),
@@ -179,7 +180,7 @@ func TestGitServerHandler_AuthenticatedAccessToGitHubRepos(t *testing.T) {
 			handler := NewGitServerHandler(tt.credentials, nil)
 
 			// Valid github git request, prioritises non-installation token
-			req := newTestRequest(t, "GET", fmt.Sprintf("https://github.com/%s", tt.repoNWO), nil)
+			req := httptest.NewRequestWithContext(t.Context(), "GET", fmt.Sprintf("https://github.com/%s", tt.repoNWO), nil)
 			req = handleRequestAndClose(handler, req, nil)
 
 			switch {
@@ -239,7 +240,7 @@ func TestGitServerHandlerNoRetry(t *testing.T) {
 	roundTripper := goproxy.RoundTripperFunc(func(*http.Request, *goproxy.ProxyCtx) (*http.Response, error) {
 		return &http.Response{StatusCode: 401, Body: io.NopCloser(strings.NewReader(""))}, nil
 	})
-	req := newTestRequest(t, "GET", url, nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req.SetBasicAuth("x-access-token", "v1.token")
 	proxyCtx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
 
@@ -490,7 +491,7 @@ func TestGitServerHandler_RepositoryScopedCredentials(t *testing.T) {
 				return &http.Response{StatusCode: 401, Body: io.NopCloser(strings.NewReader(""))}, nil
 			})
 
-			req := newTestRequest(t, "GET", url, nil)
+			req := httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 			proxyCtx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
 			rsp := &http.Response{StatusCode: 401, Body: io.NopCloser(strings.NewReader(""))}
 

--- a/internal/handlers/git_server_test.go
+++ b/internal/handlers/git_server_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -32,7 +31,7 @@ func TestGitServerHandler_url(t *testing.T) {
 	handler := NewGitServerHandler(config.Credentials{cred}, nil)
 
 	// Valid github git request, prioritises non-installation token
-	req := httptest.NewRequest("GET", "https://github.com/account/repo", nil)
+	req := newTestRequest(t, "GET", "https://github.com/account/repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req,
 		cred["username"].(string),
@@ -65,7 +64,7 @@ func TestGitServerHandler(t *testing.T) {
 	handler := NewGitServerHandler(credentials, nil)
 
 	// Valid github git request, prioritises non-installation token
-	req := httptest.NewRequest("GET", "https://github.com/account/repo", nil)
+	req := newTestRequest(t, "GET", "https://github.com/account/repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req,
 		otherGitHubCred.GetString("username"),
@@ -73,7 +72,7 @@ func TestGitServerHandler(t *testing.T) {
 		"valid github request")
 
 	// Valid github git request, git user included but no password
-	req = httptest.NewRequest("GET", "https://git@github.com/account/repo", nil)
+	req = newTestRequest(t, "GET", "https://git@github.com/account/repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req,
 		otherGitHubCred.GetString("username"),
@@ -81,7 +80,7 @@ func TestGitServerHandler(t *testing.T) {
 		"valid github request")
 
 	// Valid bitbucket git request, prioritises non-installation token
-	req = httptest.NewRequest("GET", "https://bitbucket.org:443/account/repo", nil)
+	req = newTestRequest(t, "GET", "https://bitbucket.org:443/account/repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req,
 		bitBucketCred.GetString("username"),
@@ -89,7 +88,7 @@ func TestGitServerHandler(t *testing.T) {
 		"valid bitbucket request")
 
 	// Valid GHE request
-	req = httptest.NewRequest("GET", "https://ghe.some-corp.com/account/_dependabot", nil)
+	req = newTestRequest(t, "GET", "https://ghe.some-corp.com/account/_dependabot", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req,
 		gheCred.GetString("username"),
@@ -97,17 +96,17 @@ func TestGitServerHandler(t *testing.T) {
 		"valid ghe request")
 
 	// Special GHE dependabot-api endpoint
-	req = httptest.NewRequest("GET", "https://ghe.some-corp.com/_dependabot/update_jobs/123/details", nil)
+	req = newTestRequest(t, "GET", "https://ghe.some-corp.com/_dependabot/update_jobs/123/details", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "_dependabot api URL prefix")
 
 	// Different subdomain - not the GitHub API
-	req = httptest.NewRequest("GET", "https://api.github.com/account/repo", nil)
+	req = newTestRequest(t, "GET", "https://api.github.com/account/repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = httptest.NewRequest("GET", "http://github.com/account/repo", nil)
+	req = newTestRequest(t, "GET", "http://github.com/account/repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "http, not https")
 
@@ -119,7 +118,7 @@ func TestGitServerHandler(t *testing.T) {
 	handler = NewGitServerHandler(credentials, nil)
 
 	// Valid github git request, uses installation token
-	req = httptest.NewRequest("GET", "https://github.com/account/repo", nil)
+	req = newTestRequest(t, "GET", "https://github.com/account/repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req,
 		installationCred.GetString("username"),
@@ -180,7 +179,7 @@ func TestGitServerHandler_AuthenticatedAccessToGitHubRepos(t *testing.T) {
 			handler := NewGitServerHandler(tt.credentials, nil)
 
 			// Valid github git request, prioritises non-installation token
-			req := httptest.NewRequest("GET", fmt.Sprintf("https://github.com/%s", tt.repoNWO), nil)
+			req := newTestRequest(t, "GET", fmt.Sprintf("https://github.com/%s", tt.repoNWO), nil)
 			req = handleRequestAndClose(handler, req, nil)
 
 			switch {
@@ -240,7 +239,7 @@ func TestGitServerHandlerNoRetry(t *testing.T) {
 	roundTripper := goproxy.RoundTripperFunc(func(*http.Request, *goproxy.ProxyCtx) (*http.Response, error) {
 		return &http.Response{StatusCode: 401, Body: io.NopCloser(strings.NewReader(""))}, nil
 	})
-	req := httptest.NewRequest("GET", url, nil)
+	req := newTestRequest(t, "GET", url, nil)
 	req.SetBasicAuth("x-access-token", "v1.token")
 	proxyCtx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
 
@@ -491,7 +490,7 @@ func TestGitServerHandler_RepositoryScopedCredentials(t *testing.T) {
 				return &http.Response{StatusCode: 401, Body: io.NopCloser(strings.NewReader(""))}, nil
 			})
 
-			req := httptest.NewRequest("GET", url, nil)
+			req := newTestRequest(t, "GET", url, nil)
 			proxyCtx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
 			rsp := &http.Response{StatusCode: 401, Body: io.NopCloser(strings.NewReader(""))}
 

--- a/internal/handlers/github_api_test.go
+++ b/internal/handlers/github_api_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -26,7 +25,7 @@ func TestGitHubAPIHandler_withUrlFallback(t *testing.T) {
 
 	handler := NewGitHubAPIHandler(usingURL)
 
-	req := httptest.NewRequest("GET", "https://api.github.com/some-repo", nil)
+	req := newTestRequest(t, "GET", "https://api.github.com/some-repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "token", "super-secret-token", "valid api request")
 }
@@ -62,22 +61,22 @@ func TestGitHubAPIHandler(t *testing.T) {
 			handler := NewGitHubAPIHandler(credentials)
 
 			// Valid API request, prioritises non-installation token
-			req := httptest.NewRequest("GET", "https://api.github.com/some-repo", nil)
+			req := newTestRequest(t, "GET", "https://api.github.com/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertHasTokenAuth(t, req, "token", tt.personalAccessToken.GetString("password"), "valid api request")
 
 			// Valid API request with port, prioritises non-installation token
-			req = httptest.NewRequest("GET", "https://api.github.com:443/some-repo", nil)
+			req = newTestRequest(t, "GET", "https://api.github.com:443/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertHasTokenAuth(t, req, "token", tt.personalAccessToken.GetString("password"), "valid api request with port")
 
 			// Different subdomain - not the GitHub API
-			req = httptest.NewRequest("GET", "https://github.com/some-repo", nil)
+			req = newTestRequest(t, "GET", "https://github.com/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertUnauthenticated(t, req, "different subdomain")
 
 			// HTTP, not HTTPS
-			req = httptest.NewRequest("GET", "http://api.github.com/some-repo", nil)
+			req = newTestRequest(t, "GET", "http://api.github.com/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertUnauthenticated(t, req, "http, not https")
 		})
@@ -87,7 +86,7 @@ func TestGitHubAPIHandler(t *testing.T) {
 		handler := NewGitHubAPIHandler(credentials)
 
 		// Valid API request, uses installation token
-		req := httptest.NewRequest("GET", "https://api.github.com/some-repo", nil)
+		req := newTestRequest(t, "GET", "https://api.github.com/some-repo", nil)
 		req = handleRequestAndClose(handler, req, nil)
 		assertHasTokenAuth(t, req, "token", installationCred.GetString("password"), "valid api request")
 
@@ -96,7 +95,7 @@ func TestGitHubAPIHandler(t *testing.T) {
 		handler = NewGitHubAPIHandler(credentials)
 
 		// Valid API request, uses installation token
-		req = httptest.NewRequest("GET", "https://api.github.com/some-repo", nil)
+		req = newTestRequest(t, "GET", "https://api.github.com/some-repo", nil)
 		req = handleRequestAndClose(handler, req, nil)
 		assertUnauthenticated(t, req, "Proxima is unauthenticated")
 		assertHasProximaHeader(t, req, proximaCred.GetString("password"), "valid api request")
@@ -156,7 +155,7 @@ func TestGitHubAPIHandler_AuthenticatedAccessToGitHubRepos(t *testing.T) {
 			handler := NewGitHubAPIHandler(tt.credentials)
 
 			// Valid github git request, prioritises non-installation token
-			req := httptest.NewRequest("GET", fmt.Sprintf("https://api.github.com/%s", tt.repoNWO), nil)
+			req := newTestRequest(t, "GET", fmt.Sprintf("https://api.github.com/%s", tt.repoNWO), nil)
 			req = handleRequestAndClose(handler, req, nil)
 
 			switch {
@@ -200,22 +199,22 @@ func TestGitHubAPIHandlerInProxima(t *testing.T) {
 			handler := NewGitHubAPIHandler(credentials)
 
 			// Valid API request, prioritises non-installation token
-			req := httptest.NewRequest("GET", "https://api.foo.ghe.com/some-repo", nil)
+			req := newTestRequest(t, "GET", "https://api.foo.ghe.com/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertHasTokenAuth(t, req, "token", tt.personalAccessToken.GetString("password"), "valid api request")
 
 			// Valid API request with port, prioritises non-installation token
-			req = httptest.NewRequest("GET", "https://api.foo.ghe.com:443/some-repo", nil)
+			req = newTestRequest(t, "GET", "https://api.foo.ghe.com:443/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertHasTokenAuth(t, req, "token", tt.personalAccessToken.GetString("password"), "valid api request with port")
 
 			// Different subdomain - not the GitHub API
-			req = httptest.NewRequest("GET", "https://ghe.com/some-repo", nil)
+			req = newTestRequest(t, "GET", "https://ghe.com/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertUnauthenticated(t, req, "different subdomain")
 
 			// HTTP, not HTTPS
-			req = httptest.NewRequest("GET", "http://api.foo.ghe.com/some-repo", nil)
+			req = newTestRequest(t, "GET", "http://api.foo.ghe.com/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertUnauthenticated(t, req, "http, not https")
 		})
@@ -225,7 +224,7 @@ func TestGitHubAPIHandlerInProxima(t *testing.T) {
 		handler := NewGitHubAPIHandler(credentials)
 
 		// Valid API request, uses installation token
-		req := httptest.NewRequest("GET", "https://api.foo.ghe.com/some-repo", nil)
+		req := newTestRequest(t, "GET", "https://api.foo.ghe.com/some-repo", nil)
 		req = handleRequestAndClose(handler, req, nil)
 		assertHasTokenAuth(t, req, "token", installationCred.GetString("password"), "valid api request")
 
@@ -253,17 +252,17 @@ func TestGitHubAPIHandlerWithMulipleHosts(t *testing.T) {
 			handler := NewGitHubAPIHandler(credentials)
 
 			// Request to github.com, using the correct token
-			req := httptest.NewRequest("GET", "https://api.github.com/some-repo", nil)
+			req := newTestRequest(t, "GET", "https://api.github.com/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertHasTokenAuth(t, req, "token", tt.personalAccessToken.GetString("password"), "request to github.com")
 
 			// Request to foo.ghe.com, using the correct token
-			req = httptest.NewRequest("GET", "https://api.foo.ghe.com/some-repo", nil)
+			req = newTestRequest(t, "GET", "https://api.foo.ghe.com/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertHasTokenAuth(t, req, "token", fooGheCred.GetString("password"), "request to foo.ghe.com")
 
 			// Different subdomain - not the GitHub API
-			req = httptest.NewRequest("GET", "https://github.com/some-repo", nil)
+			req = newTestRequest(t, "GET", "https://github.com/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertUnauthenticated(t, req, "different subdomain")
 		})
@@ -274,7 +273,7 @@ func TestGitHubAPIHandlerWithMulipleHosts(t *testing.T) {
 	handler := NewGitHubAPIHandler(credentials)
 
 	// Valid API request, uses only github.com token
-	req := httptest.NewRequest("GET", "https://api.github.com/some-repo", nil)
+	req := newTestRequest(t, "GET", "https://api.github.com/some-repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "token", githubCred.GetString("password"), "request to github.com")
 
@@ -283,7 +282,7 @@ func TestGitHubAPIHandlerWithMulipleHosts(t *testing.T) {
 	fooGhehandler := NewGitHubAPIHandler(fooGheCredentials)
 
 	// Valid API request, uses only foo.ghe.com token
-	fooGheReq := httptest.NewRequest("GET", "https://api.foo.ghe.com/some-repo", nil)
+	fooGheReq := newTestRequest(t, "GET", "https://api.foo.ghe.com/some-repo", nil)
 	fooGheReq = handleRequestAndClose(fooGhehandler, fooGheReq, nil)
 	assertHasTokenAuth(t, fooGheReq, "token", fooGheCred.GetString("password"), "request to foo.ghe.com")
 }
@@ -293,7 +292,7 @@ func TestGitHubAPIHandler_InstallationTokenFormat(t *testing.T) {
 	credentials := config.Credentials{installationCred}
 	handler := NewGitHubAPIHandler(credentials)
 
-	req := httptest.NewRequest("GET", "https://api.github.com/some-repo", nil)
+	req := newTestRequest(t, "GET", "https://api.github.com/some-repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "token", installationCred.GetString("password"), "valid api request")
 }
@@ -303,7 +302,7 @@ func TestGitHubAPIHandler_InstallationTokenFormat_Proxima(t *testing.T) {
 	credentials := config.Credentials{installationCred}
 	handler := NewGitHubAPIHandler(credentials)
 
-	req := httptest.NewRequest("GET", "https://api.foo.ghe.com/some-repo", nil)
+	req := newTestRequest(t, "GET", "https://api.foo.ghe.com/some-repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "token", installationCred.GetString("password"), "valid api request")
 }

--- a/internal/handlers/github_api_test.go
+++ b/internal/handlers/github_api_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -25,7 +26,7 @@ func TestGitHubAPIHandler_withUrlFallback(t *testing.T) {
 
 	handler := NewGitHubAPIHandler(usingURL)
 
-	req := newTestRequest(t, "GET", "https://api.github.com/some-repo", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://api.github.com/some-repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "token", "super-secret-token", "valid api request")
 }
@@ -61,22 +62,22 @@ func TestGitHubAPIHandler(t *testing.T) {
 			handler := NewGitHubAPIHandler(credentials)
 
 			// Valid API request, prioritises non-installation token
-			req := newTestRequest(t, "GET", "https://api.github.com/some-repo", nil)
+			req := httptest.NewRequestWithContext(t.Context(), "GET", "https://api.github.com/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertHasTokenAuth(t, req, "token", tt.personalAccessToken.GetString("password"), "valid api request")
 
 			// Valid API request with port, prioritises non-installation token
-			req = newTestRequest(t, "GET", "https://api.github.com:443/some-repo", nil)
+			req = httptest.NewRequestWithContext(t.Context(), "GET", "https://api.github.com:443/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertHasTokenAuth(t, req, "token", tt.personalAccessToken.GetString("password"), "valid api request with port")
 
 			// Different subdomain - not the GitHub API
-			req = newTestRequest(t, "GET", "https://github.com/some-repo", nil)
+			req = httptest.NewRequestWithContext(t.Context(), "GET", "https://github.com/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertUnauthenticated(t, req, "different subdomain")
 
 			// HTTP, not HTTPS
-			req = newTestRequest(t, "GET", "http://api.github.com/some-repo", nil)
+			req = httptest.NewRequestWithContext(t.Context(), "GET", "http://api.github.com/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertUnauthenticated(t, req, "http, not https")
 		})
@@ -86,7 +87,7 @@ func TestGitHubAPIHandler(t *testing.T) {
 		handler := NewGitHubAPIHandler(credentials)
 
 		// Valid API request, uses installation token
-		req := newTestRequest(t, "GET", "https://api.github.com/some-repo", nil)
+		req := httptest.NewRequestWithContext(t.Context(), "GET", "https://api.github.com/some-repo", nil)
 		req = handleRequestAndClose(handler, req, nil)
 		assertHasTokenAuth(t, req, "token", installationCred.GetString("password"), "valid api request")
 
@@ -95,7 +96,7 @@ func TestGitHubAPIHandler(t *testing.T) {
 		handler = NewGitHubAPIHandler(credentials)
 
 		// Valid API request, uses installation token
-		req = newTestRequest(t, "GET", "https://api.github.com/some-repo", nil)
+		req = httptest.NewRequestWithContext(t.Context(), "GET", "https://api.github.com/some-repo", nil)
 		req = handleRequestAndClose(handler, req, nil)
 		assertUnauthenticated(t, req, "Proxima is unauthenticated")
 		assertHasProximaHeader(t, req, proximaCred.GetString("password"), "valid api request")
@@ -155,7 +156,7 @@ func TestGitHubAPIHandler_AuthenticatedAccessToGitHubRepos(t *testing.T) {
 			handler := NewGitHubAPIHandler(tt.credentials)
 
 			// Valid github git request, prioritises non-installation token
-			req := newTestRequest(t, "GET", fmt.Sprintf("https://api.github.com/%s", tt.repoNWO), nil)
+			req := httptest.NewRequestWithContext(t.Context(), "GET", fmt.Sprintf("https://api.github.com/%s", tt.repoNWO), nil)
 			req = handleRequestAndClose(handler, req, nil)
 
 			switch {
@@ -199,22 +200,22 @@ func TestGitHubAPIHandlerInProxima(t *testing.T) {
 			handler := NewGitHubAPIHandler(credentials)
 
 			// Valid API request, prioritises non-installation token
-			req := newTestRequest(t, "GET", "https://api.foo.ghe.com/some-repo", nil)
+			req := httptest.NewRequestWithContext(t.Context(), "GET", "https://api.foo.ghe.com/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertHasTokenAuth(t, req, "token", tt.personalAccessToken.GetString("password"), "valid api request")
 
 			// Valid API request with port, prioritises non-installation token
-			req = newTestRequest(t, "GET", "https://api.foo.ghe.com:443/some-repo", nil)
+			req = httptest.NewRequestWithContext(t.Context(), "GET", "https://api.foo.ghe.com:443/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertHasTokenAuth(t, req, "token", tt.personalAccessToken.GetString("password"), "valid api request with port")
 
 			// Different subdomain - not the GitHub API
-			req = newTestRequest(t, "GET", "https://ghe.com/some-repo", nil)
+			req = httptest.NewRequestWithContext(t.Context(), "GET", "https://ghe.com/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertUnauthenticated(t, req, "different subdomain")
 
 			// HTTP, not HTTPS
-			req = newTestRequest(t, "GET", "http://api.foo.ghe.com/some-repo", nil)
+			req = httptest.NewRequestWithContext(t.Context(), "GET", "http://api.foo.ghe.com/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertUnauthenticated(t, req, "http, not https")
 		})
@@ -224,7 +225,7 @@ func TestGitHubAPIHandlerInProxima(t *testing.T) {
 		handler := NewGitHubAPIHandler(credentials)
 
 		// Valid API request, uses installation token
-		req := newTestRequest(t, "GET", "https://api.foo.ghe.com/some-repo", nil)
+		req := httptest.NewRequestWithContext(t.Context(), "GET", "https://api.foo.ghe.com/some-repo", nil)
 		req = handleRequestAndClose(handler, req, nil)
 		assertHasTokenAuth(t, req, "token", installationCred.GetString("password"), "valid api request")
 
@@ -252,17 +253,17 @@ func TestGitHubAPIHandlerWithMulipleHosts(t *testing.T) {
 			handler := NewGitHubAPIHandler(credentials)
 
 			// Request to github.com, using the correct token
-			req := newTestRequest(t, "GET", "https://api.github.com/some-repo", nil)
+			req := httptest.NewRequestWithContext(t.Context(), "GET", "https://api.github.com/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertHasTokenAuth(t, req, "token", tt.personalAccessToken.GetString("password"), "request to github.com")
 
 			// Request to foo.ghe.com, using the correct token
-			req = newTestRequest(t, "GET", "https://api.foo.ghe.com/some-repo", nil)
+			req = httptest.NewRequestWithContext(t.Context(), "GET", "https://api.foo.ghe.com/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertHasTokenAuth(t, req, "token", fooGheCred.GetString("password"), "request to foo.ghe.com")
 
 			// Different subdomain - not the GitHub API
-			req = newTestRequest(t, "GET", "https://github.com/some-repo", nil)
+			req = httptest.NewRequestWithContext(t.Context(), "GET", "https://github.com/some-repo", nil)
 			req = handleRequestAndClose(handler, req, nil)
 			assertUnauthenticated(t, req, "different subdomain")
 		})
@@ -273,7 +274,7 @@ func TestGitHubAPIHandlerWithMulipleHosts(t *testing.T) {
 	handler := NewGitHubAPIHandler(credentials)
 
 	// Valid API request, uses only github.com token
-	req := newTestRequest(t, "GET", "https://api.github.com/some-repo", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://api.github.com/some-repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "token", githubCred.GetString("password"), "request to github.com")
 
@@ -282,7 +283,7 @@ func TestGitHubAPIHandlerWithMulipleHosts(t *testing.T) {
 	fooGhehandler := NewGitHubAPIHandler(fooGheCredentials)
 
 	// Valid API request, uses only foo.ghe.com token
-	fooGheReq := newTestRequest(t, "GET", "https://api.foo.ghe.com/some-repo", nil)
+	fooGheReq := httptest.NewRequestWithContext(t.Context(), "GET", "https://api.foo.ghe.com/some-repo", nil)
 	fooGheReq = handleRequestAndClose(fooGhehandler, fooGheReq, nil)
 	assertHasTokenAuth(t, fooGheReq, "token", fooGheCred.GetString("password"), "request to foo.ghe.com")
 }
@@ -292,7 +293,7 @@ func TestGitHubAPIHandler_InstallationTokenFormat(t *testing.T) {
 	credentials := config.Credentials{installationCred}
 	handler := NewGitHubAPIHandler(credentials)
 
-	req := newTestRequest(t, "GET", "https://api.github.com/some-repo", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://api.github.com/some-repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "token", installationCred.GetString("password"), "valid api request")
 }
@@ -302,7 +303,7 @@ func TestGitHubAPIHandler_InstallationTokenFormat_Proxima(t *testing.T) {
 	credentials := config.Credentials{installationCred}
 	handler := NewGitHubAPIHandler(credentials)
 
-	req := newTestRequest(t, "GET", "https://api.foo.ghe.com/some-repo", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://api.foo.ghe.com/some-repo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "token", installationCred.GetString("password"), "valid api request")
 }

--- a/internal/handlers/goproxy_server_handler_test.go
+++ b/internal/handlers/goproxy_server_handler_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/dependabot/proxy/internal/config"
@@ -37,51 +38,51 @@ func TestGoProxyHandler(t *testing.T) {
 	}
 	handler := NewGoProxyServerHandler(credentials)
 
-	req := newTestRequest(t, "GET", "https://corp.dependabot.com/packages/somepkg", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://corp.dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, dependabotUser, dependabotPassword, "dependabot repository request")
 
-	req = newTestRequest(t, "GET", "https://corp.deltaforce.com/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://corp.deltaforce.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "deltaforce repository request")
 
 	// Path mismatch
-	req = newTestRequest(t, "GET", "https://corp.dependabot.com/foo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://corp.dependabot.com/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "path mismatch")
 
 	// Missing repo subdomain
-	req = newTestRequest(t, "GET", "https://dependabot.com/packages/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = newTestRequest(t, "GET", "http://corp.dependabot.com/packages/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "http://corp.dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, dependabotUser, dependabotPassword, "dependabot repository http request")
 
 	// HTTP, not HTTPS, missing submomain
-	req = newTestRequest(t, "GET", "http://dependabot.com/packages/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "http://dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// Not a GET request
-	req = newTestRequest(t, "POST", "https://corp.dependabot.com/packages/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "POST", "https://corp.dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "post request")
 
 	// No username and password in credential
-	req = newTestRequest(t, "GET", "https://open.dependabot.com/maven2/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://open.dependabot.com/maven2/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "no username and password")
 
 	// Azure DevOps
-	req = newTestRequest(t, "GET", "https://pkgs.dev.azure.com/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://pkgs.dev.azure.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "azure devops repository request")
 
 	// Azure DevOps case insensitive
-	req = newTestRequest(t, "GET", "https://PKGS.dev.azure.com/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://PKGS.dev.azure.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "azure devops case insensitive registry request")
 }

--- a/internal/handlers/goproxy_server_handler_test.go
+++ b/internal/handlers/goproxy_server_handler_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"net/http/httptest"
 	"testing"
 
 	"github.com/dependabot/proxy/internal/config"
@@ -38,51 +37,51 @@ func TestGoProxyHandler(t *testing.T) {
 	}
 	handler := NewGoProxyServerHandler(credentials)
 
-	req := httptest.NewRequest("GET", "https://corp.dependabot.com/packages/somepkg", nil)
+	req := newTestRequest(t, "GET", "https://corp.dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, dependabotUser, dependabotPassword, "dependabot repository request")
 
-	req = httptest.NewRequest("GET", "https://corp.deltaforce.com/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://corp.deltaforce.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "deltaforce repository request")
 
 	// Path mismatch
-	req = httptest.NewRequest("GET", "https://corp.dependabot.com/foo", nil)
+	req = newTestRequest(t, "GET", "https://corp.dependabot.com/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "path mismatch")
 
 	// Missing repo subdomain
-	req = httptest.NewRequest("GET", "https://dependabot.com/packages/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = httptest.NewRequest("GET", "http://corp.dependabot.com/packages/somepkg", nil)
+	req = newTestRequest(t, "GET", "http://corp.dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, dependabotUser, dependabotPassword, "dependabot repository http request")
 
 	// HTTP, not HTTPS, missing submomain
-	req = httptest.NewRequest("GET", "http://dependabot.com/packages/somepkg", nil)
+	req = newTestRequest(t, "GET", "http://dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// Not a GET request
-	req = httptest.NewRequest("POST", "https://corp.dependabot.com/packages/somepkg", nil)
+	req = newTestRequest(t, "POST", "https://corp.dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "post request")
 
 	// No username and password in credential
-	req = httptest.NewRequest("GET", "https://open.dependabot.com/maven2/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://open.dependabot.com/maven2/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "no username and password")
 
 	// Azure DevOps
-	req = httptest.NewRequest("GET", "https://pkgs.dev.azure.com/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://pkgs.dev.azure.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "azure devops repository request")
 
 	// Azure DevOps case insensitive
-	req = httptest.NewRequest("GET", "https://PKGS.dev.azure.com/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://PKGS.dev.azure.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "azure devops case insensitive registry request")
 }

--- a/internal/handlers/helm_registry_test.go
+++ b/internal/handlers/helm_registry_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/dependabot/proxy/internal/config"
@@ -32,30 +33,30 @@ func TestHelmRegistryHandler(t *testing.T) {
 	}
 	handler := NewHelmRegistryHandler(credentials)
 
-	req := newTestRequest(t, "GET", "https://helmreg.bigco.com/some_chart", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://helmreg.bigco.com/some_chart", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, bigCoUser, bigCoPassword, "valid registry request")
 
-	req = newTestRequest(t, "GET", "https://example.com/some_chart", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://example.com/some_chart", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, bigCoUser, bigCoPassword, "valid registry request")
 
-	req = newTestRequest(t, "GET", "https://helmreg.smallco.com/some_chart", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://helmreg.smallco.com/some_chart", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, smallCoToken, "", "valid registry request")
 
 	// Missing repo subdomain
-	req = newTestRequest(t, "GET", "https://bigco.com/some_chart", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://bigco.com/some_chart", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = newTestRequest(t, "GET", "http://helmreg.bigco.com/some_chart", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "http://helmreg.bigco.com/some_chart", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "http, not https")
 
 	// Not a GET request
-	req = newTestRequest(t, "POST", "https://helmreg.bigco.com/some_chart", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "POST", "https://helmreg.bigco.com/some_chart", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "post request")
 }

--- a/internal/handlers/helm_registry_test.go
+++ b/internal/handlers/helm_registry_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"net/http/httptest"
 	"testing"
 
 	"github.com/dependabot/proxy/internal/config"
@@ -33,30 +32,30 @@ func TestHelmRegistryHandler(t *testing.T) {
 	}
 	handler := NewHelmRegistryHandler(credentials)
 
-	req := httptest.NewRequest("GET", "https://helmreg.bigco.com/some_chart", nil)
+	req := newTestRequest(t, "GET", "https://helmreg.bigco.com/some_chart", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, bigCoUser, bigCoPassword, "valid registry request")
 
-	req = httptest.NewRequest("GET", "https://example.com/some_chart", nil)
+	req = newTestRequest(t, "GET", "https://example.com/some_chart", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, bigCoUser, bigCoPassword, "valid registry request")
 
-	req = httptest.NewRequest("GET", "https://helmreg.smallco.com/some_chart", nil)
+	req = newTestRequest(t, "GET", "https://helmreg.smallco.com/some_chart", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, smallCoToken, "", "valid registry request")
 
 	// Missing repo subdomain
-	req = httptest.NewRequest("GET", "https://bigco.com/some_chart", nil)
+	req = newTestRequest(t, "GET", "https://bigco.com/some_chart", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = httptest.NewRequest("GET", "http://helmreg.bigco.com/some_chart", nil)
+	req = newTestRequest(t, "GET", "http://helmreg.bigco.com/some_chart", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "http, not https")
 
 	// Not a GET request
-	req = httptest.NewRequest("POST", "https://helmreg.bigco.com/some_chart", nil)
+	req = newTestRequest(t, "POST", "https://helmreg.bigco.com/some_chart", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "post request")
 }

--- a/internal/handlers/hex_organization_test.go
+++ b/internal/handlers/hex_organization_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/dependabot/proxy/internal/config"
@@ -23,31 +24,31 @@ func TestHexOrganizationHandler(t *testing.T) {
 	}
 	handler := NewHexOrganizationHandler(credentials)
 
-	req := newTestRequest(t, "GET", "https://repo.hex.pm/repos/dependabot/packages/foo", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://repo.hex.pm/repos/dependabot/packages/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", dependabotKey, "dependabot registry request")
 
-	req = newTestRequest(t, "GET", "https://repo.hex.pm/repos/deltaforce/packages/foo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://repo.hex.pm/repos/deltaforce/packages/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", deltaForceKey, "deltaforce registry request")
 
 	// Not an org
-	req = newTestRequest(t, "GET", "https://repo.hex.pm/packages/foo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://repo.hex.pm/packages/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "not an org-scoped package")
 
 	// Missing repo subdomain
-	req = newTestRequest(t, "GET", "https://hex.pm/repos/deltaforce/packages/foo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://hex.pm/repos/deltaforce/packages/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = newTestRequest(t, "GET", "http://repo.hex.pm/repos/deltaforce/packages/foo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "http://repo.hex.pm/repos/deltaforce/packages/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "http, not https")
 
 	// Not a GET request
-	req = newTestRequest(t, "POST", "https://repo.hex.pm/repos/deltaforce/packages/foo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "POST", "https://repo.hex.pm/repos/deltaforce/packages/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "post request")
 }
@@ -63,7 +64,7 @@ func TestHexOrganizationHandler_BackwardsCompatibility(t *testing.T) {
 		}
 		handler := NewHexOrganizationHandler(credentials)
 
-		req := newTestRequest(t, "GET", "https://repo.hex.pm/repos/legacy-org/packages/foo", nil)
+		req := httptest.NewRequestWithContext(t.Context(), "GET", "https://repo.hex.pm/repos/legacy-org/packages/foo", nil)
 		req = handleRequestAndClose(handler, req, nil)
 		assertHasTokenAuth(t, req, "", "legacy-token", "should support legacy token field")
 	})
@@ -79,7 +80,7 @@ func TestHexOrganizationHandler_BackwardsCompatibility(t *testing.T) {
 		}
 		handler := NewHexOrganizationHandler(credentials)
 
-		req := newTestRequest(t, "GET", "https://repo.hex.pm/repos/test-org/packages/foo", nil)
+		req := httptest.NewRequestWithContext(t.Context(), "GET", "https://repo.hex.pm/repos/test-org/packages/foo", nil)
 		req = handleRequestAndClose(handler, req, nil)
 		assertHasTokenAuth(t, req, "", "new-key", "key should take precedence over token")
 	})

--- a/internal/handlers/hex_organization_test.go
+++ b/internal/handlers/hex_organization_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"net/http/httptest"
 	"testing"
 
 	"github.com/dependabot/proxy/internal/config"
@@ -24,31 +23,31 @@ func TestHexOrganizationHandler(t *testing.T) {
 	}
 	handler := NewHexOrganizationHandler(credentials)
 
-	req := httptest.NewRequest("GET", "https://repo.hex.pm/repos/dependabot/packages/foo", nil)
+	req := newTestRequest(t, "GET", "https://repo.hex.pm/repos/dependabot/packages/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", dependabotKey, "dependabot registry request")
 
-	req = httptest.NewRequest("GET", "https://repo.hex.pm/repos/deltaforce/packages/foo", nil)
+	req = newTestRequest(t, "GET", "https://repo.hex.pm/repos/deltaforce/packages/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", deltaForceKey, "deltaforce registry request")
 
 	// Not an org
-	req = httptest.NewRequest("GET", "https://repo.hex.pm/packages/foo", nil)
+	req = newTestRequest(t, "GET", "https://repo.hex.pm/packages/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "not an org-scoped package")
 
 	// Missing repo subdomain
-	req = httptest.NewRequest("GET", "https://hex.pm/repos/deltaforce/packages/foo", nil)
+	req = newTestRequest(t, "GET", "https://hex.pm/repos/deltaforce/packages/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = httptest.NewRequest("GET", "http://repo.hex.pm/repos/deltaforce/packages/foo", nil)
+	req = newTestRequest(t, "GET", "http://repo.hex.pm/repos/deltaforce/packages/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "http, not https")
 
 	// Not a GET request
-	req = httptest.NewRequest("POST", "https://repo.hex.pm/repos/deltaforce/packages/foo", nil)
+	req = newTestRequest(t, "POST", "https://repo.hex.pm/repos/deltaforce/packages/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "post request")
 }
@@ -64,7 +63,7 @@ func TestHexOrganizationHandler_BackwardsCompatibility(t *testing.T) {
 		}
 		handler := NewHexOrganizationHandler(credentials)
 
-		req := httptest.NewRequest("GET", "https://repo.hex.pm/repos/legacy-org/packages/foo", nil)
+		req := newTestRequest(t, "GET", "https://repo.hex.pm/repos/legacy-org/packages/foo", nil)
 		req = handleRequestAndClose(handler, req, nil)
 		assertHasTokenAuth(t, req, "", "legacy-token", "should support legacy token field")
 	})
@@ -80,7 +79,7 @@ func TestHexOrganizationHandler_BackwardsCompatibility(t *testing.T) {
 		}
 		handler := NewHexOrganizationHandler(credentials)
 
-		req := httptest.NewRequest("GET", "https://repo.hex.pm/repos/test-org/packages/foo", nil)
+		req := newTestRequest(t, "GET", "https://repo.hex.pm/repos/test-org/packages/foo", nil)
 		req = handleRequestAndClose(handler, req, nil)
 		assertHasTokenAuth(t, req, "", "new-key", "key should take precedence over token")
 	})

--- a/internal/handlers/hex_repository_test.go
+++ b/internal/handlers/hex_repository_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -33,37 +32,37 @@ func TestHexRepositoryHandler(t *testing.T) {
 
 	// valid request, should authenticate
 	url := validConfigUrl + validPath
-	req := httptest.NewRequest("GET", url, nil)
+	req := newTestRequest(t, "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", authKey, "dependabot registry request")
 
 	// requests to /public_key are passed through
 	url = validConfigUrl + "/public_key"
-	req = httptest.NewRequest("GET", url, nil)
+	req = newTestRequest(t, "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "requests to /public_key should not be authenticated")
 
 	url = noAuthKeyUrl + validPath
-	req = httptest.NewRequest("GET", url, nil)
+	req = newTestRequest(t, "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "should not authenticate when missing auth key")
 
 	// path isn't defined correctly
 	url = validConfigUrl + "/packages/jason"
-	req = httptest.NewRequest("GET", url, nil)
+	req = newTestRequest(t, "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", authKey, "alternative registry request")
 
 	// HTTP, not HTTPS
 	httpUrl := strings.Replace(validConfigUrl, "https", "http", 1)
 	url = httpUrl + validPath
-	req = httptest.NewRequest("GET", url, nil)
+	req = newTestRequest(t, "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "HTTP, not HTTPS request")
 
 	// Non-GET request
 	url = validConfigUrl + validPath
-	req = httptest.NewRequest("POST", url, nil)
+	req = newTestRequest(t, "POST", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "non-GET request")
 }

--- a/internal/handlers/hex_repository_test.go
+++ b/internal/handlers/hex_repository_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -32,37 +33,37 @@ func TestHexRepositoryHandler(t *testing.T) {
 
 	// valid request, should authenticate
 	url := validConfigUrl + validPath
-	req := newTestRequest(t, "GET", url, nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", authKey, "dependabot registry request")
 
 	// requests to /public_key are passed through
 	url = validConfigUrl + "/public_key"
-	req = newTestRequest(t, "GET", url, nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "requests to /public_key should not be authenticated")
 
 	url = noAuthKeyUrl + validPath
-	req = newTestRequest(t, "GET", url, nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "should not authenticate when missing auth key")
 
 	// path isn't defined correctly
 	url = validConfigUrl + "/packages/jason"
-	req = newTestRequest(t, "GET", url, nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "", authKey, "alternative registry request")
 
 	// HTTP, not HTTPS
 	httpUrl := strings.Replace(validConfigUrl, "https", "http", 1)
 	url = httpUrl + validPath
-	req = newTestRequest(t, "GET", url, nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "HTTP, not HTTPS request")
 
 	// Non-GET request
 	url = validConfigUrl + validPath
-	req = newTestRequest(t, "POST", url, nil)
+	req = httptest.NewRequestWithContext(t.Context(), "POST", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "non-GET request")
 }

--- a/internal/handlers/maven_repository_test.go
+++ b/internal/handlers/maven_repository_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/dependabot/proxy/internal/config"
@@ -37,51 +38,51 @@ func TestMavenRepositoryHandler(t *testing.T) {
 	}
 	handler := NewMavenRepositoryHandler(credentials)
 
-	req := newTestRequest(t, "GET", "https://corp.dependabot.com/packages/somepkg", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://corp.dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, dependabotUser, dependabotPassword, "dependabot repository request")
 
-	req = newTestRequest(t, "GET", "https://corp.deltaforce.com/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://corp.deltaforce.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "deltaforce repository request")
 
 	// Path mismatch
-	req = newTestRequest(t, "GET", "https://corp.dependabot.com/foo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://corp.dependabot.com/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "path mismatch")
 
 	// Missing repo subdomain
-	req = newTestRequest(t, "GET", "https://dependabot.com/packages/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = newTestRequest(t, "GET", "http://corp.dependabot.com/packages/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "http://corp.dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, dependabotUser, dependabotPassword, "dependabot repository http request")
 
 	// HTTP, not HTTPS, missing submomain
-	req = newTestRequest(t, "GET", "http://dependabot.com/packages/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "http://dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// Not a GET request
-	req = newTestRequest(t, "POST", "https://corp.dependabot.com/packages/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "POST", "https://corp.dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "post request")
 
 	// No username and password in credential
-	req = newTestRequest(t, "GET", "https://open.dependabot.com/maven2/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://open.dependabot.com/maven2/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "no username and password")
 
 	// Azure DevOps
-	req = newTestRequest(t, "GET", "https://pkgs.dev.azure.com/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://pkgs.dev.azure.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "azure devops repository request")
 
 	// Azure DevOps case insensitive
-	req = newTestRequest(t, "GET", "https://PKGS.dev.azure.com/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://PKGS.dev.azure.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "azure devops case insensitive registry request")
 }

--- a/internal/handlers/maven_repository_test.go
+++ b/internal/handlers/maven_repository_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"net/http/httptest"
 	"testing"
 
 	"github.com/dependabot/proxy/internal/config"
@@ -38,51 +37,51 @@ func TestMavenRepositoryHandler(t *testing.T) {
 	}
 	handler := NewMavenRepositoryHandler(credentials)
 
-	req := httptest.NewRequest("GET", "https://corp.dependabot.com/packages/somepkg", nil)
+	req := newTestRequest(t, "GET", "https://corp.dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, dependabotUser, dependabotPassword, "dependabot repository request")
 
-	req = httptest.NewRequest("GET", "https://corp.deltaforce.com/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://corp.deltaforce.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "deltaforce repository request")
 
 	// Path mismatch
-	req = httptest.NewRequest("GET", "https://corp.dependabot.com/foo", nil)
+	req = newTestRequest(t, "GET", "https://corp.dependabot.com/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "path mismatch")
 
 	// Missing repo subdomain
-	req = httptest.NewRequest("GET", "https://dependabot.com/packages/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = httptest.NewRequest("GET", "http://corp.dependabot.com/packages/somepkg", nil)
+	req = newTestRequest(t, "GET", "http://corp.dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, dependabotUser, dependabotPassword, "dependabot repository http request")
 
 	// HTTP, not HTTPS, missing submomain
-	req = httptest.NewRequest("GET", "http://dependabot.com/packages/somepkg", nil)
+	req = newTestRequest(t, "GET", "http://dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// Not a GET request
-	req = httptest.NewRequest("POST", "https://corp.dependabot.com/packages/somepkg", nil)
+	req = newTestRequest(t, "POST", "https://corp.dependabot.com/packages/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "post request")
 
 	// No username and password in credential
-	req = httptest.NewRequest("GET", "https://open.dependabot.com/maven2/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://open.dependabot.com/maven2/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "no username and password")
 
 	// Azure DevOps
-	req = httptest.NewRequest("GET", "https://pkgs.dev.azure.com/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://pkgs.dev.azure.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "azure devops repository request")
 
 	// Azure DevOps case insensitive
-	req = httptest.NewRequest("GET", "https://PKGS.dev.azure.com/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://PKGS.dev.azure.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "azure devops case insensitive registry request")
 }

--- a/internal/handlers/npm_registry_test.go
+++ b/internal/handlers/npm_registry_test.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"fmt"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/dependabot/proxy/internal/config"
@@ -43,48 +42,48 @@ func TestNPMRegistryHandler(t *testing.T) {
 	}
 	handler := NewNPMRegistryHandler(credentials)
 
-	req := httptest.NewRequest("GET", "https://registry.npmjs.org/private-package", nil)
+	req := newTestRequest(t, "GET", "https://registry.npmjs.org/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", npmjsOrgToken, "valid registry request")
 
-	req = httptest.NewRequest("GET", "https://registry.yarnpkg.com/private-package", nil)
+	req = newTestRequest(t, "GET", "https://registry.yarnpkg.com/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", npmjsOrgToken, "yarn registry request, given npmjs.org creds")
 
-	req = httptest.NewRequest("GET", "https://example.com/reg-path/private-package", nil)
+	req = newTestRequest(t, "GET", "https://example.com/reg-path/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", privateRegToken, "valid registry request with port and path")
 
-	req = httptest.NewRequest("GET", "https://example.org/reg-path/private-package", nil)
+	req = newTestRequest(t, "GET", "https://example.org/reg-path/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", privateRegToken, "valid registry request with port and path")
 
 	// Sibling path on the same host should NOT receive credentials from /reg-path
-	req = httptest.NewRequest("GET", "https://example.com/other-path/private-package", nil)
+	req = newTestRequest(t, "GET", "https://example.com/other-path/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "sibling path should not match")
 
-	req = httptest.NewRequest("GET", "https://nexus.some-company.com/private-package", nil)
+	req = newTestRequest(t, "GET", "https://nexus.some-company.com/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, nexusUser, nexusPassword, "http basic auth")
 
 	// Different subdomain
-	req = httptest.NewRequest("GET", "https://foo.example.com/reg-path/private-package", nil)
+	req = newTestRequest(t, "GET", "https://foo.example.com/reg-path/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = httptest.NewRequest("GET", "http://example.com/reg-path/private-package", nil)
+	req = newTestRequest(t, "GET", "http://example.com/reg-path/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "http, not https")
 
 	// Azure DevOps
-	req = httptest.NewRequest("GET", "https://pkgs.dev.azure.com/private-package", nil)
+	req = newTestRequest(t, "GET", "https://pkgs.dev.azure.com/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, nexusUser, nexusPassword, "azure devops registry request")
 
 	// Azure DevOps case insensitive
-	req = httptest.NewRequest("GET", "https://PKGS.dev.azure.com/private-package", nil)
+	req = newTestRequest(t, "GET", "https://PKGS.dev.azure.com/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, nexusUser, nexusPassword, "azure devops case insensitive registry request")
 }
@@ -107,17 +106,17 @@ func TestNPMRegistryHandler_SameHostDifferentPaths(t *testing.T) {
 	handler := NewNPMRegistryHandler(credentials)
 
 	// Request to team-a path should use team-a token
-	req := httptest.NewRequest("GET", "https://artifactory.example.com/api/npm/team-a-npm/@scope/pkg", nil)
+	req := newTestRequest(t, "GET", "https://artifactory.example.com/api/npm/team-a-npm/@scope/pkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", teamAToken, "team-a path should use team-a token")
 
 	// Request to team-b path should use team-b token, not team-a
-	req = httptest.NewRequest("GET", "https://artifactory.example.com/api/npm/team-b-npm/@scope/pkg", nil)
+	req = newTestRequest(t, "GET", "https://artifactory.example.com/api/npm/team-b-npm/@scope/pkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", teamBToken, "team-b path should use team-b token")
 
 	// Request to unrelated path should not be authenticated
-	req = httptest.NewRequest("GET", "https://artifactory.example.com/api/npm/team-c-npm/@scope/pkg", nil)
+	req = newTestRequest(t, "GET", "https://artifactory.example.com/api/npm/team-c-npm/@scope/pkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "unrelated path should not match any credential")
 }

--- a/internal/handlers/npm_registry_test.go
+++ b/internal/handlers/npm_registry_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"fmt"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/dependabot/proxy/internal/config"
@@ -42,48 +43,48 @@ func TestNPMRegistryHandler(t *testing.T) {
 	}
 	handler := NewNPMRegistryHandler(credentials)
 
-	req := newTestRequest(t, "GET", "https://registry.npmjs.org/private-package", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.npmjs.org/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", npmjsOrgToken, "valid registry request")
 
-	req = newTestRequest(t, "GET", "https://registry.yarnpkg.com/private-package", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.yarnpkg.com/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", npmjsOrgToken, "yarn registry request, given npmjs.org creds")
 
-	req = newTestRequest(t, "GET", "https://example.com/reg-path/private-package", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://example.com/reg-path/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", privateRegToken, "valid registry request with port and path")
 
-	req = newTestRequest(t, "GET", "https://example.org/reg-path/private-package", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://example.org/reg-path/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", privateRegToken, "valid registry request with port and path")
 
 	// Sibling path on the same host should NOT receive credentials from /reg-path
-	req = newTestRequest(t, "GET", "https://example.com/other-path/private-package", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://example.com/other-path/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "sibling path should not match")
 
-	req = newTestRequest(t, "GET", "https://nexus.some-company.com/private-package", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://nexus.some-company.com/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, nexusUser, nexusPassword, "http basic auth")
 
 	// Different subdomain
-	req = newTestRequest(t, "GET", "https://foo.example.com/reg-path/private-package", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://foo.example.com/reg-path/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = newTestRequest(t, "GET", "http://example.com/reg-path/private-package", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "http://example.com/reg-path/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "http, not https")
 
 	// Azure DevOps
-	req = newTestRequest(t, "GET", "https://pkgs.dev.azure.com/private-package", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://pkgs.dev.azure.com/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, nexusUser, nexusPassword, "azure devops registry request")
 
 	// Azure DevOps case insensitive
-	req = newTestRequest(t, "GET", "https://PKGS.dev.azure.com/private-package", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://PKGS.dev.azure.com/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, nexusUser, nexusPassword, "azure devops case insensitive registry request")
 }
@@ -106,17 +107,17 @@ func TestNPMRegistryHandler_SameHostDifferentPaths(t *testing.T) {
 	handler := NewNPMRegistryHandler(credentials)
 
 	// Request to team-a path should use team-a token
-	req := newTestRequest(t, "GET", "https://artifactory.example.com/api/npm/team-a-npm/@scope/pkg", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://artifactory.example.com/api/npm/team-a-npm/@scope/pkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", teamAToken, "team-a path should use team-a token")
 
 	// Request to team-b path should use team-b token, not team-a
-	req = newTestRequest(t, "GET", "https://artifactory.example.com/api/npm/team-b-npm/@scope/pkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://artifactory.example.com/api/npm/team-b-npm/@scope/pkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", teamBToken, "team-b path should use team-b token")
 
 	// Request to unrelated path should not be authenticated
-	req = newTestRequest(t, "GET", "https://artifactory.example.com/api/npm/team-c-npm/@scope/pkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://artifactory.example.com/api/npm/team-c-npm/@scope/pkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "unrelated path should not match any credential")
 }

--- a/internal/handlers/nuget_feed_test.go
+++ b/internal/handlers/nuget_feed_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -137,84 +138,84 @@ func TestNugetFeedHandler(t *testing.T) {
 	assert.False(t, strings.Contains(logContents, "* authenticating nuget feed request (host: api.nuget.org, bearer auth)"), "don't authenticate a feed without a token or password")
 	assert.True(t, strings.Contains(logContents, "unauthorized for nuget feed https://nuget.example.com/auth-required/v3"), "authentication failure is reported")
 
-	req := newTestRequest(t, "GET", "https://corp.dependabot.com/nuget", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://corp.dependabot.com/nuget", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", dependabotToken, "dependabot feed request")
 
-	req = newTestRequest(t, "GET", "https://corp.deltaforce.com/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://corp.deltaforce.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "deltaforce feed request")
 
 	// Base URL listed in the v3 feed index
-	req = newTestRequest(t, "GET", "https://pkg-search.dependabot.com/query", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://pkg-search.dependabot.com/query", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", dependabotToken, "url listed in feed index")
 
 	// Other URL listed in the v3 feed index
-	req = newTestRequest(t, "GET", "https://pkg-search.dependabot.com/autocomplete", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://pkg-search.dependabot.com/autocomplete", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", dependabotToken, "other url in feed index")
 
 	// Template URL not authenticated
-	req = newTestRequest(t, "GET", "https://pkg-search.dependabot.com/some.package/1.2.3/ReportAbuse", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://pkg-search.dependabot.com/some.package/1.2.3/ReportAbuse", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "Template URL")
 
 	// v2 API
-	req = newTestRequest(t, "GET", "https://nuget.example.com/v2/FindPackagesById()?Id='Some.Package'", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://nuget.example.com/v2/FindPackagesById()?Id='Some.Package'", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", dependabotToken, "authenticated v2 API")
 
 	// v2 API - redirected
-	req = newTestRequest(t, "GET", "https://redirected.example.com/v2/FindPackagesById()?Id='Some.Package'", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://redirected.example.com/v2/FindPackagesById()?Id='Some.Package'", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", dependabotToken, "redirected authenticated v2 API")
 
 	// Path mismatch
-	req = newTestRequest(t, "GET", "https://corp.dependabot.com/foo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://corp.dependabot.com/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "Path mismatch")
 
 	// Missing repo subdomain
-	req = newTestRequest(t, "GET", "https://dependabot.com/nuget", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://dependabot.com/nuget", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = newTestRequest(t, "GET", "http://corp.dependabot.com/nuget", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "http://corp.dependabot.com/nuget", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", dependabotToken, "dependabot feed http request")
 
 	// HTTP, not HTTPS, path mismatch
-	req = newTestRequest(t, "GET", "http://corp.dependabot.com/feed", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "http://corp.dependabot.com/feed", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "Path mismatch")
 
 	// Not a GET request
-	req = newTestRequest(t, "POST", "https://corp.dependabot.com/nuget", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "POST", "https://corp.dependabot.com/nuget", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "post request")
 
 	// Azure DevOps
-	req = newTestRequest(t, "GET", "https://pkgs.dev.azure.com/dependabot/_packaging/dependabot/nuget/v3/index.json", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://pkgs.dev.azure.com/dependabot/_packaging/dependabot/nuget/v3/index.json", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "Azure DevOps feed request")
 
 	// Azure DevOps case insensitive
-	req = newTestRequest(t, "GET", "https://PKGS.dev.azure.com/dependabot/_packaging/dependabot/nuget/v3/index.json", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://PKGS.dev.azure.com/dependabot/_packaging/dependabot/nuget/v3/index.json", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "Azure DevOps case insensitive feed request")
 
 	// Reset buffer to catch log contents
 	buf.Reset()
-	req = newTestRequest(t, "GET", "https://pkgs.dev.azure.com/example/public/_packaging/some-feed/nuget/v3/some.package/index.json", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://pkgs.dev.azure.com/example/public/_packaging/some-feed/nuget/v3/some.package/index.json", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, "", dependabotToken, "Azure DevOps token handling")
 	logContents = buf.String()
 	assert.True(t, strings.Contains(logContents, ", basic auth for Azure DevOps)"), "expected Azure DevOps token handling")
 
 	// Check Azure token edge case in which it has a prepended ":" and is treated as a password successfully
-	req = newTestRequest(t, "GET", "https://pkgs.dev.azure.com/example/public/_packaging/some-feed2/nuget/v3/some.package/index.json", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://pkgs.dev.azure.com/example/public/_packaging/some-feed2/nuget/v3/some.package/index.json", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, "", dependabotToken, "Azure DevOps token handling")
 }

--- a/internal/handlers/nuget_feed_test.go
+++ b/internal/handlers/nuget_feed_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -138,84 +137,84 @@ func TestNugetFeedHandler(t *testing.T) {
 	assert.False(t, strings.Contains(logContents, "* authenticating nuget feed request (host: api.nuget.org, bearer auth)"), "don't authenticate a feed without a token or password")
 	assert.True(t, strings.Contains(logContents, "unauthorized for nuget feed https://nuget.example.com/auth-required/v3"), "authentication failure is reported")
 
-	req := httptest.NewRequest("GET", "https://corp.dependabot.com/nuget", nil)
+	req := newTestRequest(t, "GET", "https://corp.dependabot.com/nuget", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", dependabotToken, "dependabot feed request")
 
-	req = httptest.NewRequest("GET", "https://corp.deltaforce.com/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://corp.deltaforce.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "deltaforce feed request")
 
 	// Base URL listed in the v3 feed index
-	req = httptest.NewRequest("GET", "https://pkg-search.dependabot.com/query", nil)
+	req = newTestRequest(t, "GET", "https://pkg-search.dependabot.com/query", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", dependabotToken, "url listed in feed index")
 
 	// Other URL listed in the v3 feed index
-	req = httptest.NewRequest("GET", "https://pkg-search.dependabot.com/autocomplete", nil)
+	req = newTestRequest(t, "GET", "https://pkg-search.dependabot.com/autocomplete", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", dependabotToken, "other url in feed index")
 
 	// Template URL not authenticated
-	req = httptest.NewRequest("GET", "https://pkg-search.dependabot.com/some.package/1.2.3/ReportAbuse", nil)
+	req = newTestRequest(t, "GET", "https://pkg-search.dependabot.com/some.package/1.2.3/ReportAbuse", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "Template URL")
 
 	// v2 API
-	req = httptest.NewRequest("GET", "https://nuget.example.com/v2/FindPackagesById()?Id='Some.Package'", nil)
+	req = newTestRequest(t, "GET", "https://nuget.example.com/v2/FindPackagesById()?Id='Some.Package'", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", dependabotToken, "authenticated v2 API")
 
 	// v2 API - redirected
-	req = httptest.NewRequest("GET", "https://redirected.example.com/v2/FindPackagesById()?Id='Some.Package'", nil)
+	req = newTestRequest(t, "GET", "https://redirected.example.com/v2/FindPackagesById()?Id='Some.Package'", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", dependabotToken, "redirected authenticated v2 API")
 
 	// Path mismatch
-	req = httptest.NewRequest("GET", "https://corp.dependabot.com/foo", nil)
+	req = newTestRequest(t, "GET", "https://corp.dependabot.com/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "Path mismatch")
 
 	// Missing repo subdomain
-	req = httptest.NewRequest("GET", "https://dependabot.com/nuget", nil)
+	req = newTestRequest(t, "GET", "https://dependabot.com/nuget", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = httptest.NewRequest("GET", "http://corp.dependabot.com/nuget", nil)
+	req = newTestRequest(t, "GET", "http://corp.dependabot.com/nuget", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", dependabotToken, "dependabot feed http request")
 
 	// HTTP, not HTTPS, path mismatch
-	req = httptest.NewRequest("GET", "http://corp.dependabot.com/feed", nil)
+	req = newTestRequest(t, "GET", "http://corp.dependabot.com/feed", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "Path mismatch")
 
 	// Not a GET request
-	req = httptest.NewRequest("POST", "https://corp.dependabot.com/nuget", nil)
+	req = newTestRequest(t, "POST", "https://corp.dependabot.com/nuget", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "post request")
 
 	// Azure DevOps
-	req = httptest.NewRequest("GET", "https://pkgs.dev.azure.com/dependabot/_packaging/dependabot/nuget/v3/index.json", nil)
+	req = newTestRequest(t, "GET", "https://pkgs.dev.azure.com/dependabot/_packaging/dependabot/nuget/v3/index.json", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "Azure DevOps feed request")
 
 	// Azure DevOps case insensitive
-	req = httptest.NewRequest("GET", "https://PKGS.dev.azure.com/dependabot/_packaging/dependabot/nuget/v3/index.json", nil)
+	req = newTestRequest(t, "GET", "https://PKGS.dev.azure.com/dependabot/_packaging/dependabot/nuget/v3/index.json", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "Azure DevOps case insensitive feed request")
 
 	// Reset buffer to catch log contents
 	buf.Reset()
-	req = httptest.NewRequest("GET", "https://pkgs.dev.azure.com/example/public/_packaging/some-feed/nuget/v3/some.package/index.json", nil)
+	req = newTestRequest(t, "GET", "https://pkgs.dev.azure.com/example/public/_packaging/some-feed/nuget/v3/some.package/index.json", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, "", dependabotToken, "Azure DevOps token handling")
 	logContents = buf.String()
 	assert.True(t, strings.Contains(logContents, ", basic auth for Azure DevOps)"), "expected Azure DevOps token handling")
 
 	// Check Azure token edge case in which it has a prepended ":" and is treated as a password successfully
-	req = httptest.NewRequest("GET", "https://pkgs.dev.azure.com/example/public/_packaging/some-feed2/nuget/v3/some.package/index.json", nil)
+	req = newTestRequest(t, "GET", "https://pkgs.dev.azure.com/example/public/_packaging/some-feed2/nuget/v3/some.package/index.json", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, "", dependabotToken, "Azure DevOps token handling")
 }

--- a/internal/handlers/oidc_handling_test.go
+++ b/internal/handlers/oidc_handling_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -1667,7 +1668,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 
 			// check URLs are authenticated
 			for _, urlToAuth := range tc.urlsToAuthenticate {
-				req := newTestRequest(t, "GET", urlToAuth, nil)
+				req := httptest.NewRequestWithContext(t.Context(), "GET", urlToAuth, nil)
 				req = handleRequestAndClose(handler, req, nil)
 				switch tc.provider {
 				case "cloudsmith":
@@ -1731,12 +1732,12 @@ func TestPythonOIDCSimpleSuffixStripping(t *testing.T) {
 	handler := NewPythonIndexHandler(creds)
 
 	// /+simple/ should be stripped → registered as /org/feed-A/
-	reqA := newTestRequest(t, "GET", "https://pkgs.example.com/org/feed-A/pkg/a", nil)
+	reqA := httptest.NewRequestWithContext(t.Context(), "GET", "https://pkgs.example.com/org/feed-A/pkg/a", nil)
 	reqA = handleRequestAndClose(handler, reqA, nil)
 	assertHasTokenAuth(t, reqA, "Bearer", "__token_A__", "feed-A request should use token A")
 
 	// /simple should be stripped → registered as /org/feed-B/
-	reqB := newTestRequest(t, "GET", "https://pkgs.example.com/org/feed-B/pkg/b", nil)
+	reqB := httptest.NewRequestWithContext(t.Context(), "GET", "https://pkgs.example.com/org/feed-B/pkg/b", nil)
 	reqB = handleRequestAndClose(handler, reqB, nil)
 	assertHasTokenAuth(t, reqB, "Bearer", "__token_B__", "feed-B request should use token B")
 }
@@ -1767,7 +1768,7 @@ func TestPythonOIDCAuthenticatesDiscoveredDownloadPrefix(t *testing.T) {
 	})
 
 	proxyCtx := &goproxy.ProxyCtx{}
-	indexReq := newTestRequest(t,
+	indexReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
 		"https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
 		nil)
@@ -1790,7 +1791,7 @@ func TestPythonOIDCAuthenticatesDiscoveredDownloadPrefix(t *testing.T) {
 	}
 	handler.HandleResponse(indexResp, proxyCtx)
 
-	downloadReq := newTestRequest(t,
+	downloadReq := httptest.NewRequestWithContext(t.Context(),
 		"HEAD",
 		"https://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
 		nil)
@@ -1840,12 +1841,12 @@ func TestNPMOIDCSameHostDifferentPaths(t *testing.T) {
 	handler := NewNPMRegistryHandler(creds)
 
 	// Request to feed-A path should get token A
-	reqA := newTestRequest(t, "GET", "https://pkgs.example.com/org/feed-A/some-package", nil)
+	reqA := httptest.NewRequestWithContext(t.Context(), "GET", "https://pkgs.example.com/org/feed-A/some-package", nil)
 	reqA = handleRequestAndClose(handler, reqA, nil)
 	assertHasTokenAuth(t, reqA, "Bearer", "__token_A__", "feed-A should use token A")
 
 	// Request to feed-B path should get token B
-	reqB := newTestRequest(t, "GET", "https://pkgs.example.com/org/feed-B/some-package", nil)
+	reqB := httptest.NewRequestWithContext(t.Context(), "GET", "https://pkgs.example.com/org/feed-B/some-package", nil)
 	reqB = handleRequestAndClose(handler, reqB, nil)
 	assertHasTokenAuth(t, reqB, "Bearer", "__token_B__", "feed-B should use token B")
 }
@@ -1893,12 +1894,12 @@ func TestTerraformOIDCSameHostDifferentPaths(t *testing.T) {
 	handler := NewTerraformRegistryHandler(creds)
 
 	// Request to feed-A path should get token A
-	reqA := newTestRequest(t, "GET", "https://terraform.example.com/org/feed-A/v1/providers/org/name", nil)
+	reqA := httptest.NewRequestWithContext(t.Context(), "GET", "https://terraform.example.com/org/feed-A/v1/providers/org/name", nil)
 	reqA = handleRequestAndClose(handler, reqA, nil)
 	assertHasTokenAuth(t, reqA, "Bearer", "__token_A__", "feed-A should use token A")
 
 	// Request to feed-B path should get token B
-	reqB := newTestRequest(t, "GET", "https://terraform.example.com/org/feed-B/v1/providers/org/name", nil)
+	reqB := httptest.NewRequestWithContext(t.Context(), "GET", "https://terraform.example.com/org/feed-B/v1/providers/org/name", nil)
 	reqB = handleRequestAndClose(handler, reqB, nil)
 	assertHasTokenAuth(t, reqB, "Bearer", "__token_B__", "feed-B should use token B")
 }

--- a/internal/handlers/oidc_handling_test.go
+++ b/internal/handlers/oidc_handling_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -1668,7 +1667,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 
 			// check URLs are authenticated
 			for _, urlToAuth := range tc.urlsToAuthenticate {
-				req := httptest.NewRequest("GET", urlToAuth, nil)
+				req := newTestRequest(t, "GET", urlToAuth, nil)
 				req = handleRequestAndClose(handler, req, nil)
 				switch tc.provider {
 				case "cloudsmith":
@@ -1732,12 +1731,12 @@ func TestPythonOIDCSimpleSuffixStripping(t *testing.T) {
 	handler := NewPythonIndexHandler(creds)
 
 	// /+simple/ should be stripped → registered as /org/feed-A/
-	reqA := httptest.NewRequest("GET", "https://pkgs.example.com/org/feed-A/pkg/a", nil)
+	reqA := newTestRequest(t, "GET", "https://pkgs.example.com/org/feed-A/pkg/a", nil)
 	reqA = handleRequestAndClose(handler, reqA, nil)
 	assertHasTokenAuth(t, reqA, "Bearer", "__token_A__", "feed-A request should use token A")
 
 	// /simple should be stripped → registered as /org/feed-B/
-	reqB := httptest.NewRequest("GET", "https://pkgs.example.com/org/feed-B/pkg/b", nil)
+	reqB := newTestRequest(t, "GET", "https://pkgs.example.com/org/feed-B/pkg/b", nil)
 	reqB = handleRequestAndClose(handler, reqB, nil)
 	assertHasTokenAuth(t, reqB, "Bearer", "__token_B__", "feed-B request should use token B")
 }
@@ -1768,11 +1767,11 @@ func TestPythonOIDCAuthenticatesDiscoveredDownloadPrefix(t *testing.T) {
 	})
 
 	proxyCtx := &goproxy.ProxyCtx{}
-	indexReq := httptest.NewRequest(
+	indexReq := newTestRequest(t,
 		"GET",
 		"https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
-		nil,
-	)
+		nil)
+
 	indexReq = handleRequestAndClose(handler, indexReq, proxyCtx)
 	assertHasTokenAuth(t, indexReq, "Bearer", "__oidc_token__", "simple index request should use OIDC token")
 
@@ -1791,11 +1790,11 @@ func TestPythonOIDCAuthenticatesDiscoveredDownloadPrefix(t *testing.T) {
 	}
 	handler.HandleResponse(indexResp, proxyCtx)
 
-	downloadReq := httptest.NewRequest(
+	downloadReq := newTestRequest(t,
 		"HEAD",
 		"https://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
-		nil,
-	)
+		nil)
+
 	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})
 	assertHasTokenAuth(t, downloadReq, "Bearer", "__oidc_token__", "discovered download request should use OIDC token")
 }
@@ -1841,12 +1840,12 @@ func TestNPMOIDCSameHostDifferentPaths(t *testing.T) {
 	handler := NewNPMRegistryHandler(creds)
 
 	// Request to feed-A path should get token A
-	reqA := httptest.NewRequest("GET", "https://pkgs.example.com/org/feed-A/some-package", nil)
+	reqA := newTestRequest(t, "GET", "https://pkgs.example.com/org/feed-A/some-package", nil)
 	reqA = handleRequestAndClose(handler, reqA, nil)
 	assertHasTokenAuth(t, reqA, "Bearer", "__token_A__", "feed-A should use token A")
 
 	// Request to feed-B path should get token B
-	reqB := httptest.NewRequest("GET", "https://pkgs.example.com/org/feed-B/some-package", nil)
+	reqB := newTestRequest(t, "GET", "https://pkgs.example.com/org/feed-B/some-package", nil)
 	reqB = handleRequestAndClose(handler, reqB, nil)
 	assertHasTokenAuth(t, reqB, "Bearer", "__token_B__", "feed-B should use token B")
 }
@@ -1894,12 +1893,12 @@ func TestTerraformOIDCSameHostDifferentPaths(t *testing.T) {
 	handler := NewTerraformRegistryHandler(creds)
 
 	// Request to feed-A path should get token A
-	reqA := httptest.NewRequest("GET", "https://terraform.example.com/org/feed-A/v1/providers/org/name", nil)
+	reqA := newTestRequest(t, "GET", "https://terraform.example.com/org/feed-A/v1/providers/org/name", nil)
 	reqA = handleRequestAndClose(handler, reqA, nil)
 	assertHasTokenAuth(t, reqA, "Bearer", "__token_A__", "feed-A should use token A")
 
 	// Request to feed-B path should get token B
-	reqB := httptest.NewRequest("GET", "https://terraform.example.com/org/feed-B/v1/providers/org/name", nil)
+	reqB := newTestRequest(t, "GET", "https://terraform.example.com/org/feed-B/v1/providers/org/name", nil)
 	reqB = handleRequestAndClose(handler, reqB, nil)
 	assertHasTokenAuth(t, reqB, "Bearer", "__token_B__", "feed-B should use token B")
 }

--- a/internal/handlers/opentofu_registry_test.go
+++ b/internal/handlers/opentofu_registry_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -67,7 +66,7 @@ func TestOpenTofuRegistryHandler(t *testing.T) {
 		t.Run(strings.Join([]string{tt.registryType, tt.host, tt.token}, " "), func(t *testing.T) {
 			handler := NewOpenTofuRegistryHandler(tt.credentials)
 
-			request := handleRequestAndClose(handler, httptest.NewRequest("GET", tt.url, nil), nil)
+			request := handleRequestAndClose(handler, newTestRequest(t, "GET", tt.url, nil), nil)
 
 			assert.Equal(t, tt.authorization, request.Header.Get("Authorization"))
 		})
@@ -77,7 +76,7 @@ func TestOpenTofuRegistryHandler(t *testing.T) {
 		handler := NewOpenTofuRegistryHandler(config.Credentials{})
 
 		url := "https://registry.opentofu.org/v1/providers/org/name/versions"
-		request := handleRequestAndClose(handler, httptest.NewRequest("GET", url, nil), nil)
+		request := handleRequestAndClose(handler, newTestRequest(t, "GET", url, nil), nil)
 
 		assert.Equal(t, "", request.Header.Get("Authorization"), "should be empty")
 	})
@@ -90,15 +89,15 @@ func TestOpenTofuRegistryHandler(t *testing.T) {
 		handler := NewOpenTofuRegistryHandler(credentials)
 
 		// Request to org1 path should use org1 token
-		req1 := handleRequestAndClose(handler, httptest.NewRequest("GET", "https://registry.example.com/org1/v1/providers/foo", nil), nil)
+		req1 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://registry.example.com/org1/v1/providers/foo", nil), nil)
 		assert.Equal(t, "Bearer token-org1", req1.Header.Get("Authorization"), "should use org1 token")
 
 		// Request to org2 path should use org2 token
-		req2 := handleRequestAndClose(handler, httptest.NewRequest("GET", "https://registry.example.com/org2/v1/providers/bar", nil), nil)
+		req2 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://registry.example.com/org2/v1/providers/bar", nil), nil)
 		assert.Equal(t, "Bearer token-org2", req2.Header.Get("Authorization"), "should use org2 token")
 
 		// Request to unmatched path should not be authenticated
-		req3 := handleRequestAndClose(handler, httptest.NewRequest("GET", "https://registry.example.com/org3/v1/providers/baz", nil), nil)
+		req3 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://registry.example.com/org3/v1/providers/baz", nil), nil)
 		assert.Equal(t, "", req3.Header.Get("Authorization"), "should not be authenticated")
 	})
 
@@ -129,14 +128,14 @@ func TestOpenTofuRegistryHandler(t *testing.T) {
 		assert.Equal(t, "https://registry.example.com/org1", handler.credentials[0].url, "longer path should be first")
 		assert.Equal(t, "https://registry.example.com/org", handler.credentials[1].url, "shorter path should be second")
 
-		req1 := handleRequestAndClose(handler, httptest.NewRequest("GET", "https://registry.example.com/org1/v1/providers/foo", nil), nil)
+		req1 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://registry.example.com/org1/v1/providers/foo", nil), nil)
 		assert.Equal(t, "Bearer token-org1", req1.Header.Get("Authorization"), "/org1 path should use org1 token")
 
-		req2 := handleRequestAndClose(handler, httptest.NewRequest("GET", "https://registry.example.com/org/v1/providers/bar", nil), nil)
+		req2 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://registry.example.com/org/v1/providers/bar", nil), nil)
 		assert.Equal(t, "Bearer token-org", req2.Header.Get("Authorization"), "/org path should use org token")
 
 		// Request to /org123 should NOT match /org1 or /org (path boundary check)
-		req3 := handleRequestAndClose(handler, httptest.NewRequest("GET", "https://registry.example.com/org123/v1/providers/baz", nil), nil)
+		req3 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://registry.example.com/org123/v1/providers/baz", nil), nil)
 		assert.Equal(t, "", req3.Header.Get("Authorization"), "/org123 should not match /org or /org1")
 	})
 }

--- a/internal/handlers/opentofu_registry_test.go
+++ b/internal/handlers/opentofu_registry_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -66,7 +67,7 @@ func TestOpenTofuRegistryHandler(t *testing.T) {
 		t.Run(strings.Join([]string{tt.registryType, tt.host, tt.token}, " "), func(t *testing.T) {
 			handler := NewOpenTofuRegistryHandler(tt.credentials)
 
-			request := handleRequestAndClose(handler, newTestRequest(t, "GET", tt.url, nil), nil)
+			request := handleRequestAndClose(handler, httptest.NewRequestWithContext(t.Context(), "GET", tt.url, nil), nil)
 
 			assert.Equal(t, tt.authorization, request.Header.Get("Authorization"))
 		})
@@ -76,7 +77,7 @@ func TestOpenTofuRegistryHandler(t *testing.T) {
 		handler := NewOpenTofuRegistryHandler(config.Credentials{})
 
 		url := "https://registry.opentofu.org/v1/providers/org/name/versions"
-		request := handleRequestAndClose(handler, newTestRequest(t, "GET", url, nil), nil)
+		request := handleRequestAndClose(handler, httptest.NewRequestWithContext(t.Context(), "GET", url, nil), nil)
 
 		assert.Equal(t, "", request.Header.Get("Authorization"), "should be empty")
 	})
@@ -89,15 +90,15 @@ func TestOpenTofuRegistryHandler(t *testing.T) {
 		handler := NewOpenTofuRegistryHandler(credentials)
 
 		// Request to org1 path should use org1 token
-		req1 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://registry.example.com/org1/v1/providers/foo", nil), nil)
+		req1 := handleRequestAndClose(handler, httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.example.com/org1/v1/providers/foo", nil), nil)
 		assert.Equal(t, "Bearer token-org1", req1.Header.Get("Authorization"), "should use org1 token")
 
 		// Request to org2 path should use org2 token
-		req2 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://registry.example.com/org2/v1/providers/bar", nil), nil)
+		req2 := handleRequestAndClose(handler, httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.example.com/org2/v1/providers/bar", nil), nil)
 		assert.Equal(t, "Bearer token-org2", req2.Header.Get("Authorization"), "should use org2 token")
 
 		// Request to unmatched path should not be authenticated
-		req3 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://registry.example.com/org3/v1/providers/baz", nil), nil)
+		req3 := handleRequestAndClose(handler, httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.example.com/org3/v1/providers/baz", nil), nil)
 		assert.Equal(t, "", req3.Header.Get("Authorization"), "should not be authenticated")
 	})
 
@@ -128,14 +129,14 @@ func TestOpenTofuRegistryHandler(t *testing.T) {
 		assert.Equal(t, "https://registry.example.com/org1", handler.credentials[0].url, "longer path should be first")
 		assert.Equal(t, "https://registry.example.com/org", handler.credentials[1].url, "shorter path should be second")
 
-		req1 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://registry.example.com/org1/v1/providers/foo", nil), nil)
+		req1 := handleRequestAndClose(handler, httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.example.com/org1/v1/providers/foo", nil), nil)
 		assert.Equal(t, "Bearer token-org1", req1.Header.Get("Authorization"), "/org1 path should use org1 token")
 
-		req2 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://registry.example.com/org/v1/providers/bar", nil), nil)
+		req2 := handleRequestAndClose(handler, httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.example.com/org/v1/providers/bar", nil), nil)
 		assert.Equal(t, "Bearer token-org", req2.Header.Get("Authorization"), "/org path should use org token")
 
 		// Request to /org123 should NOT match /org1 or /org (path boundary check)
-		req3 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://registry.example.com/org123/v1/providers/baz", nil), nil)
+		req3 := handleRequestAndClose(handler, httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.example.com/org123/v1/providers/baz", nil), nil)
 		assert.Equal(t, "", req3.Header.Get("Authorization"), "/org123 should not match /org or /org1")
 	})
 }

--- a/internal/handlers/pub_repository_test.go
+++ b/internal/handlers/pub_repository_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -49,49 +50,49 @@ func TestPubRepositoryHandler(t *testing.T) {
 
 	// valid request, should authenticate
 	url := validURL
-	req := newTestRequest(t, "GET", url, nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", token, "valid url request")
 
 	// valid request plus a sub-path, should authenticate
 	url = validURL + "/path"
-	req = newTestRequest(t, "GET", url, nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", token, "valid url with sub-path request")
 
 	// valid request for registry without protocol, should authenticate
 	url = "https://" + validNoProtocolURL
-	req = newTestRequest(t, "GET", url, nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", token, "valid url without protocol request")
 
 	// valid request scoped to path, should authenticate
 	url = validURLWithPath
-	req = newTestRequest(t, "GET", url, nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", token, "valid path url request")
 
 	// wrong path, shouldn't authenticate
 	url = validURLWithPathBase + "/wrong_path"
-	req = newTestRequest(t, "GET", url, nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "requests to a mismatched path should not be authenticated")
 
 	url = noTokenURL
-	req = newTestRequest(t, "GET", url, nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "should not authenticate when missing token")
 
 	// HTTP, not HTTPS
 	httpURL := strings.Replace(validURL, "https", "http", 1)
 	url = httpURL
-	req = newTestRequest(t, "GET", url, nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "HTTP, not HTTPS request")
 
 	// Non-GET request
 	url = validURL
-	req = newTestRequest(t, "POST", url, nil)
+	req = httptest.NewRequestWithContext(t.Context(), "POST", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "non-GET request")
 }

--- a/internal/handlers/pub_repository_test.go
+++ b/internal/handlers/pub_repository_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -50,49 +49,49 @@ func TestPubRepositoryHandler(t *testing.T) {
 
 	// valid request, should authenticate
 	url := validURL
-	req := httptest.NewRequest("GET", url, nil)
+	req := newTestRequest(t, "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", token, "valid url request")
 
 	// valid request plus a sub-path, should authenticate
 	url = validURL + "/path"
-	req = httptest.NewRequest("GET", url, nil)
+	req = newTestRequest(t, "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", token, "valid url with sub-path request")
 
 	// valid request for registry without protocol, should authenticate
 	url = "https://" + validNoProtocolURL
-	req = httptest.NewRequest("GET", url, nil)
+	req = newTestRequest(t, "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", token, "valid url without protocol request")
 
 	// valid request scoped to path, should authenticate
 	url = validURLWithPath
-	req = httptest.NewRequest("GET", url, nil)
+	req = newTestRequest(t, "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", token, "valid path url request")
 
 	// wrong path, shouldn't authenticate
 	url = validURLWithPathBase + "/wrong_path"
-	req = httptest.NewRequest("GET", url, nil)
+	req = newTestRequest(t, "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "requests to a mismatched path should not be authenticated")
 
 	url = noTokenURL
-	req = httptest.NewRequest("GET", url, nil)
+	req = newTestRequest(t, "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "should not authenticate when missing token")
 
 	// HTTP, not HTTPS
 	httpURL := strings.Replace(validURL, "https", "http", 1)
 	url = httpURL
-	req = httptest.NewRequest("GET", url, nil)
+	req = newTestRequest(t, "GET", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "HTTP, not HTTPS request")
 
 	// Non-GET request
 	url = validURL
-	req = httptest.NewRequest("POST", url, nil)
+	req = newTestRequest(t, "POST", url, nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "non-GET request")
 }

--- a/internal/handlers/python_index_test.go
+++ b/internal/handlers/python_index_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -54,59 +55,59 @@ func TestPythonIndexHandler(t *testing.T) {
 	}
 	handler := NewPythonIndexHandler(credentials)
 
-	req := newTestRequest(t, "GET", "https://corp.dependabot.com/pyreg", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://corp.dependabot.com/pyreg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, dependabotToken, "", "dependabot registry request")
 
-	req = newTestRequest(t, "GET", "https://corp.deltaforce.com/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://corp.deltaforce.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "deltaforce registry request")
 
-	req = newTestRequest(t, "GET", "https://example.com/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://example.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "deltaforce registry request")
 
 	// Path mismatch
-	req = newTestRequest(t, "GET", "https://corp.dependabot.com/foo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://corp.dependabot.com/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "dependabot registry request")
 
-	req = newTestRequest(t, "GET", "https://pypy.com/other/pgk/a", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://pypy.com/other/pgk/a", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "other registry request")
 
 	// Path mismatch on /+simple
-	req = newTestRequest(t, "GET", "https://pypy.com/dependabot/pgk/a", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://pypy.com/dependabot/pgk/a", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, "dependabot", "sec123", "dependabot pypy registry request")
 
 	// Path mismatch on /simple
-	req = newTestRequest(t, "GET", "https://pypy.com/simple/pgk/a", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://pypy.com/simple/pgk/a", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, "simple", "sec245", "simple pypy registry request")
 
 	// Missing repo subdomain
-	req = newTestRequest(t, "GET", "https://dependabot.com/pyreg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://dependabot.com/pyreg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = newTestRequest(t, "GET", "http://corp.dependabot.com/pyreg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "http://corp.dependabot.com/pyreg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "http, not https")
 
 	// Not a GET request
-	req = newTestRequest(t, "POST", "https://corp.dependabot.com/pyreg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "POST", "https://corp.dependabot.com/pyreg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "post request")
 
 	// Azure DevOps
-	req = newTestRequest(t, "GET", "https://pkgs.dev.azure.com/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://pkgs.dev.azure.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "azure devops registry request")
 
 	// Azure DevOps case insensitive
-	req = newTestRequest(t, "GET", "https://PKGS.dev.azure.com/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://PKGS.dev.azure.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "azure devops case insensitive registry request")
 }
@@ -121,7 +122,7 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromHTML(t *test
 	})
 
 	proxyCtx := &goproxy.ProxyCtx{}
-	indexReq := newTestRequest(t,
+	indexReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
 		"https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
 		nil)
@@ -147,7 +148,7 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromHTML(t *test
 	}
 	handler.HandleResponse(indexResp, proxyCtx)
 
-	downloadReq := newTestRequest(t,
+	downloadReq := httptest.NewRequestWithContext(t.Context(),
 		"HEAD",
 		"https://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
 		nil)
@@ -155,7 +156,7 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromHTML(t *test
 	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})
 	assertHasBasicAuth(t, downloadReq, "user", "pass", "discovered download request")
 
-	samePrefixReq := newTestRequest(t,
+	samePrefixReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
 		"https://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/another-package/2.0.0/another-package-2.0.0.whl",
 		nil)
@@ -163,7 +164,7 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromHTML(t *test
 	samePrefixReq = handleRequestAndClose(handler, samePrefixReq, &goproxy.ProxyCtx{})
 	assertHasBasicAuth(t, samePrefixReq, "user", "pass", "same discovered download prefix request")
 
-	otherOrgReq := newTestRequest(t,
+	otherOrgReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
 		"https://pkgs.example.com/other-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
 		nil)
@@ -182,7 +183,7 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromJSON(t *test
 	})
 
 	proxyCtx := &goproxy.ProxyCtx{}
-	indexReq := newTestRequest(t,
+	indexReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
 		"https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
 		nil)
@@ -205,7 +206,7 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromJSON(t *test
 	}
 	handler.HandleResponse(indexResp, proxyCtx)
 
-	downloadReq := newTestRequest(t,
+	downloadReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
 		"https://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
 		nil)
@@ -261,7 +262,7 @@ func TestPythonIndexHandlerSkipsDiscoveryForAuthenticatedNonSimpleResponse(t *te
 	})
 
 	proxyCtx := &goproxy.ProxyCtx{}
-	nonSimpleReq := newTestRequest(t, "GET", "https://pkgs.example.com/org/project/status", nil)
+	nonSimpleReq := httptest.NewRequestWithContext(t.Context(), "GET", "https://pkgs.example.com/org/project/status", nil)
 	nonSimpleReq = handleRequestAndClose(handler, nonSimpleReq, proxyCtx)
 	assertHasBasicAuth(t, nonSimpleReq, "user", "pass", "path-scoped python index request")
 
@@ -278,7 +279,7 @@ func TestPythonIndexHandlerSkipsDiscoveryForAuthenticatedNonSimpleResponse(t *te
 	}
 	handler.HandleResponse(indexResp, proxyCtx)
 
-	downloadReq := newTestRequest(t,
+	downloadReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
 		"https://pkgs.example.com/org/other-project/_packaging/feed/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
 		nil)
@@ -297,7 +298,7 @@ func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixPort(t *testing.T) {
 	})
 
 	proxyCtx := &goproxy.ProxyCtx{}
-	indexReq := newTestRequest(t,
+	indexReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
 		"https://pkgs.example.com:8443/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
 		nil)
@@ -318,7 +319,7 @@ func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixPort(t *testing.T) {
 	}
 	handler.HandleResponse(indexResp, proxyCtx)
 
-	downloadReq := newTestRequest(t,
+	downloadReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
 		"https://pkgs.example.com:8443/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
 		nil)
@@ -326,7 +327,7 @@ func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixPort(t *testing.T) {
 	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})
 	assertHasBasicAuth(t, downloadReq, "user", "pass", "discovered download request on custom port")
 
-	defaultPortReq := newTestRequest(t,
+	defaultPortReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
 		"https://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
 		nil)
@@ -345,7 +346,7 @@ func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixIPv6Host(t *testing.
 	})
 
 	proxyCtx := &goproxy.ProxyCtx{}
-	indexReq := newTestRequest(t,
+	indexReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
 		"https://[2001:db8::1]/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
 		nil)
@@ -366,7 +367,7 @@ func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixIPv6Host(t *testing.
 	}
 	handler.HandleResponse(indexResp, proxyCtx)
 
-	downloadReq := newTestRequest(t,
+	downloadReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
 		"https://[2001:db8::1]/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
 		nil)
@@ -400,7 +401,7 @@ func TestPythonIndexDownloadAuthStoreEvictsOldestEntryAtLimit(t *testing.T) {
 		t.Fatalf("expected %d stored prefixes, got %d", maxPythonIndexDownloadAuthEntries, entryCount)
 	}
 
-	evictedReq := newTestRequest(t,
+	evictedReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
 		"https://pkgs.example.com/org/project/_packaging/feed-0/pypi/download/pkg/1.0/pkg.whl",
 		nil)
@@ -409,7 +410,7 @@ func TestPythonIndexDownloadAuthStoreEvictsOldestEntryAtLimit(t *testing.T) {
 		t.Fatal("oldest discovered download prefix should be evicted")
 	}
 
-	retainedReq := newTestRequest(t,
+	retainedReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
 		fmt.Sprintf(
 			"https://pkgs.example.com/org/project/_packaging/feed-%d/pypi/download/pkg/1.0/pkg.whl",
@@ -432,7 +433,7 @@ func TestPythonIndexHandlerSkipsDiscoveryForLargeSimpleResponse(t *testing.T) {
 	})
 
 	proxyCtx := &goproxy.ProxyCtx{}
-	indexReq := newTestRequest(t,
+	indexReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
 		"https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
 		nil)
@@ -459,7 +460,7 @@ func TestPythonIndexHandlerSkipsDiscoveryForLargeSimpleResponse(t *testing.T) {
 		t.Fatal("large Simple API response body was not replayed unchanged")
 	}
 
-	downloadReq := newTestRequest(t, "GET", downloadURL, nil)
+	downloadReq := httptest.NewRequestWithContext(t.Context(), "GET", downloadURL, nil)
 	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})
 	assertUnauthenticated(t, downloadReq, "large Simple API response should not be used for discovery")
 }

--- a/internal/handlers/python_index_test.go
+++ b/internal/handlers/python_index_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -55,59 +54,59 @@ func TestPythonIndexHandler(t *testing.T) {
 	}
 	handler := NewPythonIndexHandler(credentials)
 
-	req := httptest.NewRequest("GET", "https://corp.dependabot.com/pyreg", nil)
+	req := newTestRequest(t, "GET", "https://corp.dependabot.com/pyreg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, dependabotToken, "", "dependabot registry request")
 
-	req = httptest.NewRequest("GET", "https://corp.deltaforce.com/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://corp.deltaforce.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "deltaforce registry request")
 
-	req = httptest.NewRequest("GET", "https://example.com/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://example.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "deltaforce registry request")
 
 	// Path mismatch
-	req = httptest.NewRequest("GET", "https://corp.dependabot.com/foo", nil)
+	req = newTestRequest(t, "GET", "https://corp.dependabot.com/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "dependabot registry request")
 
-	req = httptest.NewRequest("GET", "https://pypy.com/other/pgk/a", nil)
+	req = newTestRequest(t, "GET", "https://pypy.com/other/pgk/a", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "other registry request")
 
 	// Path mismatch on /+simple
-	req = httptest.NewRequest("GET", "https://pypy.com/dependabot/pgk/a", nil)
+	req = newTestRequest(t, "GET", "https://pypy.com/dependabot/pgk/a", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, "dependabot", "sec123", "dependabot pypy registry request")
 
 	// Path mismatch on /simple
-	req = httptest.NewRequest("GET", "https://pypy.com/simple/pgk/a", nil)
+	req = newTestRequest(t, "GET", "https://pypy.com/simple/pgk/a", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, "simple", "sec245", "simple pypy registry request")
 
 	// Missing repo subdomain
-	req = httptest.NewRequest("GET", "https://dependabot.com/pyreg", nil)
+	req = newTestRequest(t, "GET", "https://dependabot.com/pyreg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = httptest.NewRequest("GET", "http://corp.dependabot.com/pyreg", nil)
+	req = newTestRequest(t, "GET", "http://corp.dependabot.com/pyreg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "http, not https")
 
 	// Not a GET request
-	req = httptest.NewRequest("POST", "https://corp.dependabot.com/pyreg", nil)
+	req = newTestRequest(t, "POST", "https://corp.dependabot.com/pyreg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "post request")
 
 	// Azure DevOps
-	req = httptest.NewRequest("GET", "https://pkgs.dev.azure.com/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://pkgs.dev.azure.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "azure devops registry request")
 
 	// Azure DevOps case insensitive
-	req = httptest.NewRequest("GET", "https://PKGS.dev.azure.com/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://PKGS.dev.azure.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "azure devops case insensitive registry request")
 }
@@ -122,11 +121,11 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromHTML(t *test
 	})
 
 	proxyCtx := &goproxy.ProxyCtx{}
-	indexReq := httptest.NewRequest(
+	indexReq := newTestRequest(t,
 		"GET",
 		"https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
-		nil,
-	)
+		nil)
+
 	indexReq = handleRequestAndClose(handler, indexReq, proxyCtx)
 	assertHasBasicAuth(t, indexReq, "user", "pass", "simple index request")
 
@@ -148,27 +147,27 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromHTML(t *test
 	}
 	handler.HandleResponse(indexResp, proxyCtx)
 
-	downloadReq := httptest.NewRequest(
+	downloadReq := newTestRequest(t,
 		"HEAD",
 		"https://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
-		nil,
-	)
+		nil)
+
 	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})
 	assertHasBasicAuth(t, downloadReq, "user", "pass", "discovered download request")
 
-	samePrefixReq := httptest.NewRequest(
+	samePrefixReq := newTestRequest(t,
 		"GET",
 		"https://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/another-package/2.0.0/another-package-2.0.0.whl",
-		nil,
-	)
+		nil)
+
 	samePrefixReq = handleRequestAndClose(handler, samePrefixReq, &goproxy.ProxyCtx{})
 	assertHasBasicAuth(t, samePrefixReq, "user", "pass", "same discovered download prefix request")
 
-	otherOrgReq := httptest.NewRequest(
+	otherOrgReq := newTestRequest(t,
 		"GET",
 		"https://pkgs.example.com/other-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
-		nil,
-	)
+		nil)
+
 	otherOrgReq = handleRequestAndClose(handler, otherOrgReq, &goproxy.ProxyCtx{})
 	assertUnauthenticated(t, otherOrgReq, "download request outside authenticated path scope")
 }
@@ -183,11 +182,11 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromJSON(t *test
 	})
 
 	proxyCtx := &goproxy.ProxyCtx{}
-	indexReq := httptest.NewRequest(
+	indexReq := newTestRequest(t,
 		"GET",
 		"https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
-		nil,
-	)
+		nil)
+
 	indexReq = handleRequestAndClose(handler, indexReq, proxyCtx)
 	assertHasBasicAuth(t, indexReq, "user", "pass", "simple index request")
 
@@ -206,11 +205,11 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromJSON(t *test
 	}
 	handler.HandleResponse(indexResp, proxyCtx)
 
-	downloadReq := httptest.NewRequest(
+	downloadReq := newTestRequest(t,
 		"GET",
 		"https://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
-		nil,
-	)
+		nil)
+
 	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})
 	assertHasBasicAuth(t, downloadReq, "user", "pass", "discovered JSON download request")
 }
@@ -262,7 +261,7 @@ func TestPythonIndexHandlerSkipsDiscoveryForAuthenticatedNonSimpleResponse(t *te
 	})
 
 	proxyCtx := &goproxy.ProxyCtx{}
-	nonSimpleReq := httptest.NewRequest("GET", "https://pkgs.example.com/org/project/status", nil)
+	nonSimpleReq := newTestRequest(t, "GET", "https://pkgs.example.com/org/project/status", nil)
 	nonSimpleReq = handleRequestAndClose(handler, nonSimpleReq, proxyCtx)
 	assertHasBasicAuth(t, nonSimpleReq, "user", "pass", "path-scoped python index request")
 
@@ -279,11 +278,11 @@ func TestPythonIndexHandlerSkipsDiscoveryForAuthenticatedNonSimpleResponse(t *te
 	}
 	handler.HandleResponse(indexResp, proxyCtx)
 
-	downloadReq := httptest.NewRequest(
+	downloadReq := newTestRequest(t,
 		"GET",
 		"https://pkgs.example.com/org/other-project/_packaging/feed/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
-		nil,
-	)
+		nil)
+
 	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})
 	assertUnauthenticated(t, downloadReq, "non-Simple response should not be used for discovery")
 }
@@ -298,11 +297,11 @@ func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixPort(t *testing.T) {
 	})
 
 	proxyCtx := &goproxy.ProxyCtx{}
-	indexReq := httptest.NewRequest(
+	indexReq := newTestRequest(t,
 		"GET",
 		"https://pkgs.example.com:8443/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
-		nil,
-	)
+		nil)
+
 	indexReq = handleRequestAndClose(handler, indexReq, proxyCtx)
 	assertHasBasicAuth(t, indexReq, "user", "pass", "simple index request")
 
@@ -319,19 +318,19 @@ func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixPort(t *testing.T) {
 	}
 	handler.HandleResponse(indexResp, proxyCtx)
 
-	downloadReq := httptest.NewRequest(
+	downloadReq := newTestRequest(t,
 		"GET",
 		"https://pkgs.example.com:8443/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
-		nil,
-	)
+		nil)
+
 	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})
 	assertHasBasicAuth(t, downloadReq, "user", "pass", "discovered download request on custom port")
 
-	defaultPortReq := httptest.NewRequest(
+	defaultPortReq := newTestRequest(t,
 		"GET",
 		"https://pkgs.example.com/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
-		nil,
-	)
+		nil)
+
 	defaultPortReq = handleRequestAndClose(handler, defaultPortReq, &goproxy.ProxyCtx{})
 	assertUnauthenticated(t, defaultPortReq, "download request on default port should not match custom port prefix")
 }
@@ -346,11 +345,11 @@ func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixIPv6Host(t *testing.
 	})
 
 	proxyCtx := &goproxy.ProxyCtx{}
-	indexReq := httptest.NewRequest(
+	indexReq := newTestRequest(t,
 		"GET",
 		"https://[2001:db8::1]/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
-		nil,
-	)
+		nil)
+
 	indexReq = handleRequestAndClose(handler, indexReq, proxyCtx)
 	assertHasBasicAuth(t, indexReq, "user", "pass", "simple index request")
 
@@ -367,11 +366,11 @@ func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixIPv6Host(t *testing.
 	}
 	handler.HandleResponse(indexResp, proxyCtx)
 
-	downloadReq := httptest.NewRequest(
+	downloadReq := newTestRequest(t,
 		"GET",
 		"https://[2001:db8::1]/my-org/project-id/_packaging/feed-id/pypi/download/my-package/1.0.0/my-package-1.0.0.whl",
-		nil,
-	)
+		nil)
+
 	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})
 	assertHasBasicAuth(t, downloadReq, "user", "pass", "discovered download request on IPv6 host")
 }
@@ -401,23 +400,23 @@ func TestPythonIndexDownloadAuthStoreEvictsOldestEntryAtLimit(t *testing.T) {
 		t.Fatalf("expected %d stored prefixes, got %d", maxPythonIndexDownloadAuthEntries, entryCount)
 	}
 
-	evictedReq := httptest.NewRequest(
+	evictedReq := newTestRequest(t,
 		"GET",
 		"https://pkgs.example.com/org/project/_packaging/feed-0/pypi/download/pkg/1.0/pkg.whl",
-		nil,
-	)
+		nil)
+
 	if _, ok := store.authFor(evictedReq); ok {
 		t.Fatal("oldest discovered download prefix should be evicted")
 	}
 
-	retainedReq := httptest.NewRequest(
+	retainedReq := newTestRequest(t,
 		"GET",
 		fmt.Sprintf(
 			"https://pkgs.example.com/org/project/_packaging/feed-%d/pypi/download/pkg/1.0/pkg.whl",
 			maxPythonIndexDownloadAuthEntries,
 		),
-		nil,
-	)
+		nil)
+
 	if _, ok := store.authFor(retainedReq); !ok {
 		t.Fatal("newest discovered download prefix should be retained")
 	}
@@ -433,11 +432,11 @@ func TestPythonIndexHandlerSkipsDiscoveryForLargeSimpleResponse(t *testing.T) {
 	})
 
 	proxyCtx := &goproxy.ProxyCtx{}
-	indexReq := httptest.NewRequest(
+	indexReq := newTestRequest(t,
 		"GET",
 		"https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/",
-		nil,
-	)
+		nil)
+
 	indexReq = handleRequestAndClose(handler, indexReq, proxyCtx)
 	assertHasBasicAuth(t, indexReq, "user", "pass", "simple index request")
 
@@ -460,7 +459,7 @@ func TestPythonIndexHandlerSkipsDiscoveryForLargeSimpleResponse(t *testing.T) {
 		t.Fatal("large Simple API response body was not replayed unchanged")
 	}
 
-	downloadReq := httptest.NewRequest("GET", downloadURL, nil)
+	downloadReq := newTestRequest(t, "GET", downloadURL, nil)
 	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})
 	assertUnauthenticated(t, downloadReq, "large Simple API response should not be used for discovery")
 }

--- a/internal/handlers/rubygems_server_test.go
+++ b/internal/handlers/rubygems_server_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"fmt"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/dependabot/proxy/internal/config"
@@ -38,39 +39,39 @@ func TestRubyGemsServerHandler(t *testing.T) {
 	}
 	handler := NewRubyGemsServerHandler(credentials)
 
-	req := newTestRequest(t, "GET", "https://corp.dependabot.com/gems", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://corp.dependabot.com/gems", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, dependabotToken, "", "dependabot registry request")
 
-	req = newTestRequest(t, "GET", "https://corp.deltaforce.com/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://corp.deltaforce.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "deltaforce registry request")
 
-	req = newTestRequest(t, "GET", "https://example.com/gems/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://example.com/gems/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "deltaforce registry request")
 
-	req = newTestRequest(t, "GET", "https://example.com/path/to/gems/somepkg", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://example.com/path/to/gems/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, pathUser, pathPassword, "path-specific registry request")
 
 	// Path mismatch
-	req = newTestRequest(t, "GET", "https://corp.dependabot.com/foo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://corp.dependabot.com/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "Path mismatch")
 
 	// Missing repo subdomain
-	req = newTestRequest(t, "GET", "https://dependabot.com/gems", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://dependabot.com/gems", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = newTestRequest(t, "GET", "http://corp.dependabot.com/gems", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "http://corp.dependabot.com/gems", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "http, not https")
 
 	// Not a GET request
-	req = newTestRequest(t, "POST", "https://corp.dependabot.com/gems", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "POST", "https://corp.dependabot.com/gems", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "post request")
 }

--- a/internal/handlers/rubygems_server_test.go
+++ b/internal/handlers/rubygems_server_test.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"fmt"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/dependabot/proxy/internal/config"
@@ -39,39 +38,39 @@ func TestRubyGemsServerHandler(t *testing.T) {
 	}
 	handler := NewRubyGemsServerHandler(credentials)
 
-	req := httptest.NewRequest("GET", "https://corp.dependabot.com/gems", nil)
+	req := newTestRequest(t, "GET", "https://corp.dependabot.com/gems", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, dependabotToken, "", "dependabot registry request")
 
-	req = httptest.NewRequest("GET", "https://corp.deltaforce.com/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://corp.deltaforce.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "deltaforce registry request")
 
-	req = httptest.NewRequest("GET", "https://example.com/gems/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://example.com/gems/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "deltaforce registry request")
 
-	req = httptest.NewRequest("GET", "https://example.com/path/to/gems/somepkg", nil)
+	req = newTestRequest(t, "GET", "https://example.com/path/to/gems/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, pathUser, pathPassword, "path-specific registry request")
 
 	// Path mismatch
-	req = httptest.NewRequest("GET", "https://corp.dependabot.com/foo", nil)
+	req = newTestRequest(t, "GET", "https://corp.dependabot.com/foo", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "Path mismatch")
 
 	// Missing repo subdomain
-	req = httptest.NewRequest("GET", "https://dependabot.com/gems", nil)
+	req = newTestRequest(t, "GET", "https://dependabot.com/gems", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "different subdomain")
 
 	// HTTP, not HTTPS
-	req = httptest.NewRequest("GET", "http://corp.dependabot.com/gems", nil)
+	req = newTestRequest(t, "GET", "http://corp.dependabot.com/gems", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "http, not https")
 
 	// Not a GET request
-	req = httptest.NewRequest("POST", "https://corp.dependabot.com/gems", nil)
+	req = newTestRequest(t, "POST", "https://corp.dependabot.com/gems", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "post request")
 }

--- a/internal/handlers/terraform_registry_test.go
+++ b/internal/handlers/terraform_registry_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -59,7 +60,7 @@ func TestTerraformRegistryHandler(t *testing.T) {
 		t.Run(strings.Join([]string{tt.registryType, tt.host, tt.token}, " "), func(t *testing.T) {
 			handler := NewTerraformRegistryHandler(tt.credentials)
 
-			request := handleRequestAndClose(handler, newTestRequest(t, "GET", tt.url, nil), nil)
+			request := handleRequestAndClose(handler, httptest.NewRequestWithContext(t.Context(), "GET", tt.url, nil), nil)
 
 			assert.Equal(t, tt.authorization, request.Header.Get("Authorization"))
 		})
@@ -69,7 +70,7 @@ func TestTerraformRegistryHandler(t *testing.T) {
 		handler := NewTerraformRegistryHandler(config.Credentials{})
 
 		url := "https://registry.terraform.io/v1/providers/org/name/versions"
-		request := handleRequestAndClose(handler, newTestRequest(t, "GET", url, nil), nil)
+		request := handleRequestAndClose(handler, httptest.NewRequestWithContext(t.Context(), "GET", url, nil), nil)
 
 		assert.Equal(t, "", request.Header.Get("Authorization"), "should be empty")
 	})
@@ -82,15 +83,15 @@ func TestTerraformRegistryHandler(t *testing.T) {
 		handler := NewTerraformRegistryHandler(credentials)
 
 		// Request to org1 path should use org1 token
-		req1 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://terraform.example.com/org1/v1/providers/foo", nil), nil)
+		req1 := handleRequestAndClose(handler, httptest.NewRequestWithContext(t.Context(), "GET", "https://terraform.example.com/org1/v1/providers/foo", nil), nil)
 		assert.Equal(t, "Bearer token-org1", req1.Header.Get("Authorization"), "should use org1 token")
 
 		// Request to org2 path should use org2 token
-		req2 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://terraform.example.com/org2/v1/providers/bar", nil), nil)
+		req2 := handleRequestAndClose(handler, httptest.NewRequestWithContext(t.Context(), "GET", "https://terraform.example.com/org2/v1/providers/bar", nil), nil)
 		assert.Equal(t, "Bearer token-org2", req2.Header.Get("Authorization"), "should use org2 token")
 
 		// Request to unmatched path should not be authenticated
-		req3 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://terraform.example.com/org3/v1/providers/baz", nil), nil)
+		req3 := handleRequestAndClose(handler, httptest.NewRequestWithContext(t.Context(), "GET", "https://terraform.example.com/org3/v1/providers/baz", nil), nil)
 		assert.Equal(t, "", req3.Header.Get("Authorization"), "should not be authenticated")
 	})
 
@@ -121,14 +122,14 @@ func TestTerraformRegistryHandler(t *testing.T) {
 		assert.Equal(t, "https://terraform.example.com/org1", handler.credentials[0].url, "longer path should be first")
 		assert.Equal(t, "https://terraform.example.com/org", handler.credentials[1].url, "shorter path should be second")
 
-		req1 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://terraform.example.com/org1/v1/providers/foo", nil), nil)
+		req1 := handleRequestAndClose(handler, httptest.NewRequestWithContext(t.Context(), "GET", "https://terraform.example.com/org1/v1/providers/foo", nil), nil)
 		assert.Equal(t, "Bearer token-org1", req1.Header.Get("Authorization"), "/org1 path should use org1 token")
 
-		req2 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://terraform.example.com/org/v1/providers/bar", nil), nil)
+		req2 := handleRequestAndClose(handler, httptest.NewRequestWithContext(t.Context(), "GET", "https://terraform.example.com/org/v1/providers/bar", nil), nil)
 		assert.Equal(t, "Bearer token-org", req2.Header.Get("Authorization"), "/org path should use org token")
 
 		// Request to /org123 should NOT match /org1 or /org (path boundary check)
-		req3 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://terraform.example.com/org123/v1/providers/baz", nil), nil)
+		req3 := handleRequestAndClose(handler, httptest.NewRequestWithContext(t.Context(), "GET", "https://terraform.example.com/org123/v1/providers/baz", nil), nil)
 		assert.Equal(t, "", req3.Header.Get("Authorization"), "/org123 should not match /org or /org1")
 	})
 }

--- a/internal/handlers/terraform_registry_test.go
+++ b/internal/handlers/terraform_registry_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -60,7 +59,7 @@ func TestTerraformRegistryHandler(t *testing.T) {
 		t.Run(strings.Join([]string{tt.registryType, tt.host, tt.token}, " "), func(t *testing.T) {
 			handler := NewTerraformRegistryHandler(tt.credentials)
 
-			request := handleRequestAndClose(handler, httptest.NewRequest("GET", tt.url, nil), nil)
+			request := handleRequestAndClose(handler, newTestRequest(t, "GET", tt.url, nil), nil)
 
 			assert.Equal(t, tt.authorization, request.Header.Get("Authorization"))
 		})
@@ -70,7 +69,7 @@ func TestTerraformRegistryHandler(t *testing.T) {
 		handler := NewTerraformRegistryHandler(config.Credentials{})
 
 		url := "https://registry.terraform.io/v1/providers/org/name/versions"
-		request := handleRequestAndClose(handler, httptest.NewRequest("GET", url, nil), nil)
+		request := handleRequestAndClose(handler, newTestRequest(t, "GET", url, nil), nil)
 
 		assert.Equal(t, "", request.Header.Get("Authorization"), "should be empty")
 	})
@@ -83,15 +82,15 @@ func TestTerraformRegistryHandler(t *testing.T) {
 		handler := NewTerraformRegistryHandler(credentials)
 
 		// Request to org1 path should use org1 token
-		req1 := handleRequestAndClose(handler, httptest.NewRequest("GET", "https://terraform.example.com/org1/v1/providers/foo", nil), nil)
+		req1 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://terraform.example.com/org1/v1/providers/foo", nil), nil)
 		assert.Equal(t, "Bearer token-org1", req1.Header.Get("Authorization"), "should use org1 token")
 
 		// Request to org2 path should use org2 token
-		req2 := handleRequestAndClose(handler, httptest.NewRequest("GET", "https://terraform.example.com/org2/v1/providers/bar", nil), nil)
+		req2 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://terraform.example.com/org2/v1/providers/bar", nil), nil)
 		assert.Equal(t, "Bearer token-org2", req2.Header.Get("Authorization"), "should use org2 token")
 
 		// Request to unmatched path should not be authenticated
-		req3 := handleRequestAndClose(handler, httptest.NewRequest("GET", "https://terraform.example.com/org3/v1/providers/baz", nil), nil)
+		req3 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://terraform.example.com/org3/v1/providers/baz", nil), nil)
 		assert.Equal(t, "", req3.Header.Get("Authorization"), "should not be authenticated")
 	})
 
@@ -122,14 +121,14 @@ func TestTerraformRegistryHandler(t *testing.T) {
 		assert.Equal(t, "https://terraform.example.com/org1", handler.credentials[0].url, "longer path should be first")
 		assert.Equal(t, "https://terraform.example.com/org", handler.credentials[1].url, "shorter path should be second")
 
-		req1 := handleRequestAndClose(handler, httptest.NewRequest("GET", "https://terraform.example.com/org1/v1/providers/foo", nil), nil)
+		req1 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://terraform.example.com/org1/v1/providers/foo", nil), nil)
 		assert.Equal(t, "Bearer token-org1", req1.Header.Get("Authorization"), "/org1 path should use org1 token")
 
-		req2 := handleRequestAndClose(handler, httptest.NewRequest("GET", "https://terraform.example.com/org/v1/providers/bar", nil), nil)
+		req2 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://terraform.example.com/org/v1/providers/bar", nil), nil)
 		assert.Equal(t, "Bearer token-org", req2.Header.Get("Authorization"), "/org path should use org token")
 
 		// Request to /org123 should NOT match /org1 or /org (path boundary check)
-		req3 := handleRequestAndClose(handler, httptest.NewRequest("GET", "https://terraform.example.com/org123/v1/providers/baz", nil), nil)
+		req3 := handleRequestAndClose(handler, newTestRequest(t, "GET", "https://terraform.example.com/org123/v1/providers/baz", nil), nil)
 		assert.Equal(t, "", req3.Header.Get("Authorization"), "/org123 should not match /org or /org1")
 	})
 }

--- a/internal/handlers/test_helpers.go
+++ b/internal/handlers/test_helpers.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -10,6 +12,11 @@ import (
 
 	"github.com/dependabot/proxy/internal/config"
 )
+
+func newTestRequest(t *testing.T, method, target string, body io.Reader) *http.Request {
+	t.Helper()
+	return httptest.NewRequestWithContext(t.Context(), method, target, body)
+}
 
 // handleRequestAndClose calls handler.HandleRequest and closes any response body.
 // Most handlers return nil responses, but the linter can't prove that.

--- a/internal/handlers/test_helpers.go
+++ b/internal/handlers/test_helpers.go
@@ -1,9 +1,7 @@
 package handlers
 
 import (
-	"io"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -12,11 +10,6 @@ import (
 
 	"github.com/dependabot/proxy/internal/config"
 )
-
-func newTestRequest(t *testing.T, method, target string, body io.Reader) *http.Request {
-	t.Helper()
-	return httptest.NewRequestWithContext(t.Context(), method, target, body)
-}
 
 // handleRequestAndClose calls handler.HandleRequest and closes any response body.
 // Most handlers return nil responses, but the linter can't prove that.

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -11,7 +11,7 @@ import (
 // newRequest builds a GET request to the given raw URL for use in tests.
 func newRequest(t *testing.T, rawURL string) *http.Request {
 	t.Helper()
-	return httptest.NewRequest(http.MethodGet, rawURL, nil)
+	return httptest.NewRequestWithContext(t.Context(), http.MethodGet, rawURL, nil)
 }
 
 // newRequestWithAuth builds a request that already carries an Authorization header,

--- a/internal/metrics/handler_test.go
+++ b/internal/metrics/handler_test.go
@@ -44,13 +44,13 @@ func TestHandlerMetrics(t *testing.T) {
 	handler := NewHandler(mockMetricsCollector)
 
 	tests := map[string]struct {
-		generateRequestMetrics func(h *Handler)
+		generateRequestMetrics func(t *testing.T, h *Handler)
 		expMetricCount         int
 		validateMetric         func(*testing.T, string)
 	}{
 		"single request": {
-			generateRequestMetrics: func(h *Handler) {
-				req := httptest.NewRequest("GET", "https://example.com/", nil)
+			generateRequestMetrics: func(t *testing.T, h *Handler) {
+				req := httptest.NewRequestWithContext(t.Context(), "GET", "https://example.com/", nil)
 				proxyCtx := &goproxy.ProxyCtx{Req: req}
 				_, resp := h.HandleRequest(req, proxyCtx)
 				if resp != nil && resp.Body != nil {
@@ -78,8 +78,8 @@ func TestHandlerMetrics(t *testing.T) {
 			expMetricCount: 2,
 		},
 		"single request to subdomain api.github.com": {
-			generateRequestMetrics: func(h *Handler) {
-				req := httptest.NewRequest("GET", "https://api.github.com/", nil)
+			generateRequestMetrics: func(t *testing.T, h *Handler) {
+				req := httptest.NewRequestWithContext(t.Context(), "GET", "https://api.github.com/", nil)
 				proxyCtx := &goproxy.ProxyCtx{Req: req}
 				_, resp := h.HandleRequest(req, proxyCtx)
 				if resp != nil && resp.Body != nil {
@@ -106,9 +106,9 @@ func TestHandlerMetrics(t *testing.T) {
 			},
 		},
 		"two requests to different subdomains": {
-			generateRequestMetrics: func(h *Handler) {
+			generateRequestMetrics: func(t *testing.T, h *Handler) {
 				for _, host := range []string{"https://thing.pypi.org/", "https://pypi.org/"} {
-					req := httptest.NewRequest("GET", host, nil)
+					req := httptest.NewRequestWithContext(t.Context(), "GET", host, nil)
 					proxyCtx := &goproxy.ProxyCtx{Req: req}
 					_, resp := h.HandleRequest(req, proxyCtx)
 					if resp != nil && resp.Body != nil {
@@ -134,9 +134,9 @@ func TestHandlerMetrics(t *testing.T) {
 			},
 		},
 		"two requests to different subdomains for github.com": {
-			generateRequestMetrics: func(h *Handler) {
+			generateRequestMetrics: func(t *testing.T, h *Handler) {
 				for _, host := range []string{"https://foo.github.com/", "https://github.com/"} {
-					req := httptest.NewRequest("GET", host, nil)
+					req := httptest.NewRequestWithContext(t.Context(), "GET", host, nil)
 					proxyCtx := &goproxy.ProxyCtx{Req: req}
 					_, resp := h.HandleRequest(req, proxyCtx)
 					if resp != nil && resp.Body != nil {
@@ -162,9 +162,9 @@ func TestHandlerMetrics(t *testing.T) {
 			},
 		},
 		"two requests to different subdomains for pkg.github.com": {
-			generateRequestMetrics: func(h *Handler) {
+			generateRequestMetrics: func(t *testing.T, h *Handler) {
 				for _, host := range []string{"https://foo.pkg.github.com/", "https://bar.pkg.github.com/"} {
-					req := httptest.NewRequest("GET", host, nil)
+					req := httptest.NewRequestWithContext(t.Context(), "GET", host, nil)
 					proxyCtx := &goproxy.ProxyCtx{Req: req}
 					_, resp := h.HandleRequest(req, proxyCtx)
 					if resp != nil && resp.Body != nil {
@@ -199,7 +199,7 @@ func TestHandlerMetrics(t *testing.T) {
 			mockMetricsCollector.On("SendMetric", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("float64"), mock.AnythingOfType("map[string]string")).Return(nil).Times(tc.expMetricCount)
 
 			// Run the generateRequestMetrics function
-			tc.generateRequestMetrics(handler)
+			tc.generateRequestMetrics(t, handler)
 
 			mockMetricsCollector.AssertNumberOfCalls(t, "SendMetric", tc.expMetricCount)
 

--- a/internal/oidc/oidc_registry_test.go
+++ b/internal/oidc/oidc_registry_test.go
@@ -149,7 +149,7 @@ func TestOIDCRegistry_TryAuth_SingleCredential(t *testing.T) {
 	cred := azureCredWithURL("tenant-1", "client-1", "https://registry.example.com/packages")
 	r.Register(cred, []string{"url"}, "test registry")
 
-	req := httptest.NewRequest("GET", "https://registry.example.com/packages/some-package", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.example.com/packages/some-package", nil)
 	ok := r.TryAuth(req, nil)
 
 	assert.True(t, ok, "should authenticate")
@@ -180,7 +180,7 @@ func TestOIDCRegistry_TryAuth_SameHostDifferentPaths_NoCollision(t *testing.T) {
 	assert.NotEqual(t, keyA, keyB, "keys should be different")
 
 	// Request to feed-A should get feed-A's token
-	reqA := httptest.NewRequest("GET",
+	reqA := httptest.NewRequestWithContext(t.Context(), "GET",
 		"https://pkgs.dev.azure.com/org/_packaging/feed-A/npm/registry/@scope/package", nil)
 	ok := r.TryAuth(reqA, nil)
 	assert.True(t, ok, "feed-A request should be authenticated")
@@ -188,7 +188,7 @@ func TestOIDCRegistry_TryAuth_SameHostDifferentPaths_NoCollision(t *testing.T) {
 		"feed-A request should get feed-A's token")
 
 	// Request to feed-B should get feed-B's token
-	reqB := httptest.NewRequest("GET",
+	reqB := httptest.NewRequestWithContext(t.Context(), "GET",
 		"https://pkgs.dev.azure.com/org/_packaging/feed-B/npm/registry/@scope/package", nil)
 	ok = r.TryAuth(reqB, nil)
 	assert.True(t, ok, "feed-B request should be authenticated")
@@ -214,7 +214,7 @@ func TestOIDCRegistry_TryAuth_HostOnlyMatchesAnyPath(t *testing.T) {
 	r.Register(cred, []string{"url"}, "test registry")
 
 	// Should match any path on that host
-	req := httptest.NewRequest("GET", "https://registry.example.com/any/path/here", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.example.com/any/path/here", nil)
 	ok := r.TryAuth(req, nil)
 
 	assert.True(t, ok, "host-only credential should match any path")
@@ -229,7 +229,7 @@ func TestOIDCRegistry_TryAuth_NoMatch(t *testing.T) {
 	r.Register(cred, []string{"url"}, "test registry")
 
 	// Request to a different host
-	req := httptest.NewRequest("GET", "https://other.example.com/packages/something", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://other.example.com/packages/something", nil)
 	ok := r.TryAuth(req, nil)
 
 	assert.False(t, ok, "should not match different host")
@@ -245,7 +245,7 @@ func TestOIDCRegistry_TryAuth_WrongPathNoMatch(t *testing.T) {
 	r.Register(cred, []string{"url"}, "test registry")
 
 	// Request to same host but different feed path
-	req := httptest.NewRequest("GET",
+	req := httptest.NewRequestWithContext(t.Context(), "GET",
 		"https://pkgs.dev.azure.com/org/_packaging/feed-B/npm/registry/@scope/pkg", nil)
 	ok := r.TryAuth(req, nil)
 
@@ -263,7 +263,7 @@ func TestOIDCRegistry_CredentialForRequestConcurrentRegistration(t *testing.T) {
 	}
 	r.RegisterURL("https://registry.example.com/packages", credential, "test registry")
 
-	req := httptest.NewRequest("GET", "https://registry.example.com/packages/some-package", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.example.com/packages/some-package", nil)
 
 	var wg sync.WaitGroup
 	for i := range 50 {
@@ -305,7 +305,7 @@ func TestOIDCRegistry_RegisterURL(t *testing.T) {
 	r.RegisterURL("https://nuget.example.com/v3/package-content", oidcCred, "nuget resource")
 
 	// Request to discovered URL should be authenticated
-	req := httptest.NewRequest("GET",
+	req := httptest.NewRequestWithContext(t.Context(), "GET",
 		"https://nuget.example.com/v3/package-content/some-package/1.0.0", nil)
 	ok = r.TryAuth(req, nil)
 
@@ -321,7 +321,7 @@ func TestOIDCRegistry_TryAuth_PortMismatch(t *testing.T) {
 	r.Register(cred, []string{"url"}, "test registry")
 
 	// Request on default port (443) should not match cred on port 8443
-	req := httptest.NewRequest("GET", "https://registry.example.com/packages/something", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.example.com/packages/something", nil)
 	ok := r.TryAuth(req, nil)
 
 	assert.False(t, ok, "should not match different port")
@@ -359,7 +359,7 @@ func TestOIDCRegistry_TryAuth_PathSpecificBeatsHostOnly(t *testing.T) {
 	r.Register(hostOnlyCred, []string{"url"}, "test registry")
 	r.Register(pathSpecificCred, []string{"url"}, "test registry")
 
-	req := httptest.NewRequest("GET", "https://registry.example.com/packages/private/module.tgz", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.example.com/packages/private/module.tgz", nil)
 	ok := r.TryAuth(req, nil)
 
 	assert.True(t, ok, "path-specific credential should match request")
@@ -382,7 +382,7 @@ func TestOIDCRegistry_TryAuth_LongestPathPrefixWins(t *testing.T) {
 	r.Register(shortPrefixCred, []string{"url"}, "test registry")
 	r.Register(longPrefixCred, []string{"url"}, "test registry")
 
-	req := httptest.NewRequest("GET", "https://registry.example.com/packages/private/module.tgz", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.example.com/packages/private/module.tgz", nil)
 	ok := r.TryAuth(req, nil)
 
 	assert.True(t, ok, "longer path prefix should match request")
@@ -401,7 +401,7 @@ func TestOIDCRegistry_TryAuth_CaseInsensitiveHost(t *testing.T) {
 	r.Register(cred, []string{"url"}, "test registry")
 
 	// Request with different casing should still match
-	req := httptest.NewRequest("GET", "https://REGISTRY.EXAMPLE.COM/packages/something", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://REGISTRY.EXAMPLE.COM/packages/something", nil)
 	ok := r.TryAuth(req, nil)
 
 	assert.True(t, ok, "host matching should be case-insensitive")
@@ -438,7 +438,7 @@ func TestOIDCRegistry_TryAuth_Cloudsmith_UsesAPIKey(t *testing.T) {
 	cred := cloudsmithCred("my-org", "my-service", "https://cloudsmith.io", "https://dl.cloudsmith.io/basic/my-org/my-repo")
 	r.Register(cred, []string{"url"}, "test registry")
 
-	req := httptest.NewRequest("GET", "https://dl.cloudsmith.io/basic/my-org/my-repo/some-package", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://dl.cloudsmith.io/basic/my-org/my-repo/some-package", nil)
 	ok := r.TryAuth(req, nil)
 
 	assert.True(t, ok, "cloudsmith OIDC should authenticate")
@@ -473,7 +473,7 @@ func TestOIDCRegistry_TryAuth_GCP_UsesBearer(t *testing.T) {
 	cred := gcpCred("projects/123/locations/global/workloadIdentityPools/pool/providers/prov", "https://us-central1-python.pkg.dev/my-project/my-repo/simple")
 	r.Register(cred, []string{"url"}, "test registry")
 
-	req := httptest.NewRequest("GET", "https://us-central1-python.pkg.dev/my-project/my-repo/simple/some-package", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://us-central1-python.pkg.dev/my-project/my-repo/simple/some-package", nil)
 	ok := r.TryAuth(req, nil)
 
 	assert.True(t, ok, "GCP OIDC should authenticate")
@@ -492,7 +492,7 @@ func TestOIDCRegistry_TryAuth_GCP_DockerUsesBasicAuth(t *testing.T) {
 	cred := gcpCred("projects/123/locations/global/workloadIdentityPools/pool/providers/prov", "https://us-central1-docker.pkg.dev/my-project/my-repo")
 	r.Register(cred, []string{"url"}, "docker registry")
 
-	req := httptest.NewRequest("GET", "https://us-central1-docker.pkg.dev/my-project/my-repo/v2/some-image/manifests/latest", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://us-central1-docker.pkg.dev/my-project/my-repo/v2/some-image/manifests/latest", nil)
 	ok := r.TryAuth(req, nil)
 
 	assert.True(t, ok, "GCP OIDC should authenticate docker")
@@ -529,7 +529,7 @@ func TestOIDCRegistry_TryAuth_URLWithoutProtocol(t *testing.T) {
 	cred["url"] = "registry.example.com/packages"
 	r.Register(cred, []string{"url"}, "test registry")
 
-	req := httptest.NewRequest("GET", "https://registry.example.com/packages/something", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.example.com/packages/something", nil)
 	ok := r.TryAuth(req, nil)
 
 	assert.True(t, ok, "URL without protocol should be handled by ParseURLLax")
@@ -554,7 +554,7 @@ func TestOIDCRegistry_RegisterURL_MultipleOnSameHost(t *testing.T) {
 
 	// All three paths should authenticate
 	for _, path := range []string{"/v3/index.json", "/v3/package-content/Some.Package/1.0.0", "/v3/registrations/some.package/index.json"} {
-		req := httptest.NewRequest("GET", "https://nuget.example.com"+path, nil)
+		req := httptest.NewRequestWithContext(t.Context(), "GET", "https://nuget.example.com"+path, nil)
 		ok := r.TryAuth(req, nil)
 		assert.True(t, ok, "should authenticate: "+path)
 		assert.Equal(t, "Bearer __test_token__", req.Header.Get("Authorization"))

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -37,7 +37,11 @@ func TestProxyHTTPRequest(t *testing.T) {
 	url, httpSrv := testHTTPServer(t)
 	defer httpSrv.Close()
 
-	rsp, err := client.Get(url)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("initializing new request: %v", err)
+	}
+	rsp, err := client.Do(req)
 	if err != nil {
 		t.Errorf("making proxied request: %v", err)
 	}
@@ -63,7 +67,11 @@ func TestIPRestrictions(t *testing.T) {
 
 	for _, url := range httpTestCases {
 		t.Run(url, func(t *testing.T) {
-			rsp, err := client.Get(url)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+			if err != nil {
+				t.Fatalf("initializing new request: %v", err)
+			}
+			rsp, err := client.Do(req)
 			if err != nil {
 				t.Errorf("making proxied request: %v", err)
 				return
@@ -86,7 +94,11 @@ func TestIPRestrictions(t *testing.T) {
 	// the connection from being established while goproxy tries to setup TLS
 	for _, url := range httpsTestCases {
 		t.Run(url, func(t *testing.T) {
-			_, err := client.Get(url) //nolint:bodyclose // error expected, no body to close
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+			if err != nil {
+				t.Fatalf("initializing new request: %v", err)
+			}
+			_, err = client.Do(req) //nolint:bodyclose // error expected, no body to close
 			assert.Error(t, err)
 		})
 	}


### PR DESCRIPTION
### What are you trying to accomplish?

Resolve all 266 `noctx` findings. Test requests now use `t.Context()`, proxy tests send explicit requests with `client.Do`, and the connectivity probe uses `DialContext`.

This keeps cancellation available while preserving the probe's 100 ms timeout and cached result.

### Anything you want to highlight for special attention from reviewers?

Most of the diff is mechanical. Handler tests use a small `newTestRequest` helper to avoid repeating the context setup.

The full linter still reports 104 existing `bodyclose`, `errcheck`, `gocritic`, and `gosec` findings. `origin/main` reports the same 104 findings, plus the `noctx` findings fixed here.

### How will you know you've accomplished your goal?

- `go test ./...`
- `golangci-lint run --enable-only noctx --max-issues-per-linter=0`

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
