### PR TITLE
Use context-aware requests in NuGet test

### DIFF
--- a/internal/handlers/nuget_feed_test.go
+++ b/internal/handlers/nuget_feed_test.go
@@ -501,6 +501,7 @@ func TestNugetFeedHandlerConcurrentDiscoveryIsDeduplicated(t *testing.T) {
 	const workers = 50
 	responseBody := nugetV3Response("https://cdn.example.com/packages")
 	start := make(chan struct{})
+	ctx := t.Context()
 	var waitGroup sync.WaitGroup
 	for range workers {
 		waitGroup.Add(1)
@@ -508,7 +509,7 @@ func TestNugetFeedHandlerConcurrentDiscoveryIsDeduplicated(t *testing.T) {
 			defer waitGroup.Done()
 			<-start
 			proxyCtx := &goproxy.ProxyCtx{}
-			indexReq := httptest.NewRequest(http.MethodGet, "https://nuget.example.com/index.json", nil)
+			indexReq := httptest.NewRequestWithContext(ctx, http.MethodGet, "https://nuget.example.com/index.json", nil)
 			handler.PrepareRequest(indexReq, proxyCtx)
 			handler.HandleRequest(indexReq, proxyCtx)
 			resp := &http.Response{
@@ -518,7 +519,7 @@ func TestNugetFeedHandlerConcurrentDiscoveryIsDeduplicated(t *testing.T) {
 			handler.HandleResponse(resp, proxyCtx)
 			resp.Body.Close()
 
-			packageReq := httptest.NewRequest(http.MethodGet, "https://cdn.example.com/packages/example/index.json", nil)
+			packageReq := httptest.NewRequestWithContext(ctx, http.MethodGet, "https://cdn.example.com/packages/example/index.json", nil)
 			handler.HandleRequest(packageReq, &goproxy.ProxyCtx{})
 		}()
 	}


### PR DESCRIPTION
### What are you trying to accomplish?

Use `httptest.NewRequestWithContext` for requests created by the concurrent NuGet discovery test so the `noctx` check passes.

### Anything you want to highlight for special attention from reviewers?

This is layer 3 of 6. The test context is captured before the worker goroutines start and shared by both request types.

### How will you know you've accomplished your goal?

`golangci-lint run --enable-only=noctx ./...` and the concurrent discovery test pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.