### PR TITLE
Fix gocritic warning in cargo registry handler

### DIFF
--- a/internal/handlers/cargo_registry.go
+++ b/internal/handlers/cargo_registry.go
@@ -83,16 +83,17 @@ func NewCargoRegistryHandler(credentials config.Credentials) *CargoRegistryHandl
 			password: password,
 		}
 
-		if url != "" {
+		switch {
+		case url != "":
 			if _, err := helpers.ParseURLLax(cargoCred.url); err != nil {
 				logrus.Warnf("ignoring invalid registry url (%s): %v", cargoCred.url, err)
 				continue
 			}
-		} else if host != "" {
+		case host != "":
 			// Only set host when url is empty so URL/path scoping always
 			// takes precedence and never falls back to host-only matching.
 			cargoCred.host = host
-		} else {
+		default:
 			logrus.Warn("ignoring cargo_registry credential with no url or host")
 			continue
 		}


### PR DESCRIPTION
### What are you trying to accomplish?

Replace the cargo credential URL and host `if` chain with a `switch` so the `gocritic` `ifElseChain` check passes. Matching and validation behavior stay the same.

### Anything you want to highlight for special attention from reviewers?

This is layer 1 of 6. The URL-scoped, host-scoped, and invalid credential paths are unchanged.

### How will you know you've accomplished your goal?

`golangci-lint run --enable-only=gocritic ./...` and `go test ./internal/handlers` pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.