### PR TITLE
Remove ineffectual NuGet test assignment

### DIFF
--- a/internal/handlers/nuget_feed_test.go
+++ b/internal/handlers/nuget_feed_test.go
@@ -724,7 +724,7 @@ func discoverNugetFeed(t *testing.T, handler *NugetFeedHandler, sourceURL string
 	proxyCtx := &goproxy.ProxyCtx{}
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, sourceURL, nil)
 	handler.PrepareRequest(req, proxyCtx)
-	req = handleRequestAndClose(handler, req, proxyCtx)
+	handleRequestAndClose(handler, req, proxyCtx)
 
 	resp := &http.Response{
 		StatusCode: statusCode,


### PR DESCRIPTION
### What are you trying to accomplish?

Remove an unused assignment in `discoverNugetFeed` so the `ineffassign` check passes. The helper still runs for its response cleanup side effect.

### Anything you want to highlight for special attention from reviewers?

This is layer 2 of 6. The returned request was never read after the call.

### How will you know you've accomplished your goal?

`golangci-lint run --enable-only=ineffassign ./...` and `go test ./internal/handlers` pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.