### PR TITLE
Refactor tests to use Testify assertions

### DIFF
--- a/internal/cache/handlers_test.go
+++ b/internal/cache/handlers_test.go
@@ -16,6 +16,8 @@ import (
 	"time"
 
 	"github.com/elazarl/goproxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // None of these tests should make network calls
@@ -27,9 +29,7 @@ func TestCache_Disabled(t *testing.T) {
 	defer os.RemoveAll(cacheDir)
 
 	cacher, err := New(enabled, cacheDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	req := httptest.NewRequestWithContext(t.Context(), "GET", URL, nil)
 	proxyCtx := &goproxy.ProxyCtx{
@@ -41,8 +41,8 @@ func TestCache_Disabled(t *testing.T) {
 	_, resp := cacher.OnRequest(req, proxyCtx)
 	if resp != nil {
 		resp.Body.Close()
-		t.Error("Cache is not disabled")
 	}
+	assert.Nil(t, resp)
 
 	// Verify that we didn't read the body of the response to cache it.
 	originalBody := io.NopCloser(bytes.NewBufferString(""))
@@ -50,9 +50,7 @@ func TestCache_Disabled(t *testing.T) {
 	proxyCtx.Resp = resp2
 	resp3 := cacher.OnResponse(resp2, proxyCtx)
 	defer resp3.Body.Close()
-	if originalBody != resp3.Body {
-		t.Error("Cache is not disabled")
-	}
+	assert.Equal(t, originalBody, resp3.Body)
 }
 
 func TestCache(t *testing.T) {
@@ -61,13 +59,9 @@ func TestCache(t *testing.T) {
 	defer os.RemoveAll(cacheDir)
 
 	cacher, err := New(enabled, cacheDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if len(cacher.cacheDB) != 0 {
-		t.Error("cache should have 0 entry, got", len(cacher.cacheDB))
-	}
+	assert.Empty(t, cacher.cacheDB)
 
 	t.Run("Cache miss", func(t *testing.T) {
 		req := httptest.NewRequestWithContext(t.Context(), "GET", URL, nil)
@@ -78,8 +72,8 @@ func TestCache(t *testing.T) {
 		_, resp := cacher.OnRequest(req, proxyCtx)
 		if resp != nil {
 			resp.Body.Close()
-			t.Error("No cache should exist yet")
 		}
+		assert.Nil(t, resp)
 
 		body := `{"hello":"world"}`
 		resp = &http.Response{
@@ -90,12 +84,8 @@ func TestCache(t *testing.T) {
 		resp = cacher.OnResponse(resp, proxyCtx)
 		result, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		if len(cacher.cacheDB) != 1 {
-			t.Error("cache should have 1 entry, got", len(cacher.cacheDB))
-		}
-		if string(result) != body {
-			t.Error("Data was corrupted while caching")
-		}
+		assert.Len(t, cacher.cacheDB, 1)
+		assert.Equal(t, body, string(result))
 	})
 
 	t.Run("Cache hit", func(t *testing.T) {
@@ -106,9 +96,7 @@ func TestCache(t *testing.T) {
 
 		// a cached response means OnRequest returns a resp
 		_, resp := cacher.OnRequest(req, proxyCtx)
-		if resp == nil {
-			t.Error("Request should be cached")
-		} else {
+		if assert.NotNil(t, resp) {
 			resp.Body.Close()
 		}
 
@@ -119,9 +107,7 @@ func TestCache(t *testing.T) {
 		}
 		resp = cacher.OnResponse(resp, proxyCtx)
 		resp.Body.Close()
-		if len(cacher.cacheDB) != 1 {
-			t.Error("cache should have 1 entry, got", len(cacher.cacheDB))
-		}
+		assert.Len(t, cacher.cacheDB, 1)
 	})
 }
 
@@ -135,9 +121,7 @@ func Test_sanitize(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if v := sanitize(test.Input); v != test.Expected {
-			t.Errorf("sanitize %v, expected %v, got %v", test.Input, test.Expected, v)
-		}
+		assert.Equal(t, test.Expected, sanitize(test.Input))
 	}
 }
 
@@ -152,10 +136,7 @@ func Test_key(t *testing.T) {
 	t.Run("Reflexive property", func(t *testing.T) {
 		key1 := key(req)
 		key2 := key(req)
-
-		if key1 != key2 {
-			t.Error("The same request should produce the same key")
-		}
+		assert.Equal(t, key1, key2)
 	})
 
 	t.Run("Methods not equal", func(t *testing.T) {
@@ -164,9 +145,7 @@ func Test_key(t *testing.T) {
 
 		key1 := key(req)
 		key2 := key(req2)
-		if key2 == key1 {
-			t.Error("Methods not equal")
-		}
+		assert.NotEqual(t, key1, key2)
 	})
 
 	t.Run("URLs not equal", func(t *testing.T) {
@@ -175,9 +154,7 @@ func Test_key(t *testing.T) {
 
 		key1 := key(req)
 		key2 := key(req2)
-		if key2 == key1 {
-			t.Error("URLs not equal")
-		}
+		assert.NotEqual(t, key1, key2)
 	})
 
 	t.Run("Header commutative property", func(t *testing.T) {
@@ -187,9 +164,7 @@ func Test_key(t *testing.T) {
 
 		key1 := key(req)
 		key2 := key(req2)
-		if key2 != key1 {
-			t.Error("Header value order should not matter")
-		}
+		assert.Equal(t, key1, key2)
 	})
 
 	t.Run("Some headers are inconsequential to the cache", func(t *testing.T) {
@@ -198,9 +173,7 @@ func Test_key(t *testing.T) {
 
 		key1 := key(req)
 		key2 := key(req2)
-		if key2 != key1 {
-			t.Error("Header should be ignored")
-		}
+		assert.Equal(t, key1, key2)
 	})
 
 	t.Run("Headers not equal", func(t *testing.T) {
@@ -209,9 +182,7 @@ func Test_key(t *testing.T) {
 
 		key1 := key(req)
 		key2 := key(req2)
-		if key2 == key1 {
-			t.Error("Headers are not equal")
-		}
+		assert.NotEqual(t, key1, key2)
 	})
 
 	t.Run("Body equality", func(t *testing.T) {
@@ -221,9 +192,7 @@ func Test_key(t *testing.T) {
 
 		key1 := key(req)
 		key2 := key(req2)
-		if key2 != key1 {
-			t.Error("Bodies are equal")
-		}
+		assert.Equal(t, key1, key2)
 	})
 
 	t.Run("Body inequality", func(t *testing.T) {
@@ -233,17 +202,13 @@ func Test_key(t *testing.T) {
 
 		key1 := key(req)
 		key2 := key(req2)
-		if key2 == key1 {
-			t.Error("Bodies are not equal")
-		}
+		assert.NotEqual(t, key1, key2)
 	})
 
 	t.Run("A request with no headers should result in a blank headerHash", func(t *testing.T) {
 		req := httptest.NewRequestWithContext(t.Context(), "GET", "https://github.com", nil)
 		key := key(req)
-		if key.HeaderHash != "" {
-			t.Error("headerHash should be blank, got", key.HeaderHash)
-		}
+		assert.Empty(t, key.HeaderHash)
 	})
 
 	// Integration tests for the gitproto hookup. Edge-case behaviour of the
@@ -263,9 +228,7 @@ func Test_key(t *testing.T) {
 			"0032have 553c2077f0edc3d5dc5d17262f6aa498e69d6f8e\n0009done\n"
 		body2 := "0080want 7fd1a60b01f91b314f59955a4e4d4e80d8edf11d multi_ack_detailed no-done side-band-64k thin-pack ofs-delta agent=git/2.53.0\n" +
 			"0032have 553c2077f0edc3d5dc5d17262f6aa498e69d6f8e\n0009done\n"
-		if key(mkUpReq(upUrl, upCT, body1)) != key(mkUpReq(upUrl, upCT, body2)) {
-			t.Error("agent-only difference must collapse")
-		}
+		assert.Equal(t, key(mkUpReq(upUrl, upCT, body1)), key(mkUpReq(upUrl, upCT, body2)))
 	})
 
 	t.Run("git-upload-pack: different haves hash distinctly", func(t *testing.T) {
@@ -273,33 +236,25 @@ func Test_key(t *testing.T) {
 			"0032have 553c2077f0edc3d5dc5d17262f6aa498e69d6f8e\n0009done\n"
 		body2 := "0032want 7fd1a60b01f91b314f59955a4e4d4e80d8edf11d\n0000" +
 			"0032have a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2\n0009done\n"
-		if key(mkUpReq(upUrl, upCT, body1)) == key(mkUpReq(upUrl, upCT, body2)) {
-			t.Error("haves shape the upstream pack and must not collapse")
-		}
+		assert.NotEqual(t, key(mkUpReq(upUrl, upCT, body1)), key(mkUpReq(upUrl, upCT, body2)))
 	})
 
 	t.Run("git-upload-pack: malformed body falls back to raw hashing", func(t *testing.T) {
-		if key(mkUpReq(upUrl, upCT, "garbage one")) == key(mkUpReq(upUrl, upCT, "garbage two")) {
-			t.Error("malformed bodies must hash distinctly")
-		}
+		assert.NotEqual(t, key(mkUpReq(upUrl, upCT, "garbage one")), key(mkUpReq(upUrl, upCT, "garbage two")))
 	})
 
 	t.Run("non-git POST is not normalized even with similar substrings", func(t *testing.T) {
 		const u = "https://api.github.com/graphql"
 		k1 := key(httptest.NewRequestWithContext(t.Context(), "POST", u, strings.NewReader(`{"q":"have stuff agent=foo"}`)))
 		k2 := key(httptest.NewRequestWithContext(t.Context(), "POST", u, strings.NewReader(`{"q":"have other agent=bar"}`)))
-		if k1 == k2 {
-			t.Error("non-git POSTs must not be normalized")
-		}
+		assert.NotEqual(t, k1, k2)
 	})
 
 	t.Run("upload-pack path without Content-Type is not normalized", func(t *testing.T) {
 		const u = "https://example.com/foo/git-upload-pack"
 		body1 := "0032have 553c2077f0edc3d5dc5d17262f6aa498e69d6f8e\n0009done\n"
 		body2 := "0032have a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2\n0009done\n"
-		if key(mkUpReq(u, "", body1)) == key(mkUpReq(u, "", body2)) {
-			t.Error("missing Content-Type must skip normalization")
-		}
+		assert.NotEqual(t, key(mkUpReq(u, "", body1)), key(mkUpReq(u, "", body2)))
 	})
 }
 
@@ -332,24 +287,12 @@ func TestTeeReadCloser(t *testing.T) {
 		tee := TeeReadCloser(readCloser, writeCloser, callback)
 
 		data, err := io.ReadAll(tee)
-		if err != nil {
-			t.Error("failed to read from the tee")
-		}
-		if string(data) != "hello" {
-			t.Error("tee did not read from the reader")
-		}
-		if writeCloser.String() != "hello" {
-			t.Error("callback did not write to the buffer")
-		}
-		if err := tee.Close(); err != nil {
-			t.Error("failed to close the tee")
-		}
-		if !callbackWasCalled {
-			t.Error("callback was not called")
-		}
-		if !writeCloser.WasCloseCalled {
-			t.Error("close was not called on the writer")
-		}
+		assert.NoError(t, err)
+		assert.Equal(t, "hello", string(data))
+		assert.Equal(t, "hello", writeCloser.String())
+		assert.NoError(t, tee.Close())
+		assert.True(t, callbackWasCalled)
+		assert.True(t, writeCloser.WasCloseCalled)
 	})
 
 	t.Run("when the writer fails", func(t *testing.T) {
@@ -364,21 +307,10 @@ func TestTeeReadCloser(t *testing.T) {
 		tee := TeeReadCloser(readCloser, writeCloser, callback)
 
 		data, err := io.ReadAll(tee)
-		if err != nil {
-			t.Error("the writer should not affect the reader")
-		}
-		if string(data) != "hello" {
-			t.Error("the reader should still read from the reader")
-		}
-		if err := tee.Close(); err != nil {
-			t.Error("failed to close the tee")
-		}
-		if callbackWasCalled {
-			// this will prevent caching responses that failed to write to disk
-			t.Error("the callback should not be called")
-		}
-		if !writeCloser.WasCloseCalled {
-			t.Error("close was not called on the buffer")
-		}
+		assert.NoError(t, err)
+		assert.Equal(t, "hello", string(data))
+		assert.NoError(t, tee.Close())
+		assert.False(t, callbackWasCalled)
+		assert.True(t, writeCloser.WasCloseCalled)
 	})
 }

--- a/internal/cache/handlers_test.go
+++ b/internal/cache/handlers_test.go
@@ -45,12 +45,12 @@ func TestCache_Disabled(t *testing.T) {
 	assert.Nil(t, resp)
 
 	// Verify that we didn't read the body of the response to cache it.
-	originalBody := io.NopCloser(bytes.NewBufferString(""))
+	originalBody := &BufferWithClose{}
 	resp2 := &http.Response{Body: originalBody}
 	proxyCtx.Resp = resp2
 	resp3 := cacher.OnResponse(resp2, proxyCtx)
 	defer resp3.Body.Close()
-	assert.Equal(t, originalBody, resp3.Body)
+	assert.Same(t, originalBody, resp3.Body)
 }
 
 func TestCache(t *testing.T) {

--- a/internal/gitproto/pktline.go
+++ b/internal/gitproto/pktline.go
@@ -45,7 +45,7 @@ func parseHex4(b []byte) (n int, ok bool) {
 	return n, true
 }
 
-// parsePktLine returns ok=false on malformed or truncated input so callers
+// parsePktLine returns nil, false on malformed or truncated input so callers
 // can fall back to opaque hashing of the original bytes.
 func parsePktLine(data []byte) (packets []packet, ok bool) {
 	for len(data) > 0 {

--- a/internal/gitproto/pktline_test.go
+++ b/internal/gitproto/pktline_test.go
@@ -1,18 +1,16 @@
 package gitproto
 
 import (
-	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParsePktLine_Empty(t *testing.T) {
 	pkts, ok := parsePktLine(nil)
-	if !ok {
-		t.Error("expected ok=true for empty input")
-	}
-	if len(pkts) != 0 {
-		t.Fatalf("expected 0 packets, got %d", len(pkts))
-	}
+	assert.True(t, ok)
+	assert.Empty(t, pkts)
 }
 
 func TestParsePktLine_SpecialPackets(t *testing.T) {
@@ -23,8 +21,9 @@ func TestParsePktLine_SpecialPackets(t *testing.T) {
 	}
 	for input, want := range cases {
 		pkts, ok := parsePktLine([]byte(input))
-		if !ok || len(pkts) != 1 || pkts[0].typ != want {
-			t.Errorf("input %q: got %+v ok=%v, want type %d", input, pkts, ok, want)
+		assert.True(t, ok)
+		if assert.Len(t, pkts, 1) {
+			assert.Equal(t, want, pkts[0].typ)
 		}
 	}
 }
@@ -32,28 +31,30 @@ func TestParsePktLine_SpecialPackets(t *testing.T) {
 func TestParsePktLine_DataPacket(t *testing.T) {
 	// "000ahello\n" = length 0x000a (10), payload "hello\n"
 	pkts, ok := parsePktLine([]byte("000ahello\n"))
-	if !ok || len(pkts) != 1 || pkts[0].typ != pktData || string(pkts[0].payload) != "hello\n" {
-		t.Errorf("got %+v ok=%v", pkts, ok)
+	assert.True(t, ok)
+	if assert.Len(t, pkts, 1) {
+		assert.Equal(t, pktData, pkts[0].typ)
+		assert.Equal(t, "hello\n", string(pkts[0].payload))
 	}
 }
 
 func TestParsePktLine_MalformedAndTruncated(t *testing.T) {
 	// Bad hex prefix.
-	if _, ok := parsePktLine([]byte("gggghi")); ok {
-		t.Error("expected ok=false for malformed length prefix")
-	}
+	pkts, ok := parsePktLine([]byte("gggghi"))
+	assert.False(t, ok)
+	assert.Nil(t, pkts)
 	// Length claims 0x0020 but only 9 bytes available.
-	if _, ok := parsePktLine([]byte("0020short")); ok {
-		t.Error("expected ok=false for truncated packet")
-	}
+	pkts, ok = parsePktLine([]byte("0020short"))
+	assert.False(t, ok)
+	assert.Nil(t, pkts)
 	// Length 3 is reserved; we treat as malformed.
-	if _, ok := parsePktLine([]byte("00030000")); ok {
-		t.Error("expected ok=false for reserved length 3")
-	}
+	pkts, ok = parsePktLine([]byte("00030000"))
+	assert.False(t, ok)
+	assert.Nil(t, pkts)
 	// Less than 4 bytes.
-	if _, ok := parsePktLine([]byte("ab")); ok {
-		t.Error("expected ok=false for sub-prefix input")
-	}
+	pkts, ok = parsePktLine([]byte("ab"))
+	assert.False(t, ok)
+	assert.Nil(t, pkts)
 }
 
 func TestParsePktLine_RealV1Body(t *testing.T) {
@@ -64,17 +65,11 @@ func TestParsePktLine_RealV1Body(t *testing.T) {
 		"0032have 553c2077f0edc3d5dc5d17262f6aa498e69d6f8e\n" +
 		"0009done\n"
 	pkts, ok := parsePktLine([]byte(input))
-	if !ok {
-		t.Fatal("expected ok=true for well-formed v1 body")
-	}
+	require.True(t, ok)
 	wantTypes := []pktType{pktData, pktData, pktFlush, pktData, pktData}
-	if len(pkts) != len(wantTypes) {
-		t.Fatalf("got %d packets, want %d", len(pkts), len(wantTypes))
-	}
+	require.Len(t, pkts, len(wantTypes))
 	for i, want := range wantTypes {
-		if pkts[i].typ != want {
-			t.Errorf("packet %d: got type %d, want %d", i, pkts[i].typ, want)
-		}
+		assert.Equal(t, want, pkts[i].typ)
 	}
 }
 
@@ -87,21 +82,15 @@ func TestParsePktLine_RealV2Body(t *testing.T) {
 		"0009done\n" +
 		"0000"
 	pkts, ok := parsePktLine([]byte(input))
-	if !ok || len(pkts) != 7 {
-		t.Fatalf("got %d packets ok=%v, want 7 ok=true", len(pkts), ok)
-	}
-	if pkts[2].typ != pktDelim || pkts[6].typ != pktFlush {
-		t.Error("special packets misidentified")
-	}
+	require.True(t, ok)
+	require.Len(t, pkts, 7)
+	assert.Equal(t, pktDelim, pkts[2].typ)
+	assert.Equal(t, pktFlush, pkts[6].typ)
 }
 
 func TestEncodePktLine_RoundTrip(t *testing.T) {
 	input := []byte("000ahello\n" + "0000" + "0001" + "000aworld\n" + "0002")
 	pkts, ok := parsePktLine(input)
-	if !ok {
-		t.Fatal("parse failed on well-formed input")
-	}
-	if got := encodePktLine(pkts); !bytes.Equal(got, input) {
-		t.Errorf("round-trip mismatch:\n  in:  %q\n  out: %q", input, got)
-	}
+	require.True(t, ok)
+	assert.Equal(t, input, encodePktLine(pkts))
 }

--- a/internal/gitproto/upload_pack_test.go
+++ b/internal/gitproto/upload_pack_test.go
@@ -1,11 +1,11 @@
 package gitproto
 
 import (
-	"bytes"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func normalize(body string) string {
@@ -39,9 +39,7 @@ func TestIsUploadPackRequest(t *testing.T) {
 			if tc.contentType != "" {
 				req.Header.Set("Content-Type", tc.contentType)
 			}
-			if got := IsUploadPackRequest(req); got != tc.want {
-				t.Errorf("got %v, want %v", got, tc.want)
-			}
+			assert.Equal(t, tc.want, IsUploadPackRequest(req))
 		})
 	}
 }
@@ -63,25 +61,19 @@ func TestNormalizeUploadPackBody(t *testing.T) {
 		body2 := "00a3want " + oidA + " multi_ack_detailed no-done side-band-64k thin-pack no-progress ofs-delta deepen-since deepen-not agent=git/2.9.5\n" +
 			"0032want " + oidB + "\n0000" +
 			"0032have " + oidH1 + "\n0009done\n"
-		if normalize(body1) != normalize(body2) {
-			t.Errorf("normalized bodies differ:\n  %q\n  %q", normalize(body1), normalize(body2))
-		}
+		assert.Equal(t, normalize(body1), normalize(body2))
 	})
 
 	t.Run("different haves do not collide", func(t *testing.T) {
 		body1 := "0032want " + oidA + "\n0000" + "0032have " + oidH1 + "\n0009done\n"
 		body2 := "0032want " + oidA + "\n0000" + "0032have " + oidH2 + "\n0009done\n"
-		if normalize(body1) == normalize(body2) {
-			t.Error("haves drive the upstream pack and must not collapse")
-		}
+		assert.NotEqual(t, normalize(body1), normalize(body2))
 	})
 
 	t.Run("different wants do not collide", func(t *testing.T) {
 		body1 := "0032want " + oidA + "\n0009done\n"
 		body2 := "0032want " + oidC + "\n0009done\n"
-		if normalize(body1) == normalize(body2) {
-			t.Error("different wants must not collide")
-		}
+		assert.NotEqual(t, normalize(body1), normalize(body2))
 	})
 
 	t.Run("response-shaping fields stay distinct", func(t *testing.T) {
@@ -97,9 +89,7 @@ func TestNormalizeUploadPackBody(t *testing.T) {
 		seen := make(map[string]string)
 		for name, body := range bodies {
 			n := normalize(body)
-			if other, ok := seen[n]; ok {
-				t.Errorf("collision: %q == %q", name, other)
-			}
+			assert.NotContains(t, seen, n)
 			seen[n] = name
 		}
 	})
@@ -107,42 +97,31 @@ func TestNormalizeUploadPackBody(t *testing.T) {
 	t.Run("v2 ls-refs ref-prefix is preserved", func(t *testing.T) {
 		body1 := "0014command=ls-refs\n0015agent=git/2.43.0\n001bref-prefix refs/heads/\n0000"
 		body2 := "0014command=ls-refs\n0015agent=git/2.43.0\n001aref-prefix refs/tags/\n0000"
-		if normalize(body1) == normalize(body2) {
-			t.Error("different ref-prefix must not collide")
-		}
+		assert.NotEqual(t, normalize(body1), normalize(body2))
 	})
 
 	t.Run("v2 fetch agent drift collapses", func(t *testing.T) {
 		body1 := "0012command=fetch\n001bagent=git/2.43.0-Linux\n0001000ddeepen 1\n0032want " + oidA + "\n0009done\n0000"
 		body2 := "0012command=fetch\n001bagent=git/2.53.0-Linux\n0001000ddeepen 1\n0032want " + oidA + "\n0009done\n0000"
-		if normalize(body1) != normalize(body2) {
-			t.Error("v2 agent drift must not affect normalization")
-		}
+		assert.Equal(t, normalize(body1), normalize(body2))
 	})
 
 	t.Run("v1 inline agent stripped, other capabilities kept", func(t *testing.T) {
 		body1 := "0080want " + oidA + " multi_ack_detailed no-done side-band-64k thin-pack ofs-delta agent=git/2.43.0\n0009done\n"
 		body2 := "0080want " + oidA + " multi_ack_detailed no-done side-band-64k thin-pack ofs-delta agent=git/2.53.0\n0009done\n"
 		got := normalize(body1)
-		if got != normalize(body2) {
-			t.Errorf("agent-only difference must collapse:\n  %q\n  %q", got, normalize(body2))
-		}
-		if !strings.Contains(got, "thin-pack") || strings.Contains(got, "agent=") {
-			t.Errorf("got %q", got)
-		}
+		assert.Equal(t, normalize(body2), got)
+		assert.Contains(t, got, "thin-pack")
+		assert.NotContains(t, got, "agent=")
 	})
 
 	t.Run("malformed body returned unchanged", func(t *testing.T) {
 		body := []byte("this is not pkt-line data")
-		if got := NormalizeUploadPackBody(body); !bytes.Equal(got, body) {
-			t.Errorf("got %q", got)
-		}
+		assert.Equal(t, body, NormalizeUploadPackBody(body))
 	})
 
 	t.Run("empty body produces empty output", func(t *testing.T) {
-		if got := NormalizeUploadPackBody(nil); len(got) != 0 {
-			t.Errorf("got %q", got)
-		}
+		assert.Empty(t, NormalizeUploadPackBody(nil))
 	})
 
 	// session-id is a per-invocation UUID added in Git 2.36 (April 2022).
@@ -150,28 +129,25 @@ func TestNormalizeUploadPackBody(t *testing.T) {
 		body1 := "0012command=fetch\n0015agent=git/2.43.0\n0016session-id=abcdef\n00010032want " + oidA + "\n0009done\n0000"
 		body2 := "0012command=fetch\n0015agent=git/2.43.0\n0016session-id=fedcba\n00010032want " + oidA + "\n0009done\n0000"
 		got := normalize(body1)
-		if got != normalize(body2) || strings.Contains(got, "session-id=") {
-			t.Errorf("got %q", got)
-		}
+		assert.Equal(t, normalize(body2), got)
+		assert.NotContains(t, got, "session-id=")
 	})
 
 	t.Run("v1 inline session-id stripped alongside agent", func(t *testing.T) {
 		body1 := "009awant " + oidA + " multi_ack_detailed no-done side-band-64k thin-pack ofs-delta agent=git/2.43.0 session-id=aaa-1\n0009done\n"
 		body2 := "009awant " + oidA + " multi_ack_detailed no-done side-band-64k thin-pack ofs-delta agent=git/2.53.0 session-id=zzz-2\n0009done\n"
 		got := normalize(body1)
-		if got != normalize(body2) ||
-			strings.Contains(got, "session-id=") || strings.Contains(got, "agent=") ||
-			!strings.Contains(got, "thin-pack") {
-			t.Errorf("got %q", got)
-		}
+		assert.Equal(t, normalize(body2), got)
+		assert.NotContains(t, got, "session-id=")
+		assert.NotContains(t, got, "agent=")
+		assert.Contains(t, got, "thin-pack")
 	})
 
 	// Prefix matching is exact: substrings of stripped tokens must survive.
 	t.Run("'haven' and 'session-ids' prefixes are not stripped", func(t *testing.T) {
 		body := "000ehaven foo\n0014session-ids=keep\n0009done\n"
 		got := normalize(body)
-		if !strings.Contains(got, "haven foo") || !strings.Contains(got, "session-ids=keep") {
-			t.Errorf("got %q", got)
-		}
+		assert.Contains(t, got, "haven foo")
+		assert.Contains(t, got, "session-ids=keep")
 	})
 }

--- a/internal/handlers/git_server_test.go
+++ b/internal/handlers/git_server_test.go
@@ -204,9 +204,7 @@ func TestGitServerHandler404Retry(t *testing.T) {
 	handler := NewGitServerHandler(credentials, nil)
 	rsp := &http.Response{StatusCode: 404, Body: io.NopCloser(strings.NewReader(""))}
 	url, err := url.Parse("https://example.com")
-	if err != nil {
-		t.Errorf("parsing url: %v", err)
-	}
+	require.NoError(t, err)
 
 	roundTripper := goproxy.RoundTripperFunc(func(r *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Response, error) {
 		assert.Equal(t, "", r.Header.Get("Authorization"), "auth should be removed")
@@ -454,9 +452,10 @@ func TestGitServerHandler_NoCloneWithSingleCredPost(t *testing.T) {
 	require.NoError(t, err, "failed to create request")
 	proxyCtx := &goproxy.ProxyCtx{Req: req}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
-	_, found := proxyctx.GetBuffer(proxyCtx, reqBodyCtxKey)
+	buffer, found := proxyctx.GetBuffer(proxyCtx, reqBodyCtxKey)
 
 	assert.False(t, found, "expect clone buffer not present")
+	assert.Nil(t, buffer)
 }
 
 func TestGitServerHandler_RepositoryScopedCredentials(t *testing.T) {
@@ -543,9 +542,7 @@ func TestGitServerHandler_RequestJITAccess(t *testing.T) {
 			handler := NewGitServerHandler(credentials, testClient)
 			rsp := &http.Response{StatusCode: 404, Body: io.NopCloser(strings.NewReader(""))}
 			url, err := url.Parse(test.url)
-			if err != nil {
-				t.Errorf("parsing url: %v", err)
-			}
+			require.NoError(t, err)
 
 			roundTripper := goproxy.RoundTripperFunc(func(r *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Response, error) {
 				_, pass, ok := r.BasicAuth()

--- a/internal/handlers/github_api_test.go
+++ b/internal/handlers/github_api_test.go
@@ -440,9 +440,7 @@ func TestGitHubAPIHandler_TokenFallback_In_Proxima(t *testing.T) {
 	}
 	handler := NewGitHubAPIHandler(credentials)
 	url, err := url.Parse("https://api.foo.ghe.com/repos/github/dependabot-action")
-	if err != nil {
-		t.Errorf("parsing url: %v", err)
-	}
+	require.NoError(t, err)
 
 	tests := []struct {
 		name                   string

--- a/internal/handlers/nuget_feed_test.go
+++ b/internal/handlers/nuget_feed_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dependabot/proxy/internal/config"
 )
@@ -82,9 +83,7 @@ func TestNugetFeedHandler(t *testing.T) {
 	}
 
 	jsonResponder, err := httpmock.NewJsonResponder(200, rsp)
-	if err != nil {
-		t.Errorf("constructing httpmock responser: %v", err)
-	}
+	require.NoError(t, err)
 	httpmock.RegisterResponder("GET", "https://corp.dependabot.com/nuget/", jsonResponder)
 
 	xmlResponse := `
@@ -110,9 +109,7 @@ func TestNugetFeedHandler(t *testing.T) {
 	}
 
 	azureDevOpsJsonResponder, err := httpmock.NewJsonResponder(200, azureDevOpsRsp)
-	if err != nil {
-		t.Errorf("constructing httpmock responser: %v", err)
-	}
+	require.NoError(t, err)
 	httpmock.RegisterResponder("GET", "https://pkgs.dev.azure.com/example/public/_packaging/some-feed/nuget/v3/index.json", azureDevOpsJsonResponder)
 
 	azureDevOpsRsp2 := nugetV3IndexResponse{
@@ -125,9 +122,7 @@ func TestNugetFeedHandler(t *testing.T) {
 	}
 
 	azureDevOpsJsonResponder2, err := httpmock.NewJsonResponder(200, azureDevOpsRsp2)
-	if err != nil {
-		t.Errorf("constructing httpmock responser: %v", err)
-	}
+	require.NoError(t, err)
 	httpmock.RegisterResponder("GET", "https://pkgs.dev.azure.com/example/public/_packaging/some-feed2/nuget/v3/index.json", azureDevOpsJsonResponder2)
 
 	// Log for initial authentication contains appropriate information

--- a/internal/handlers/python_index_test.go
+++ b/internal/handlers/python_index_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/elazarl/goproxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dependabot/proxy/internal/config"
 )
@@ -217,9 +219,7 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromJSON(t *test
 
 func TestPythonDownloadPrefixFromSimpleLinkRejectsUnscopedLinks(t *testing.T) {
 	baseURL, err := url.Parse("https://pkgs.example.com/my-org/my-project/_packaging/my-feed/pypi/simple/my-package/")
-	if err != nil {
-		t.Fatalf("failed to parse base URL: %v", err)
-	}
+	require.NoError(t, err)
 
 	tests := []struct {
 		name string
@@ -245,9 +245,9 @@ func TestPythonDownloadPrefixFromSimpleLinkRejectsUnscopedLinks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if prefix, ok := pythonDownloadPrefixFromSimpleLink(tt.link, baseURL); ok {
-				t.Fatalf("expected download prefix discovery to be rejected, got %s", prefix)
-			}
+			prefix, ok := pythonDownloadPrefixFromSimpleLink(tt.link, baseURL)
+			assert.False(t, ok)
+			assert.Nil(t, prefix)
 		})
 	}
 }
@@ -388,27 +388,23 @@ func TestPythonIndexDownloadAuthStoreEvictsOldestEntryAtLimit(t *testing.T) {
 			"https://pkgs.example.com/org/project/_packaging/feed-%d/pypi/download/",
 			i,
 		))
-		if err != nil {
-			t.Fatalf("failed to parse prefix URL: %v", err)
-		}
+		require.NoError(t, err)
 		store.add(prefix, auth)
 	}
 
 	store.mutex.RLock()
 	entryCount := len(store.entries)
 	store.mutex.RUnlock()
-	if entryCount != maxPythonIndexDownloadAuthEntries {
-		t.Fatalf("expected %d stored prefixes, got %d", maxPythonIndexDownloadAuthEntries, entryCount)
-	}
+	assert.Equal(t, maxPythonIndexDownloadAuthEntries, entryCount)
 
 	evictedReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
 		"https://pkgs.example.com/org/project/_packaging/feed-0/pypi/download/pkg/1.0/pkg.whl",
 		nil)
 
-	if _, ok := store.authFor(evictedReq); ok {
-		t.Fatal("oldest discovered download prefix should be evicted")
-	}
+	evictedAuth, ok := store.authFor(evictedReq)
+	assert.False(t, ok)
+	assert.Zero(t, evictedAuth)
 
 	retainedReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
@@ -418,9 +414,8 @@ func TestPythonIndexDownloadAuthStoreEvictsOldestEntryAtLimit(t *testing.T) {
 		),
 		nil)
 
-	if _, ok := store.authFor(retainedReq); !ok {
-		t.Fatal("newest discovered download prefix should be retained")
-	}
+	_, ok = store.authFor(retainedReq)
+	assert.True(t, ok)
 }
 
 func TestPythonIndexHandlerSkipsDiscoveryForLargeSimpleResponse(t *testing.T) {
@@ -453,12 +448,8 @@ func TestPythonIndexHandlerSkipsDiscoveryForLargeSimpleResponse(t *testing.T) {
 	handler.HandleResponse(indexResp, proxyCtx)
 
 	replayedBody, err := io.ReadAll(indexResp.Body)
-	if err != nil {
-		t.Fatalf("failed to read replayed response body: %v", err)
-	}
-	if string(replayedBody) != responseBody {
-		t.Fatal("large Simple API response body was not replayed unchanged")
-	}
+	require.NoError(t, err)
+	assert.Equal(t, responseBody, string(replayedBody))
 
 	downloadReq := httptest.NewRequestWithContext(t.Context(), "GET", downloadURL, nil)
 	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // newRequest builds a GET request to the given raw URL for use in tests.
@@ -29,9 +31,7 @@ func TestSetBasicAuthorization(t *testing.T) {
 		SetBasicAuthorization(req, "user", "pass")
 
 		want := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:pass"))
-		if got := req.Header.Get("Authorization"); got != want {
-			t.Errorf("Authorization = %q, want %q", got, want)
-		}
+		assert.Equal(t, want, req.Header.Get("Authorization"))
 	})
 
 	t.Run("clears pre-existing Authorization header", func(t *testing.T) {
@@ -39,12 +39,8 @@ func TestSetBasicAuthorization(t *testing.T) {
 		SetBasicAuthorization(req, "user", "pass")
 
 		want := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:pass"))
-		if got := req.Header.Get("Authorization"); got != want {
-			t.Errorf("Authorization = %q, want %q", got, want)
-		}
-		if vals := req.Header["Authorization"]; len(vals) != 1 {
-			t.Errorf("expected exactly 1 Authorization value, got %d: %v", len(vals), vals)
-		}
+		assert.Equal(t, want, req.Header.Get("Authorization"))
+		assert.Len(t, req.Header["Authorization"], 1)
 	})
 
 	t.Run("encodes empty username correctly", func(t *testing.T) {
@@ -52,9 +48,7 @@ func TestSetBasicAuthorization(t *testing.T) {
 		SetBasicAuthorization(req, "", "token")
 
 		want := "Basic " + base64.StdEncoding.EncodeToString([]byte(":token"))
-		if got := req.Header.Get("Authorization"); got != want {
-			t.Errorf("Authorization = %q, want %q", got, want)
-		}
+		assert.Equal(t, want, req.Header.Get("Authorization"))
 	})
 }
 
@@ -63,21 +57,15 @@ func TestSetBearerAuthorization(t *testing.T) {
 		req := newRequest(t, "https://example.com")
 		SetBearerAuthorization(req, "my-token")
 
-		if got := req.Header.Get("Authorization"); got != "Bearer my-token" {
-			t.Errorf("Authorization = %q, want %q", got, "Bearer my-token")
-		}
+		assert.Equal(t, "Bearer my-token", req.Header.Get("Authorization"))
 	})
 
 	t.Run("clears pre-existing Authorization header", func(t *testing.T) {
 		req := newRequestWithAuth(t, "https://example.com", "Basic dXNlcjpwYXNz")
 		SetBearerAuthorization(req, "new-token")
 
-		if got := req.Header.Get("Authorization"); got != "Bearer new-token" {
-			t.Errorf("Authorization = %q, want %q", got, "Bearer new-token")
-		}
-		if vals := req.Header["Authorization"]; len(vals) != 1 {
-			t.Errorf("expected exactly 1 Authorization value, got %d: %v", len(vals), vals)
-		}
+		assert.Equal(t, "Bearer new-token", req.Header.Get("Authorization"))
+		assert.Len(t, req.Header["Authorization"], 1)
 	})
 }
 
@@ -86,21 +74,15 @@ func TestSetGitHubAPITokenAuthorization(t *testing.T) {
 		req := newRequest(t, "https://api.github.com")
 		SetGitHubAPITokenAuthorization(req, "ghp_abc123")
 
-		if got := req.Header.Get("Authorization"); got != "token ghp_abc123" {
-			t.Errorf("Authorization = %q, want %q", got, "token ghp_abc123")
-		}
+		assert.Equal(t, "token ghp_abc123", req.Header.Get("Authorization"))
 	})
 
 	t.Run("clears pre-existing Authorization header", func(t *testing.T) {
 		req := newRequestWithAuth(t, "https://api.github.com", "token old-token")
 		SetGitHubAPITokenAuthorization(req, "new-token")
 
-		if got := req.Header.Get("Authorization"); got != "token new-token" {
-			t.Errorf("Authorization = %q, want %q", got, "token new-token")
-		}
-		if vals := req.Header["Authorization"]; len(vals) != 1 {
-			t.Errorf("expected exactly 1 Authorization value, got %d: %v", len(vals), vals)
-		}
+		assert.Equal(t, "token new-token", req.Header.Get("Authorization"))
+		assert.Len(t, req.Header["Authorization"], 1)
 	})
 }
 
@@ -109,21 +91,15 @@ func TestSetRawAuthorization(t *testing.T) {
 		req := newRequest(t, "https://example.com")
 		SetRawAuthorization(req, "Bearer already-formatted")
 
-		if got := req.Header.Get("Authorization"); got != "Bearer already-formatted" {
-			t.Errorf("Authorization = %q, want %q", got, "Bearer already-formatted")
-		}
+		assert.Equal(t, "Bearer already-formatted", req.Header.Get("Authorization"))
 	})
 
 	t.Run("clears pre-existing Authorization header", func(t *testing.T) {
 		req := newRequestWithAuth(t, "https://example.com", "Bearer stale")
 		SetRawAuthorization(req, "token new-raw")
 
-		if got := req.Header.Get("Authorization"); got != "token new-raw" {
-			t.Errorf("Authorization = %q, want %q", got, "token new-raw")
-		}
-		if vals := req.Header["Authorization"]; len(vals) != 1 {
-			t.Errorf("expected exactly 1 Authorization value, got %d: %v", len(vals), vals)
-		}
+		assert.Equal(t, "token new-raw", req.Header.Get("Authorization"))
+		assert.Len(t, req.Header["Authorization"], 1)
 	})
 }
 
@@ -132,12 +108,8 @@ func TestReplaceAuthorization_CustomKey(t *testing.T) {
 		req := newRequest(t, "https://cloudsmith.example.com")
 		ReplaceAuthorization(req, "X-Api-Key", "my-api-key")
 
-		if got := req.Header.Get("X-Api-Key"); got != "my-api-key" {
-			t.Errorf("X-Api-Key = %q, want %q", got, "my-api-key")
-		}
-		if got := req.Header.Get("Authorization"); got != "" {
-			t.Errorf("Authorization should be empty, got %q", got)
-		}
+		assert.Equal(t, "my-api-key", req.Header.Get("X-Api-Key"))
+		assert.Empty(t, req.Header.Get("Authorization"))
 	})
 
 	t.Run("clears pre-existing Authorization header before setting custom key", func(t *testing.T) {
@@ -145,12 +117,8 @@ func TestReplaceAuthorization_CustomKey(t *testing.T) {
 		req.Header.Set("X-Api-Key", "old-key")
 		ReplaceAuthorization(req, "X-Api-Key", "new-key")
 
-		if got := req.Header.Get("X-Api-Key"); got != "new-key" {
-			t.Errorf("X-Api-Key = %q, want %q", got, "new-key")
-		}
-		if vals := req.Header["X-Api-Key"]; len(vals) != 1 {
-			t.Errorf("expected exactly 1 X-Api-Key value, got %d: %v", len(vals), vals)
-		}
+		assert.Equal(t, "new-key", req.Header.Get("X-Api-Key"))
+		assert.Len(t, req.Header["X-Api-Key"], 1)
 	})
 }
 
@@ -240,9 +208,7 @@ func TestUrlMatchesRequest(t *testing.T) {
 			req := &http.Request{URL: reqURL}
 
 			result := UrlMatchesRequest(req, tt.urlStr, tt.pathMatch)
-			if result != tt.expected {
-				t.Errorf("urlMatchesRequest() = %v, expected %v", result, tt.expected)
-			}
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/internal/oidc/oidc_credential_test.go
+++ b/internal/oidc/oidc_credential_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dependabot/proxy/internal/config"
 )
@@ -31,15 +32,10 @@ func TestSuccessfulAuthenticationDoesNotMakeARepeatedRequest(t *testing.T) {
 		"tenant-id": "test-tenant-id",
 		"client-id": "test-client-id",
 	})
-	if err != nil {
-		t.Fatalf("unexpected error creating OIDC credential: %v", err)
-	}
+	require.NoError(t, err)
 
 	// ensure of type azure
-	_, ok := creds.parameters.(*AzureOIDCParameters)
-	if !ok {
-		t.Fatalf("expected AzureOIDCParameters, but got %T", creds.parameters)
-	}
+	require.IsType(t, &AzureOIDCParameters{}, creds.parameters)
 
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
@@ -49,9 +45,7 @@ func TestSuccessfulAuthenticationDoesNotMakeARepeatedRequest(t *testing.T) {
 		Count: 1,
 		Value: "abc",
 	})
-	if err != nil {
-		t.Fatalf("unexpected error creating JSON responder: %v", err)
-	}
+	require.NoError(t, err)
 	httpmock.RegisterResponder("GET", "https://example.com/token", jsonResponder)
 
 	// mock Azure OIDC token request
@@ -77,16 +71,12 @@ func TestSuccessfulAuthenticationDoesNotMakeARepeatedRequest(t *testing.T) {
 	// request the token - should succeed
 	ctx := context.Background()
 	token, err := GetOrRefreshOIDCToken(creds, ctx)
-	if err != nil {
-		t.Fatalf("unexpected error getting OIDC token on first try")
-	}
+	require.NoError(t, err)
 	assert.Equal(t, "__test_token__", token, "expected token to match mocked value")
 
 	// request the token again - should succeed
 	token, err = GetOrRefreshOIDCToken(creds, ctx)
-	if err != nil {
-		t.Fatalf("unexpected error getting OIDC token on second try")
-	}
+	require.NoError(t, err)
 	assert.Equal(t, "__test_token__", token, "expected token to match mocked value")
 
 	// ensure only one request was actually made
@@ -107,15 +97,10 @@ func TestFailedAuthenticationIsNotRetried(t *testing.T) {
 		"tenant-id": "test-tenant-id",
 		"client-id": "test-client-id",
 	})
-	if err != nil {
-		t.Fatalf("unexpected error creating OIDC credential: %v", err)
-	}
+	require.NoError(t, err)
 
 	// ensure of type azure
-	_, ok := creds.parameters.(*AzureOIDCParameters)
-	if !ok {
-		t.Fatalf("expected AzureOIDCParameters, but got %T", creds.parameters)
-	}
+	require.IsType(t, &AzureOIDCParameters{}, creds.parameters)
 
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
@@ -125,9 +110,7 @@ func TestFailedAuthenticationIsNotRetried(t *testing.T) {
 		Count: 1,
 		Value: "abc",
 	})
-	if err != nil {
-		t.Fatalf("unexpected error creating JSON responder: %v", err)
-	}
+	require.NoError(t, err)
 	httpmock.RegisterResponder("GET", "https://example.com/token", jsonResponder)
 
 	// mock Azure OIDC token request
@@ -147,16 +130,12 @@ func TestFailedAuthenticationIsNotRetried(t *testing.T) {
 
 	// request the token - should fail
 	ctx := context.Background()
-	token, err := GetOrRefreshOIDCToken(creds, ctx)
-	if err == nil {
-		t.Fatalf("expected error getting OIDC token on first try, but got token: %s", token)
-	}
+	_, err = GetOrRefreshOIDCToken(creds, ctx)
+	assert.Error(t, err)
 
 	// request the token again - should fail
-	token, err = GetOrRefreshOIDCToken(creds, ctx)
-	if err == nil {
-		t.Fatalf("expected error getting OIDC token on second try, but got token: %s", token)
-	}
+	_, err = GetOrRefreshOIDCToken(creds, ctx)
+	assert.Error(t, err)
 
 	// ensure only one request was actually made
 	assert.Equal(t, 1, requestsReceived, "expected only one token request due to failed authentication being cached")
@@ -369,18 +348,11 @@ func TestTryCreateOIDCCredential(t *testing.T) {
 
 			actual, _ := CreateOIDCCredential(tc.cred)
 			if tc.expectedParameters == nil {
-				if actual != nil {
-					t.Fatalf("expected no credential, but got %+v", actual)
-				}
-
-				// otherwise good
+				assert.Nil(t, actual)
 				return
 			}
 
-			if actual == nil {
-				t.Fatalf("expected credential, but got nil")
-				return
-			}
+			require.NotNil(t, actual)
 
 			// check type
 			assert.Equal(t, tc.expectedParameters.Name(), actual.Provider())

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dependabot/proxy/internal/config"
 )
@@ -38,13 +39,9 @@ func TestProxyHTTPRequest(t *testing.T) {
 	defer httpSrv.Close()
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
-	if err != nil {
-		t.Fatalf("initializing new request: %v", err)
-	}
+	require.NoError(t, err)
 	rsp, err := client.Do(req)
-	if err != nil {
-		t.Errorf("making proxied request: %v", err)
-	}
+	require.NoError(t, err)
 	defer rsp.Body.Close()
 	assert.Equal(t, 200, rsp.StatusCode)
 }
@@ -68,14 +65,9 @@ func TestIPRestrictions(t *testing.T) {
 	for _, url := range httpTestCases {
 		t.Run(url, func(t *testing.T) {
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
-			if err != nil {
-				t.Fatalf("initializing new request: %v", err)
-			}
+			require.NoError(t, err)
 			rsp, err := client.Do(req)
-			if err != nil {
-				t.Errorf("making proxied request: %v", err)
-				return
-			}
+			require.NoError(t, err)
 			defer rsp.Body.Close()
 
 			assert.Equal(t, 403, rsp.StatusCode)
@@ -95,9 +87,7 @@ func TestIPRestrictions(t *testing.T) {
 	for _, url := range httpsTestCases {
 		t.Run(url, func(t *testing.T) {
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
-			if err != nil {
-				t.Fatalf("initializing new request: %v", err)
-			}
+			require.NoError(t, err)
 			_, err = client.Do(req) //nolint:bodyclose // error expected, no body to close
 			assert.Error(t, err)
 		})
@@ -147,15 +137,11 @@ func TestMetadataAPIRestriction(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.url, func(t *testing.T) {
 			req, err := http.NewRequestWithContext(context.Background(), "GET", tc.url, nil)
-			if err != nil {
-				t.Errorf("initializing new request: %v", err)
-			}
+			require.NoError(t, err)
 			req.Host = tc.host
 
 			rsp, err := client.Do(req)
-			if err != nil {
-				t.Errorf("making proxied request: %v", err)
-			}
+			require.NoError(t, err)
 			defer rsp.Body.Close()
 
 			assert.Equal(t, 403, rsp.StatusCode)
@@ -180,26 +166,18 @@ func testProxyServer(t *testing.T, cfg *config.Config, blockedIPs []net.IP) (*ht
 
 	lc := net.ListenConfig{}
 	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Errorf("net.Listen: %v", err)
-	}
+	require.NoError(t, err)
 	srv.Addr = ln.Addr().String()
 
 	go func() {
-		if err := srv.Serve(ln); err != http.ErrServerClosed {
-			t.Errorf("ListenAndServe: %v", err)
-		}
+		assert.ErrorIs(t, srv.Serve(ln), http.ErrServerClosed)
 	}()
 
 	// Build a client for the proxy
 	proxyURL, err := url.Parse("http://" + srv.Addr)
-	if err != nil {
-		t.Errorf("url.Parse: %v", err)
-	}
+	require.NoError(t, err)
 	rootCAs := x509.NewCertPool()
-	if ok := rootCAs.AppendCertsFromPEM([]byte(testProxyConfig.CA.Cert)); !ok {
-		t.Fatal("AppendCertsFromPEM not ok")
-	}
+	require.True(t, rootCAs.AppendCertsFromPEM([]byte(testProxyConfig.CA.Cert)))
 	client := &http.Client{
 		Transport: &http.Transport{
 			Proxy: http.ProxyURL(proxyURL),
@@ -224,15 +202,11 @@ func testHTTPServer(t *testing.T) (string, *http.Server) {
 
 	lc := net.ListenConfig{}
 	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Errorf("net.Listen: %v", err)
-	}
+	require.NoError(t, err)
 	srv.Addr = ln.Addr().String()
 
 	go func() {
-		if err := srv.Serve(ln); err != http.ErrServerClosed {
-			t.Errorf("ListenAndServe: %v", err)
-		}
+		assert.ErrorIs(t, srv.Serve(ln), http.ErrServerClosed)
 	}()
 
 	return "http://" + srv.Addr, srv


### PR DESCRIPTION
## Summary
- replace manual `t.Error`, `t.Errorf`, `t.Fatal`, and `t.Fatalf` checks with typed Testify assertions where they improve diagnostics
- use `require` for setup and preconditions needed by subsequent test code, and `assert` for behavior under test
- assert nil or zero companion values when project helpers return `false`, making their failure contracts explicit
- avoid redundant assertion messages and retain `t.Fatal` where Testify would add a one-off import without improving the test

## Benefits
- produces structured expected/actual diagnostics instead of hand-formatted failure messages
- stops tests when setup prerequisites fail, preventing misleading follow-up failures and nil dereferences
- keeps behavioral checks non-fatal so independent assertions can report multiple failures in one run
- verifies failed lookups do not expose partial or stale values
- removes repetitive error-handling boilerplate and visual noise, making test intent easier to scan

## Testing
- `go test ./...`