### PR TITLE
Handle all errcheck findings

### DIFF
--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -4,6 +4,7 @@ package apiclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -100,7 +101,7 @@ func WithTransport(transport *http.Transport) ClientOpt {
 // RequestJITAccess asks the API to create a token with access to the specified repository.
 // If username and password are provided, they are used for basic auth; otherwise the client's
 // default token is used in the Authorization header.
-func (c *Client) RequestJITAccess(proxyCtx *goproxy.ProxyCtx, endpoint string, username string, password string, account string, repo string) (*config.Credential, error) {
+func (c *Client) RequestJITAccess(proxyCtx *goproxy.ProxyCtx, endpoint string, username string, password string, account string, repo string) (_ *config.Credential, err error) {
 	url := c.newURL("%s", endpoint)
 
 	if err := c.jitRateLimit.Acquire(proxyCtx.Req.Context(), 1); err != nil {
@@ -126,7 +127,9 @@ func (c *Client) RequestJITAccess(proxyCtx *goproxy.ProxyCtx, endpoint string, u
 	if err != nil {
 		return nil, err
 	}
-	defer rsp.Body.Close()
+	defer func() {
+		err = errors.Join(err, rsp.Body.Close())
+	}()
 	data, err := io.ReadAll(rsp.Body)
 	if err != nil {
 		logging.RequestLogf(proxyCtx, "Failed reading scope response: %v", err)
@@ -148,7 +151,7 @@ func (c *Client) RequestJITAccess(proxyCtx *goproxy.ProxyCtx, endpoint string, u
 }
 
 // ReportMetrics sends metric data to the server.
-func (c *Client) ReportMetrics(ctx context.Context, metricsData string) error {
+func (c *Client) ReportMetrics(ctx context.Context, metricsData string) (err error) {
 	metricErrorURL := c.newURL("/update_jobs/%s/record_metrics", c.jobID)
 
 	// Submit JSON:
@@ -156,7 +159,9 @@ func (c *Client) ReportMetrics(ctx context.Context, metricsData string) error {
 	if err != nil {
 		return err
 	}
-	defer rsp.Body.Close()
+	defer func() {
+		err = errors.Join(err, rsp.Body.Close())
+	}()
 	return nil
 }
 

--- a/internal/apiclient/client_test.go
+++ b/internal/apiclient/client_test.go
@@ -124,7 +124,8 @@ func TestClient_RequestJITAccess(t *testing.T) {
 			var repoData map[string]string
 			if err := json.NewDecoder(r.Body).Decode(&repoData); err != nil {
 				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte("Invalid request"))
+				_, err := w.Write([]byte("Invalid request"))
+				require.NoError(t, err)
 				return
 			}
 
@@ -136,7 +137,8 @@ func TestClient_RequestJITAccess(t *testing.T) {
 			}
 			data, err := json.Marshal(credentialMap)
 			assert.NoError(t, err)
-			w.Write(data)
+			_, err = w.Write(data)
+			require.NoError(t, err)
 		}))
 		defer testServer.Close()
 
@@ -154,7 +156,8 @@ func TestClient_RequestJITAccess(t *testing.T) {
 	t.Run("not implemented", func(t *testing.T) {
 		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotImplemented)
-			w.Write([]byte("Not Implemented"))
+			_, err := w.Write([]byte("Not Implemented"))
+			require.NoError(t, err)
 		}))
 		defer testServer.Close()
 
@@ -178,7 +181,8 @@ func TestClient_RequestJITAccess(t *testing.T) {
 			atomic.AddInt32(&totalCounter, 1)
 			if concurrencyCounter.Load() > 1 {
 				w.WriteHeader(http.StatusTooManyRequests)
-				w.Write([]byte("Too many requests"))
+				_, err := w.Write([]byte("Too many requests"))
+				require.NoError(t, err)
 				return
 			}
 			defer concurrencyCounter.Add(-1)

--- a/internal/cache/handlers.go
+++ b/internal/cache/handlers.go
@@ -67,7 +67,9 @@ var ignoreHeaders = map[string]struct{}{
 // generates the key used in the DB, includes a hash of the body
 func key(r *http.Request) Key {
 	data, _ := io.ReadAll(r.Body)
-	r.Body.Close()
+	if err := r.Body.Close(); err != nil {
+		logrus.Warnf("failed to close request body while generating cache key: %v", err)
+	}
 	r.Body = io.NopCloser(bytes.NewBuffer(data))
 	k := Key{
 		Method: r.Method,

--- a/internal/cache/handlers_test.go
+++ b/internal/cache/handlers_test.go
@@ -37,10 +37,17 @@ func (c *closeTrackingReadCloser) Close() error {
 	return nil
 }
 
+func cleanupCacheDir(t *testing.T, cacheDir string) {
+	t.Helper()
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(cacheDir))
+	})
+}
+
 func TestCache_Disabled(t *testing.T) {
 	const enabled = false
 	cacheDir := filepath.Join(os.TempDir(), strconv.Itoa(time.Now().Nanosecond()))
-	defer os.RemoveAll(cacheDir)
+	cleanupCacheDir(t, cacheDir)
 
 	cacher, err := New(enabled, cacheDir)
 	require.NoError(t, err)
@@ -54,7 +61,7 @@ func TestCache_Disabled(t *testing.T) {
 	// If cached there will be a response.
 	_, resp := cacher.OnRequest(req, proxyCtx)
 	if resp != nil {
-		resp.Body.Close()
+		require.NoError(t, resp.Body.Close())
 	}
 	assert.Nil(t, resp)
 
@@ -63,14 +70,16 @@ func TestCache_Disabled(t *testing.T) {
 	resp2 := &http.Response{Body: originalBody}
 	proxyCtx.Resp = resp2
 	resp3 := cacher.OnResponse(resp2, proxyCtx)
-	defer resp3.Body.Close()
+	defer func() {
+		require.NoError(t, resp3.Body.Close())
+	}()
 	assert.Same(t, originalBody, resp3.Body)
 }
 
 func TestCache(t *testing.T) {
 	const enabled = true
 	cacheDir := filepath.Join(os.TempDir(), strconv.Itoa(time.Now().Nanosecond()))
-	defer os.RemoveAll(cacheDir)
+	cleanupCacheDir(t, cacheDir)
 
 	cacher, err := New(enabled, cacheDir)
 	require.NoError(t, err)
@@ -85,7 +94,7 @@ func TestCache(t *testing.T) {
 
 		_, resp := cacher.OnRequest(req, proxyCtx)
 		if resp != nil {
-			resp.Body.Close()
+			require.NoError(t, resp.Body.Close())
 		}
 		assert.Nil(t, resp)
 
@@ -97,7 +106,7 @@ func TestCache(t *testing.T) {
 		}
 		resp = cacher.OnResponse(resp, proxyCtx)
 		result, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		require.NoError(t, resp.Body.Close())
 		assert.Len(t, cacher.cacheDB, 1)
 		assert.Equal(t, body, string(result))
 	})
@@ -111,7 +120,7 @@ func TestCache(t *testing.T) {
 		// a cached response means OnRequest returns a resp
 		_, resp := cacher.OnRequest(req, proxyCtx)
 		if assert.NotNil(t, resp) {
-			resp.Body.Close()
+			require.NoError(t, resp.Body.Close())
 		}
 
 		// since the response is already cached, we don't need any other fields
@@ -120,7 +129,7 @@ func TestCache(t *testing.T) {
 			Body:       io.NopCloser(bytes.NewBufferString("")),
 		}
 		resp = cacher.OnResponse(resp, proxyCtx)
-		resp.Body.Close()
+		require.NoError(t, resp.Body.Close())
 		assert.Len(t, cacher.cacheDB, 1)
 	})
 }
@@ -175,7 +184,7 @@ func TestCache_BodylessResponses(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cacheDir := filepath.Join(os.TempDir(), strconv.Itoa(time.Now().Nanosecond()))
-			defer os.RemoveAll(cacheDir)
+			cleanupCacheDir(t, cacheDir)
 
 			cacher, err := New(true, cacheDir)
 			require.NoError(t, err)
@@ -233,7 +242,7 @@ func TestCache_BodylessResponseWithWrappedBodyIsRestored(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cacheDir := filepath.Join(os.TempDir(), strconv.Itoa(time.Now().Nanosecond()))
-			defer os.RemoveAll(cacheDir)
+			cleanupCacheDir(t, cacheDir)
 
 			cacher, err := New(true, cacheDir)
 			require.NoError(t, err)
@@ -267,7 +276,7 @@ func TestCache_BodylessResponseWithWrappedBodyIsRestored(t *testing.T) {
 // (e.g. WebSocket) is not replaced with an empty body on a later request.
 func TestCache_SwitchingProtocolsNotCached(t *testing.T) {
 	cacheDir := filepath.Join(os.TempDir(), strconv.Itoa(time.Now().Nanosecond()))
-	defer os.RemoveAll(cacheDir)
+	cleanupCacheDir(t, cacheDir)
 
 	cacher, err := New(true, cacheDir)
 	require.NoError(t, err)
@@ -293,7 +302,7 @@ func TestCache_SwitchingProtocolsNotCached(t *testing.T) {
 // response. It must be tee-wrapped and produce a cache entry.
 func TestCache_ZeroByteBodyIsCached(t *testing.T) {
 	cacheDir := filepath.Join(os.TempDir(), strconv.Itoa(time.Now().Nanosecond()))
-	defer os.RemoveAll(cacheDir)
+	cleanupCacheDir(t, cacheDir)
 
 	cacher, err := New(true, cacheDir)
 	require.NoError(t, err)
@@ -332,7 +341,7 @@ func TestCache_ZeroByteBodyIsCached(t *testing.T) {
 // counter, so logs and statistics stay accurate.
 func TestCache_MissingCacheFileIsNotCountedAsHit(t *testing.T) {
 	cacheDir := filepath.Join(os.TempDir(), strconv.Itoa(time.Now().Nanosecond()))
-	defer os.RemoveAll(cacheDir)
+	cleanupCacheDir(t, cacheDir)
 
 	cacher, err := New(true, cacheDir)
 	require.NoError(t, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -91,17 +92,18 @@ type BasicAuthCredentials struct {
 }
 
 // Parse parses a config file, returning a pointer to a Config struct
-func Parse(path string) (*Config, error) {
+func Parse(path string) (_ *Config, err error) {
 	var reader *os.File
 	if path == "-" {
 		reader = os.Stdin
 	} else {
-		var err error
 		reader, err = os.Open(filepath.Clean(path))
 		if err != nil {
 			return nil, err
 		}
-		defer reader.Close()
+		defer func() {
+			err = errors.Join(err, reader.Close())
+		}()
 	}
 
 	config := &Config{}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -93,6 +93,6 @@ func mockStdin(t testing.TB, input string) {
 	t.Cleanup(func() {
 		// reset os.Stdin
 		os.Stdin = oldOsStdin
-		tmpfile.Close()
+		require.NoError(t, tmpfile.Close())
 	})
 }

--- a/internal/dialer/dialer.go
+++ b/internal/dialer/dialer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"sync"
 	"syscall"
@@ -185,7 +186,10 @@ func checkConnectivity(network, address string) bool {
 	if err != nil {
 		return false
 	}
-	return conn.Close() == nil
+	if err := conn.Close(); err != nil {
+		log.Printf("failed to close %s connectivity probe to %s: %v", network, address, err)
+	}
+	return true
 }
 
 type control func(network, address string, conn syscall.RawConn) error

--- a/internal/dialer/dialer.go
+++ b/internal/dialer/dialer.go
@@ -185,8 +185,7 @@ func checkConnectivity(network, address string) bool {
 	if err != nil {
 		return false
 	}
-	conn.Close()
-	return true
+	return conn.Close() == nil
 }
 
 type control func(network, address string, conn syscall.RawConn) error

--- a/internal/handlers/git_server_test.go
+++ b/internal/handlers/git_server_test.go
@@ -219,11 +219,13 @@ func TestGitServerHandler404Retry(t *testing.T) {
 
 	proxyctx.SetValue(proxyCtx, addedAuthCtxKey, &gitCredentials{username: "x-access-token", password: "v1.token"})
 	if newRsp.Body != nil {
-		newRsp.Body.Close()
+		require.NoError(t, newRsp.Body.Close())
 	}
 	newRsp = handler.HandleResponse(rsp, proxyCtx)
 	if newRsp != nil && newRsp.Body != nil {
-		defer newRsp.Body.Close()
+		defer func() {
+			require.NoError(t, newRsp.Body.Close())
+		}()
 	}
 	assert.Equal(t, 401, newRsp.StatusCode, "should retry")
 }
@@ -248,11 +250,13 @@ func TestGitServerHandlerNoRetry(t *testing.T) {
 	// Ensure we _don't_ retry
 	proxyctx.SetValue(proxyCtx, addedAuthCtxKey, &gitCredentials{username: "x-access-token", password: "v1.token"})
 	if newRsp.Body != nil {
-		newRsp.Body.Close()
+		require.NoError(t, newRsp.Body.Close())
 	}
 	newRsp = handler.HandleResponse(rsp, proxyCtx)
 	if newRsp != nil && newRsp.Body != nil {
-		defer newRsp.Body.Close()
+		defer func() {
+			require.NoError(t, newRsp.Body.Close())
+		}()
 	}
 	assert.Equal(t, 404, newRsp.StatusCode, "")
 }
@@ -339,7 +343,9 @@ func TestGitServerHandler_TokenFallback(t *testing.T) {
 
 			_ = handleRequestAndClose(handler, req, proxyCtx)
 			newRsp := handler.HandleResponse(rsp, proxyCtx)
-			defer newRsp.Body.Close()
+			defer func() {
+				require.NoError(t, newRsp.Body.Close())
+			}()
 			assert.Equal(t, tt.expectRespCode, newRsp.StatusCode, "expected status code")
 			assert.Equal(t, tt.expectTokens, capturedTokens, "attempted tokens")
 			if tt.expectReplacedResponse {
@@ -430,11 +436,13 @@ func TestGitServerHandler_TokenFallbackWithPost(t *testing.T) {
 			// trigger cloning body
 			rtResp, err := roundTripper(req, proxyCtx)
 			if rtResp != nil && rtResp.Body != nil {
-				rtResp.Body.Close()
+				require.NoError(t, rtResp.Body.Close())
 			}
 			require.NoError(t, err, "first request err")
 			newRsp := handler.HandleResponse(rsp, proxyCtx)
-			defer newRsp.Body.Close()
+			defer func() {
+				require.NoError(t, newRsp.Body.Close())
+			}()
 			assert.Equal(t, tt.expectRespCode, newRsp.StatusCode, "expected status code")
 			assert.Equal(t, tt.expectTokens, capturedTokens, "attempted tokens")
 		})
@@ -495,7 +503,9 @@ func TestGitServerHandler_RepositoryScopedCredentials(t *testing.T) {
 			rsp := &http.Response{StatusCode: 401, Body: io.NopCloser(strings.NewReader(""))}
 
 			newRsp := handler.HandleResponse(rsp, proxyCtx)
-			defer newRsp.Body.Close()
+			defer func() {
+				require.NoError(t, newRsp.Body.Close())
+			}()
 			assert.Equal(t, []string{
 				otherGitHubCred.GetString("password"),
 				unscopedInstallationCred.GetString("password"),
@@ -560,7 +570,9 @@ func TestGitServerHandler_RequestJITAccess(t *testing.T) {
 
 			proxyctx.SetValue(proxyCtx, addedAuthCtxKey, &gitCredentials{username: "x-access-token", password: "v1.token"})
 			newRsp := handler.HandleResponse(rsp, proxyCtx)
-			defer newRsp.Body.Close()
+			defer func() {
+				require.NoError(t, newRsp.Body.Close())
+			}()
 			assert.Equal(t, test.jitAccessEndpoint != "", testClient.receivedRequest, "request more scope unexpected")
 			if test.jitAccessEndpoint != "" {
 				assert.Equal(t, 200, newRsp.StatusCode, "should have succeeded")
@@ -660,7 +672,9 @@ func TestJITEndpointUsesExplicitAuthWhenProvided(t *testing.T) {
 
 	// HandleResponse triggers retry logic including JIT credential refresh
 	resp = handler.HandleResponse(resp, proxyCtx)
-	defer resp.Body.Close()
+	defer func() {
+		require.NoError(t, resp.Body.Close())
+	}()
 
 	body, _ := io.ReadAll(resp.Body)
 	bodyStr := string(body)

--- a/internal/handlers/github_api_test.go
+++ b/internal/handlers/github_api_test.go
@@ -409,7 +409,9 @@ func TestGitHubAPIHandler_TokenFallback(t *testing.T) {
 			_ = handleRequestAndClose(handler, req, proxyCtx)
 
 			newRsp := handler.HandleResponse(rsp, proxyCtx)
-			defer newRsp.Body.Close()
+			defer func() {
+				require.NoError(t, newRsp.Body.Close())
+			}()
 			assert.Equal(t, tt.expectRespCode, newRsp.StatusCode, "expected status code")
 			assert.Equal(t, tt.expectTokens, capturedTokens, "attempted tokens")
 			if tt.expectReplacedResponse {
@@ -512,7 +514,9 @@ func TestGitHubAPIHandler_TokenFallback_In_Proxima(t *testing.T) {
 			_ = handleRequestAndClose(handler, req, proxyCtx)
 
 			newRsp := handler.HandleResponse(rsp, proxyCtx)
-			defer newRsp.Body.Close()
+			defer func() {
+				require.NoError(t, newRsp.Body.Close())
+			}()
 			assert.Equal(t, tt.expectRespCode, newRsp.StatusCode, "expected status code")
 			assert.Equal(t, tt.expectTokens, capturedTokens, "attempted tokens")
 			if tt.expectReplacedResponse {

--- a/internal/handlers/nuget_feed_test.go
+++ b/internal/handlers/nuget_feed_test.go
@@ -517,7 +517,7 @@ func TestNugetFeedHandlerConcurrentDiscoveryIsDeduplicated(t *testing.T) {
 				Body:       io.NopCloser(strings.NewReader(responseBody)),
 			}
 			handler.HandleResponse(resp, proxyCtx)
-			resp.Body.Close()
+			mustClose(resp.Body)
 
 			packageReq := httptest.NewRequestWithContext(ctx, http.MethodGet, "https://cdn.example.com/packages/example/index.json", nil)
 			handler.HandleRequest(packageReq, &goproxy.ProxyCtx{})

--- a/internal/handlers/test_helpers.go
+++ b/internal/handlers/test_helpers.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -18,9 +20,15 @@ func handleRequestAndClose(handler interface {
 }, req *http.Request, proxyCtx *goproxy.ProxyCtx) *http.Request {
 	req, resp := handler.HandleRequest(req, proxyCtx)
 	if resp != nil && resp.Body != nil {
-		resp.Body.Close()
+		mustClose(resp.Body)
 	}
 	return req
+}
+
+func mustClose(closer io.Closer) {
+	if err := closer.Close(); err != nil {
+		panic(fmt.Sprintf("failed to close test resource: %v", err))
+	}
 }
 
 func assertHasTokenAuth(t *testing.T, r *http.Request, prefix, token, msg string) {

--- a/internal/metrics/handler_test.go
+++ b/internal/metrics/handler_test.go
@@ -54,12 +54,12 @@ func TestHandlerMetrics(t *testing.T) {
 				proxyCtx := &goproxy.ProxyCtx{Req: req}
 				_, resp := h.HandleRequest(req, proxyCtx)
 				if resp != nil && resp.Body != nil {
-					resp.Body.Close()
+					require.NoError(t, resp.Body.Close())
 				}
 				time.Sleep(200 * time.Millisecond)
 				rsp := h.HandleResponse(&http.Response{StatusCode: 201}, proxyCtx)
 				if rsp != nil && rsp.Body != nil {
-					rsp.Body.Close()
+					require.NoError(t, rsp.Body.Close())
 				}
 			},
 			validateMetric: func(t *testing.T, metric string) {
@@ -83,13 +83,13 @@ func TestHandlerMetrics(t *testing.T) {
 				proxyCtx := &goproxy.ProxyCtx{Req: req}
 				_, resp := h.HandleRequest(req, proxyCtx)
 				if resp != nil && resp.Body != nil {
-					resp.Body.Close()
+					require.NoError(t, resp.Body.Close())
 				}
 				// Simulate a delay to test the timing metric
 				time.Sleep(200 * time.Millisecond)
 				rsp := h.HandleResponse(&http.Response{StatusCode: 200}, proxyCtx)
 				if rsp != nil && rsp.Body != nil {
-					rsp.Body.Close()
+					require.NoError(t, rsp.Body.Close())
 				}
 			},
 			expMetricCount: 2,
@@ -112,11 +112,11 @@ func TestHandlerMetrics(t *testing.T) {
 					proxyCtx := &goproxy.ProxyCtx{Req: req}
 					_, resp := h.HandleRequest(req, proxyCtx)
 					if resp != nil && resp.Body != nil {
-						resp.Body.Close()
+						require.NoError(t, resp.Body.Close())
 					}
 					rsp := h.HandleResponse(&http.Response{StatusCode: 200}, proxyCtx)
 					if rsp != nil && rsp.Body != nil {
-						rsp.Body.Close()
+						require.NoError(t, rsp.Body.Close())
 					}
 				}
 			},
@@ -140,11 +140,11 @@ func TestHandlerMetrics(t *testing.T) {
 					proxyCtx := &goproxy.ProxyCtx{Req: req}
 					_, resp := h.HandleRequest(req, proxyCtx)
 					if resp != nil && resp.Body != nil {
-						resp.Body.Close()
+						require.NoError(t, resp.Body.Close())
 					}
 					rsp := h.HandleResponse(&http.Response{StatusCode: 200}, proxyCtx)
 					if rsp != nil && rsp.Body != nil {
-						rsp.Body.Close()
+						require.NoError(t, rsp.Body.Close())
 					}
 				}
 			},
@@ -168,11 +168,11 @@ func TestHandlerMetrics(t *testing.T) {
 					proxyCtx := &goproxy.ProxyCtx{Req: req}
 					_, resp := h.HandleRequest(req, proxyCtx)
 					if resp != nil && resp.Body != nil {
-						resp.Body.Close()
+						require.NoError(t, resp.Body.Close())
 					}
 					rsp := h.HandleResponse(&http.Response{StatusCode: 200}, proxyCtx)
 					if rsp != nil && rsp.Body != nil {
-						rsp.Body.Close()
+						require.NoError(t, rsp.Body.Close())
 					}
 				}
 			},

--- a/internal/oidc/actions_oidc.go
+++ b/internal/oidc/actions_oidc.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -55,7 +56,7 @@ func GetRequestToken() string {
 }
 
 // GetToken retrieves a GitHub Actions OIDC token with an optional audience
-func GetToken(ctx context.Context, audience string) (string, error) {
+func GetToken(ctx context.Context, audience string) (_ string, err error) {
 	if !IsOIDCConfigured() {
 		return "", fmt.Errorf("GitHub Actions OIDC is not available: missing %s or %s environment variables",
 			envActionsIDTokenRequestURL, envActionsIDTokenRequestToken)
@@ -92,7 +93,7 @@ func GetToken(ctx context.Context, audience string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to execute OIDC request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer closeBody(resp.Body, &err)
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -227,7 +228,7 @@ type OIDCAccessToken struct {
 // githubToken: The GitHub Actions OIDC token obtained via GetTokenForAzureADExchange
 //
 // Returns an Azure AD access token scoped for Azure DevOps (499b84ac-1321-427f-aa17-267ca6975798/.default)
-func GetAzureAccessToken(ctx context.Context, params AzureOIDCParameters, githubToken string) (*OIDCAccessToken, error) {
+func GetAzureAccessToken(ctx context.Context, params AzureOIDCParameters, githubToken string) (_ *OIDCAccessToken, err error) {
 	if params.TenantID == "" {
 		return nil, fmt.Errorf("tenant ID is required")
 	}
@@ -267,7 +268,7 @@ func GetAzureAccessToken(ctx context.Context, params AzureOIDCParameters, github
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute Azure token request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer closeBody(resp.Body, &err)
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -323,7 +324,7 @@ func GetAzureAccessTokenForDevOps(ctx context.Context, params AzureOIDCParameter
 // githubToken: The GitHub Actions OIDC token obtained via GetToken
 //
 // Returns a JFrog access token
-func GetJFrogAccessToken(ctx context.Context, params JFrogOIDCParameters, githubToken string) (*OIDCAccessToken, error) {
+func GetJFrogAccessToken(ctx context.Context, params JFrogOIDCParameters, githubToken string) (_ *OIDCAccessToken, err error) {
 	if params.JFrogURL == "" {
 		return nil, fmt.Errorf("token URL base is required")
 	}
@@ -365,7 +366,7 @@ func GetJFrogAccessToken(ctx context.Context, params JFrogOIDCParameters, github
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute JFrog token request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer closeBody(resp.Body, &err)
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -424,7 +425,7 @@ func GetJFrogAccessTokenForDevOps(ctx context.Context, params JFrogOIDCParameter
 // githubToken: The GitHub Actions OIDC token obtained via GetToken
 //
 // Returns temporary AWS credentials
-func GetAWSAccessToken(ctx context.Context, params AWSOIDCParameters, githubToken string) (*OIDCAccessToken, error) {
+func GetAWSAccessToken(ctx context.Context, params AWSOIDCParameters, githubToken string) (_ *OIDCAccessToken, err error) {
 	if params.Region == "" {
 		return nil, fmt.Errorf("AWS region is required")
 	}
@@ -468,7 +469,7 @@ func GetAWSAccessToken(ctx context.Context, params AWSOIDCParameters, githubToke
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute AWS credential request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer closeBody(resp.Body, &err)
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -542,7 +543,7 @@ func GetAWSAccessToken(ctx context.Context, params AWSOIDCParameters, githubToke
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute AWS token request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer closeBody(resp.Body, &err)
 
 	body, err = io.ReadAll(resp.Body)
 	if err != nil {
@@ -592,7 +593,7 @@ func GetAWSAccessTokenForDevOps(ctx context.Context, params AWSOIDCParameters) (
 	return awsToken, nil
 }
 
-func GetCloudsmithAccessToken(ctx context.Context, params CloudsmithOIDCParameters, githubToken string) (*OIDCAccessToken, error) {
+func GetCloudsmithAccessToken(ctx context.Context, params CloudsmithOIDCParameters, githubToken string) (_ *OIDCAccessToken, err error) {
 	if params.ServiceSlug == "" {
 		return nil, fmt.Errorf("service slug is required")
 	}
@@ -633,7 +634,7 @@ func GetCloudsmithAccessToken(ctx context.Context, params CloudsmithOIDCParamete
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute cloudsmith token request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer closeBody(resp.Body, &err)
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -679,7 +680,7 @@ func GetCloudsmithAccessTokenForDevOps(ctx context.Context, params CloudsmithOID
 	return cloudsmithToken, nil
 }
 
-func GetGCPAccessToken(ctx context.Context, params GCPOIDCParameters, githubToken string) (*OIDCAccessToken, error) {
+func GetGCPAccessToken(ctx context.Context, params GCPOIDCParameters, githubToken string) (_ *OIDCAccessToken, err error) {
 	if params.WorkloadIdentityProvider == "" {
 		return nil, fmt.Errorf("workload-identity-provider is required")
 	}
@@ -721,7 +722,7 @@ func GetGCPAccessToken(ctx context.Context, params GCPOIDCParameters, githubToke
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute GCP STS request: %w", err)
 	}
-	defer stsResp.Body.Close()
+	defer closeBody(stsResp.Body, &err)
 
 	stsBody, err := io.ReadAll(stsResp.Body)
 	if err != nil {
@@ -778,7 +779,7 @@ func GetGCPAccessToken(ctx context.Context, params GCPOIDCParameters, githubToke
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute GCP IAM request: %w", err)
 	}
-	defer iamResp.Body.Close()
+	defer closeBody(iamResp.Body, &err)
 
 	iamBody, err := io.ReadAll(iamResp.Body)
 	if err != nil {
@@ -836,4 +837,8 @@ func GetGCPAccessTokenForDevOps(ctx context.Context, params GCPOIDCParameters) (
 func calculateContentSha256Header(payload []byte) string {
 	payloadHash := sha256.Sum256(payload)
 	return hex.EncodeToString(payloadHash[:])
+}
+
+func closeBody(body io.Closer, err *error) {
+	*err = errors.Join(*err, body.Close())
 }

--- a/internal/oidc/actions_oidc_test.go
+++ b/internal/oidc/actions_oidc_test.go
@@ -17,62 +17,79 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+
+	value, ok := os.LookupEnv(key)
+	require.NoError(t, os.Unsetenv(key))
+	t.Cleanup(func() {
+		if ok {
+			require.NoError(t, os.Setenv(key, value))
+			return
+		}
+		require.NoError(t, os.Unsetenv(key))
+	})
+}
+
+func writeResponse(t *testing.T, w io.Writer, body string) {
+	t.Helper()
+	_, err := io.WriteString(w, body)
+	require.NoError(t, err)
+}
+
+func encodeJSONResponse(t *testing.T, w io.Writer, value any) {
+	t.Helper()
+	require.NoError(t, json.NewEncoder(w).Encode(value))
+}
+
+func encodeXMLResponse(t *testing.T, w io.Writer, value any) {
+	t.Helper()
+	require.NoError(t, xml.NewEncoder(w).Encode(value))
+}
+
 func TestIsOIDCConfigured(t *testing.T) {
 	tests := []struct {
-		name       string
-		setupEnv   func()
-		cleanupEnv func()
-		expected   bool
+		name     string
+		setupEnv func(t *testing.T)
+		expected bool
 	}{
 		{
 			name: "both environment variables set",
-			setupEnv: func() {
-				os.Setenv(envActionsIDTokenRequestURL, "https://example.com/token")
-				os.Setenv(envActionsIDTokenRequestToken, "test-token")
-			},
-			cleanupEnv: func() {
-				os.Unsetenv(envActionsIDTokenRequestURL)
-				os.Unsetenv(envActionsIDTokenRequestToken)
+			setupEnv: func(t *testing.T) {
+				t.Setenv(envActionsIDTokenRequestURL, "https://example.com/token")
+				t.Setenv(envActionsIDTokenRequestToken, "test-token")
 			},
 			expected: true,
 		},
 		{
 			name: "missing request URL",
-			setupEnv: func() {
-				os.Unsetenv(envActionsIDTokenRequestURL)
-				os.Setenv(envActionsIDTokenRequestToken, "test-token")
-			},
-			cleanupEnv: func() {
-				os.Unsetenv(envActionsIDTokenRequestToken)
+			setupEnv: func(t *testing.T) {
+				unsetEnv(t, envActionsIDTokenRequestURL)
+				t.Setenv(envActionsIDTokenRequestToken, "test-token")
 			},
 			expected: false,
 		},
 		{
 			name: "missing request token",
-			setupEnv: func() {
-				os.Setenv(envActionsIDTokenRequestURL, "https://example.com/token")
-				os.Unsetenv(envActionsIDTokenRequestToken)
-			},
-			cleanupEnv: func() {
-				os.Unsetenv(envActionsIDTokenRequestURL)
+			setupEnv: func(t *testing.T) {
+				t.Setenv(envActionsIDTokenRequestURL, "https://example.com/token")
+				unsetEnv(t, envActionsIDTokenRequestToken)
 			},
 			expected: false,
 		},
 		{
 			name: "both environment variables missing",
-			setupEnv: func() {
-				os.Unsetenv(envActionsIDTokenRequestURL)
-				os.Unsetenv(envActionsIDTokenRequestToken)
+			setupEnv: func(t *testing.T) {
+				unsetEnv(t, envActionsIDTokenRequestURL)
+				unsetEnv(t, envActionsIDTokenRequestToken)
 			},
-			cleanupEnv: func() {},
-			expected:   false,
+			expected: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.setupEnv()
-			defer tt.cleanupEnv()
+			tt.setupEnv(t)
 
 			result := IsOIDCConfigured()
 			assert.Equal(t, tt.expected, result)
@@ -84,8 +101,7 @@ func TestGetToken(t *testing.T) {
 	tests := []struct {
 		name          string
 		audience      string
-		setupEnv      func(serverURL, token string)
-		cleanupEnv    func()
+		setupEnv      func(t *testing.T, serverURL, token string)
 		serverHandler http.HandlerFunc
 		expectError   bool
 		expectedToken string
@@ -93,13 +109,9 @@ func TestGetToken(t *testing.T) {
 		{
 			name:     "successful token request without audience",
 			audience: "",
-			setupEnv: func(serverURL, token string) {
-				os.Setenv(envActionsIDTokenRequestURL, serverURL)
-				os.Setenv(envActionsIDTokenRequestToken, token)
-			},
-			cleanupEnv: func() {
-				os.Unsetenv(envActionsIDTokenRequestURL)
-				os.Unsetenv(envActionsIDTokenRequestToken)
+			setupEnv: func(t *testing.T, serverURL, token string) {
+				t.Setenv(envActionsIDTokenRequestURL, serverURL)
+				t.Setenv(envActionsIDTokenRequestToken, token)
 			},
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				// Verify request headers
@@ -113,7 +125,7 @@ func TestGetToken(t *testing.T) {
 				// Return success response
 				resp := tokenResponse{Count: 1, Value: "test-jwt-token"}
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(resp)
+				require.NoError(t, json.NewEncoder(w).Encode(resp))
 			},
 			expectError:   false,
 			expectedToken: "test-jwt-token",
@@ -121,13 +133,9 @@ func TestGetToken(t *testing.T) {
 		{
 			name:     "successful token request with audience",
 			audience: "api://AzureADTokenExchange",
-			setupEnv: func(serverURL, token string) {
-				os.Setenv(envActionsIDTokenRequestURL, serverURL)
-				os.Setenv(envActionsIDTokenRequestToken, token)
-			},
-			cleanupEnv: func() {
-				os.Unsetenv(envActionsIDTokenRequestURL)
-				os.Unsetenv(envActionsIDTokenRequestToken)
+			setupEnv: func(t *testing.T, serverURL, token string) {
+				t.Setenv(envActionsIDTokenRequestURL, serverURL)
+				t.Setenv(envActionsIDTokenRequestToken, token)
 			},
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				// Verify audience parameter
@@ -136,7 +144,7 @@ func TestGetToken(t *testing.T) {
 				// Return success response
 				resp := tokenResponse{Count: 1, Value: "test-jwt-token-with-audience"}
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(resp)
+				require.NoError(t, json.NewEncoder(w).Encode(resp))
 			},
 			expectError:   false,
 			expectedToken: "test-jwt-token-with-audience",
@@ -144,25 +152,24 @@ func TestGetToken(t *testing.T) {
 		{
 			name:     "server returns 500 error",
 			audience: "",
-			setupEnv: func(serverURL, token string) {
-				os.Setenv(envActionsIDTokenRequestURL, serverURL)
-				os.Setenv(envActionsIDTokenRequestToken, token)
-			},
-			cleanupEnv: func() {
-				os.Unsetenv(envActionsIDTokenRequestURL)
-				os.Unsetenv(envActionsIDTokenRequestToken)
+			setupEnv: func(t *testing.T, serverURL, token string) {
+				t.Setenv(envActionsIDTokenRequestURL, serverURL)
+				t.Setenv(envActionsIDTokenRequestToken, token)
 			},
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte("Internal Server Error"))
+				_, err := w.Write([]byte("Internal Server Error"))
+				require.NoError(t, err)
 			},
 			expectError: true,
 		},
 		{
-			name:        "environment not available",
-			audience:    "",
-			setupEnv:    func(serverURL, token string) {},
-			cleanupEnv:  func() {},
+			name:     "environment not available",
+			audience: "",
+			setupEnv: func(t *testing.T, serverURL, token string) {
+				unsetEnv(t, envActionsIDTokenRequestURL)
+				unsetEnv(t, envActionsIDTokenRequestToken)
+			},
 			expectError: true,
 		},
 	}
@@ -181,8 +188,7 @@ func TestGetToken(t *testing.T) {
 				serverURL = server.URL
 			}
 
-			tt.setupEnv(serverURL, "test-token")
-			defer tt.cleanupEnv()
+			tt.setupEnv(t, serverURL, "test-token")
 
 			ctx := context.Background()
 
@@ -205,16 +211,12 @@ func TestGetTokenForAzureADExchange(t *testing.T) {
 
 		resp := tokenResponse{Count: 1, Value: "azure-exchange-token"}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
 	}))
 	defer server.Close()
 
-	os.Setenv(envActionsIDTokenRequestURL, server.URL)
-	os.Setenv(envActionsIDTokenRequestToken, "test-token")
-	defer func() {
-		os.Unsetenv(envActionsIDTokenRequestURL)
-		os.Unsetenv(envActionsIDTokenRequestToken)
-	}()
+	t.Setenv(envActionsIDTokenRequestURL, server.URL)
+	t.Setenv(envActionsIDTokenRequestToken, "test-token")
 
 	ctx := context.Background()
 
@@ -284,7 +286,7 @@ func TestGetToken_URLParsing(t *testing.T) {
 
 				resp := tokenResponse{Count: 1, Value: "test-token"}
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(resp)
+				require.NoError(t, json.NewEncoder(w).Encode(resp))
 			}))
 			defer server.Close()
 
@@ -302,12 +304,8 @@ func TestGetToken_URLParsing(t *testing.T) {
 				}
 			}
 
-			os.Setenv(envActionsIDTokenRequestURL, testURL)
-			os.Setenv(envActionsIDTokenRequestToken, "test-token")
-			defer func() {
-				os.Unsetenv(envActionsIDTokenRequestURL)
-				os.Unsetenv(envActionsIDTokenRequestToken)
-			}()
+			t.Setenv(envActionsIDTokenRequestURL, testURL)
+			t.Setenv(envActionsIDTokenRequestToken, "test-token")
 
 			ctx := context.Background()
 			_, err := GetToken(ctx, tt.audience)
@@ -360,7 +358,7 @@ func TestGetAzureAccessToken(t *testing.T) {
 					TokenType:   "Bearer",
 				}
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(resp)
+				encodeJSONResponse(t, w, resp)
 			},
 			expectError:   false,
 			expectedToken: "test-azure-access-token",
@@ -393,7 +391,7 @@ func TestGetAzureAccessToken(t *testing.T) {
 			githubToken: "invalid-token",
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusUnauthorized)
-				w.Write([]byte(`{"error":"invalid_client","error_description":"Invalid client assertion"}`))
+				writeResponse(t, w, `{"error":"invalid_client","error_description":"Invalid client assertion"}`)
 			},
 			expectError: true,
 		},
@@ -404,7 +402,7 @@ func TestGetAzureAccessToken(t *testing.T) {
 			githubToken: "test-github-jwt-token",
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				w.Write([]byte(`{invalid json`))
+				writeResponse(t, w, `{invalid json`)
 			},
 			expectError: true,
 		},
@@ -420,7 +418,7 @@ func TestGetAzureAccessToken(t *testing.T) {
 					TokenType:   "Bearer",
 				}
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(resp)
+				encodeJSONResponse(t, w, resp)
 			},
 			expectError: true,
 		},
@@ -496,7 +494,9 @@ func TestGetJFrogAccessToken(t *testing.T) {
 				// Parse request
 				bodyBytes, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
-				defer r.Body.Close()
+				defer func() {
+					require.NoError(t, r.Body.Close())
+				}()
 				var request jfrogTokenRequest
 				err = json.Unmarshal(bodyBytes, &request)
 				require.NoError(t, err)
@@ -516,7 +516,7 @@ func TestGetJFrogAccessToken(t *testing.T) {
 					TokenType:   "Bearer",
 				}
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(resp)
+				encodeJSONResponse(t, w, resp)
 			},
 			expectError:   false,
 			expectedToken: "test-jfrog-access-token",
@@ -532,7 +532,9 @@ func TestGetJFrogAccessToken(t *testing.T) {
 				// Parse request
 				bodyBytes, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
-				defer r.Body.Close()
+				defer func() {
+					require.NoError(t, r.Body.Close())
+				}()
 				var request jfrogTokenRequest
 				err = json.Unmarshal(bodyBytes, &request)
 				require.NoError(t, err)
@@ -547,7 +549,7 @@ func TestGetJFrogAccessToken(t *testing.T) {
 					TokenType:   "Bearer",
 				}
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(resp)
+				encodeJSONResponse(t, w, resp)
 			},
 			expectError:   false,
 			expectedToken: "test-jfrog-access-token",
@@ -580,7 +582,7 @@ func TestGetJFrogAccessToken(t *testing.T) {
 			githubToken:  "invalid-token",
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusUnauthorized)
-				w.Write([]byte(`{"error":"invalid_client","error_description":"Invalid client assertion"}`))
+				writeResponse(t, w, `{"error":"invalid_client","error_description":"Invalid client assertion"}`)
 			},
 			expectError: true,
 		},
@@ -590,7 +592,7 @@ func TestGetJFrogAccessToken(t *testing.T) {
 			providerName: "some-provider",
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				w.Write([]byte(`{invalid json`))
+				writeResponse(t, w, `{invalid json`)
 			},
 			expectError: true,
 		},
@@ -605,7 +607,7 @@ func TestGetJFrogAccessToken(t *testing.T) {
 					TokenType:   "Bearer",
 				}
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(resp)
+				encodeJSONResponse(t, w, resp)
 			},
 			expectError: true,
 		},
@@ -695,7 +697,7 @@ func TestGetAWSAccessToken(t *testing.T) {
 					Expiration:      "test-expiration-not-used",
 				}
 				w.Header().Set("Content-Type", "application/xml")
-				xml.NewEncoder(w).Encode(resp)
+				encodeXMLResponse(t, w, resp)
 			},
 			tokenServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				// Verify request method and headers
@@ -735,7 +737,7 @@ func TestGetAWSAccessToken(t *testing.T) {
 					Expiration:         1.5,
 				}
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(resp)
+				encodeJSONResponse(t, w, resp)
 			},
 			expectError:   false,
 			expectedToken: "test-aws-access-token",
@@ -762,7 +764,7 @@ func TestGetAWSAccessToken(t *testing.T) {
 			githubToken: "test-github-jwt-token",
 			credentialServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusUnauthorized)
-				w.Write([]byte("nope"))
+				writeResponse(t, w, "nope")
 			},
 			expectError: true,
 		},
@@ -783,11 +785,11 @@ func TestGetAWSAccessToken(t *testing.T) {
 					Expiration:      "test-expiration-not-used",
 				}
 				w.Header().Set("Content-Type", "application/xml")
-				xml.NewEncoder(w).Encode(resp)
+				encodeXMLResponse(t, w, resp)
 			},
 			tokenServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusUnauthorized)
-				w.Write([]byte("nope"))
+				writeResponse(t, w, "nope")
 			},
 			expectError: true,
 		},
@@ -862,7 +864,9 @@ func TestGetCloudsmithAccessToken(t *testing.T) {
 
 				bodyBytes, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
-				defer r.Body.Close()
+				defer func() {
+					require.NoError(t, r.Body.Close())
+				}()
 
 				var request cloudsmithTokenRequest
 				err = json.Unmarshal(bodyBytes, &request)
@@ -875,7 +879,7 @@ func TestGetCloudsmithAccessToken(t *testing.T) {
 					Token: "test-cloudsmith-token",
 				}
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(resp)
+				encodeJSONResponse(t, w, resp)
 			},
 			expectError:   false,
 			expectedToken: "test-cloudsmith-token",
@@ -942,7 +946,7 @@ func TestGetCloudsmithAccessToken(t *testing.T) {
 			githubToken: "invalid-token",
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusUnauthorized)
-				w.Write([]byte(`{"detail":"Invalid token."}`))
+				writeResponse(t, w, `{"detail":"Invalid token."}`)
 			},
 			expectError: true,
 		},
@@ -957,7 +961,7 @@ func TestGetCloudsmithAccessToken(t *testing.T) {
 			githubToken: "test-github-jwt-token",
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				w.Write([]byte(`{invalid json`))
+				writeResponse(t, w, `{invalid json`)
 			},
 			expectError: true,
 		},
@@ -975,7 +979,7 @@ func TestGetCloudsmithAccessToken(t *testing.T) {
 					Token: "",
 				}
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(resp)
+				encodeJSONResponse(t, w, resp)
 			},
 			expectError: true,
 		},
@@ -1038,7 +1042,9 @@ func TestGetGCPAccessToken(t *testing.T) {
 
 				bodyBytes, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
-				defer r.Body.Close()
+				defer func() {
+					require.NoError(t, r.Body.Close())
+				}()
 
 				var request gcpSTSTokenRequest
 				err = json.Unmarshal(bodyBytes, &request)
@@ -1051,7 +1057,7 @@ func TestGetGCPAccessToken(t *testing.T) {
 				assert.Equal(t, "https://www.googleapis.com/auth/cloud-platform", request.Scope)
 
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(gcpSTSTokenResponse{
+				encodeJSONResponse(t, w, gcpSTSTokenResponse{
 					AccessToken: "federated-access-token",
 					ExpiresIn:   3600,
 					TokenType:   "urn:ietf:params:oauth:token-type:access_token",
@@ -1070,7 +1076,7 @@ func TestGetGCPAccessToken(t *testing.T) {
 			githubToken: "test-github-jwt-token",
 			stsHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(gcpSTSTokenResponse{
+				encodeJSONResponse(t, w, gcpSTSTokenResponse{
 					AccessToken: "federated-access-token",
 					ExpiresIn:   3600,
 				})
@@ -1081,7 +1087,9 @@ func TestGetGCPAccessToken(t *testing.T) {
 
 				bodyBytes, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
-				defer r.Body.Close()
+				defer func() {
+					require.NoError(t, r.Body.Close())
+				}()
 
 				var request gcpIAMGenerateAccessTokenRequest
 				err = json.Unmarshal(bodyBytes, &request)
@@ -1089,7 +1097,7 @@ func TestGetGCPAccessToken(t *testing.T) {
 				assert.Contains(t, request.Scope, "https://www.googleapis.com/auth/cloud-platform")
 
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(gcpIAMGenerateAccessTokenResponse{
+				encodeJSONResponse(t, w, gcpIAMGenerateAccessTokenResponse{
 					AccessToken: "impersonated-access-token",
 					ExpireTime:  "2099-12-31T23:59:59Z",
 				})
@@ -1107,14 +1115,14 @@ func TestGetGCPAccessToken(t *testing.T) {
 			githubToken: "test-github-jwt-token",
 			stsHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(gcpSTSTokenResponse{
+				encodeJSONResponse(t, w, gcpSTSTokenResponse{
 					AccessToken: "federated-access-token",
 					ExpiresIn:   3600,
 				})
 			},
 			iamHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(gcpIAMGenerateAccessTokenResponse{
+				encodeJSONResponse(t, w, gcpIAMGenerateAccessTokenResponse{
 					AccessToken: "impersonated-nano-token",
 					ExpireTime:  "2099-12-31T23:59:59.999999999Z",
 				})
@@ -1157,7 +1165,7 @@ func TestGetGCPAccessToken(t *testing.T) {
 			githubToken: "invalid-token",
 			stsHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusUnauthorized)
-				w.Write([]byte(`{"error":"invalid_grant"}`))
+				writeResponse(t, w, `{"error":"invalid_grant"}`)
 			},
 			expectError: true,
 		},
@@ -1170,7 +1178,7 @@ func TestGetGCPAccessToken(t *testing.T) {
 			githubToken: "test-github-jwt-token",
 			stsHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				w.Write([]byte(`{invalid json`))
+				writeResponse(t, w, `{invalid json`)
 			},
 			expectError: true,
 		},
@@ -1183,7 +1191,7 @@ func TestGetGCPAccessToken(t *testing.T) {
 			githubToken: "test-github-jwt-token",
 			stsHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(gcpSTSTokenResponse{
+				encodeJSONResponse(t, w, gcpSTSTokenResponse{
 					AccessToken: "",
 					ExpiresIn:   3600,
 				})
@@ -1199,7 +1207,7 @@ func TestGetGCPAccessToken(t *testing.T) {
 			githubToken: "test-github-jwt-token",
 			stsHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(gcpSTSTokenResponse{
+				encodeJSONResponse(t, w, gcpSTSTokenResponse{
 					AccessToken: "federated-access-token",
 					ExpiresIn:   0,
 				})
@@ -1215,7 +1223,7 @@ func TestGetGCPAccessToken(t *testing.T) {
 			githubToken: "test-github-jwt-token",
 			stsHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(gcpSTSTokenResponse{
+				encodeJSONResponse(t, w, gcpSTSTokenResponse{
 					AccessToken: "federated-access-token",
 					ExpiresIn:   300,
 				})
@@ -1232,14 +1240,14 @@ func TestGetGCPAccessToken(t *testing.T) {
 			githubToken: "test-github-jwt-token",
 			stsHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(gcpSTSTokenResponse{
+				encodeJSONResponse(t, w, gcpSTSTokenResponse{
 					AccessToken: "federated-access-token",
 					ExpiresIn:   3600,
 				})
 			},
 			iamHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusForbidden)
-				w.Write([]byte(`{"error":{"code":403,"message":"Permission denied"}}`))
+				writeResponse(t, w, `{"error":{"code":403,"message":"Permission denied"}}`)
 			},
 			expectError: true,
 		},
@@ -1253,14 +1261,14 @@ func TestGetGCPAccessToken(t *testing.T) {
 			githubToken: "test-github-jwt-token",
 			stsHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(gcpSTSTokenResponse{
+				encodeJSONResponse(t, w, gcpSTSTokenResponse{
 					AccessToken: "federated-access-token",
 					ExpiresIn:   3600,
 				})
 			},
 			iamHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(gcpIAMGenerateAccessTokenResponse{
+				encodeJSONResponse(t, w, gcpIAMGenerateAccessTokenResponse{
 					AccessToken: "",
 					ExpireTime:  "2099-12-31T23:59:59Z",
 				})
@@ -1277,14 +1285,14 @@ func TestGetGCPAccessToken(t *testing.T) {
 			githubToken: "test-github-jwt-token",
 			stsHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(gcpSTSTokenResponse{
+				encodeJSONResponse(t, w, gcpSTSTokenResponse{
 					AccessToken: "federated-access-token",
 					ExpiresIn:   3600,
 				})
 			},
 			iamHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(gcpIAMGenerateAccessTokenResponse{
+				encodeJSONResponse(t, w, gcpIAMGenerateAccessTokenResponse{
 					AccessToken: "impersonated-access-token",
 					ExpireTime:  "2000-01-01T00:00:00Z",
 				})

--- a/internal/oidc/oidc_credential_test.go
+++ b/internal/oidc/oidc_credential_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 
@@ -20,12 +19,8 @@ import (
 
 func TestSuccessfulAuthenticationDoesNotMakeARepeatedRequest(t *testing.T) {
 	// these variables are necessary
-	os.Setenv(envActionsIDTokenRequestURL, "https://example.com/token")
-	os.Setenv(envActionsIDTokenRequestToken, "test-token")
-	defer func() {
-		os.Unsetenv(envActionsIDTokenRequestURL)
-		os.Unsetenv(envActionsIDTokenRequestToken)
-	}()
+	t.Setenv(envActionsIDTokenRequestURL, "https://example.com/token")
+	t.Setenv(envActionsIDTokenRequestToken, "test-token")
 
 	// we're using Azure for this, but anything will work
 	creds, err := CreateOIDCCredential(config.Credential{
@@ -85,12 +80,8 @@ func TestSuccessfulAuthenticationDoesNotMakeARepeatedRequest(t *testing.T) {
 
 func TestFailedAuthenticationIsNotRetried(t *testing.T) {
 	// these variables are necessary
-	os.Setenv(envActionsIDTokenRequestURL, "https://example.com/token")
-	os.Setenv(envActionsIDTokenRequestToken, "test-token")
-	defer func() {
-		os.Unsetenv(envActionsIDTokenRequestURL)
-		os.Unsetenv(envActionsIDTokenRequestToken)
-	}()
+	t.Setenv(envActionsIDTokenRequestURL, "https://example.com/token")
+	t.Setenv(envActionsIDTokenRequestToken, "test-token")
 
 	// we're using Azure for this, but anything will work
 	creds, err := CreateOIDCCredential(config.Credential{
@@ -339,12 +330,8 @@ func TestTryCreateOIDCCredential(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// these variables are necessary
-			os.Setenv(envActionsIDTokenRequestURL, "https://example.com/token")
-			os.Setenv(envActionsIDTokenRequestToken, "test-token")
-			defer func() {
-				os.Unsetenv(envActionsIDTokenRequestURL)
-				os.Unsetenv(envActionsIDTokenRequestToken)
-			}()
+			t.Setenv(envActionsIDTokenRequestURL, "https://example.com/token")
+			t.Setenv(envActionsIDTokenRequestToken, "test-token")
 
 			actual, _ := CreateOIDCCredential(tc.cred)
 			if tc.expectedParameters == nil {

--- a/logging.go
+++ b/logging.go
@@ -107,7 +107,9 @@ func logResponseBody(rsp *http.Response, proxyCtx *goproxy.ProxyCtx, maxBytes in
 			logging.RequestMultilineLogf(proxyCtx, "Remote response: %s", string(bodyBytes[:n]))
 
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
-				rsp.Body.Close()
+				if err := rsp.Body.Close(); err != nil {
+					logging.RequestLogf(proxyCtx, "Failed closing remote response body: %v", err)
+				}
 				rsp.Body = io.NopCloser(bytes.NewReader(bodyBytes[:n]))
 			} else {
 				rsp.Body = newMultiReadCloser(io.NopCloser(bytes.NewReader(bodyBytes[:n])), rsp.Body)
@@ -115,7 +117,9 @@ func logResponseBody(rsp *http.Response, proxyCtx *goproxy.ProxyCtx, maxBytes in
 		}
 	} else {
 		bodyBytes, _ := io.ReadAll(rsp.Body)
-		rsp.Body.Close()
+		if err := rsp.Body.Close(); err != nil {
+			logging.RequestLogf(proxyCtx, "Failed closing remote response body: %v", err)
+		}
 
 		logging.RequestMultilineLogf(proxyCtx, "Remote response: %s", string(bodyBytes))
 		rsp.Body = io.NopCloser(bytes.NewReader(bodyBytes))

--- a/logging_test.go
+++ b/logging_test.go
@@ -80,7 +80,7 @@ func TestRequestLogger(t *testing.T) {
 	proxyCtx := &goproxy.ProxyCtx{Session: 128}
 
 	cases := map[string]struct {
-		setup     func(l *requestLogger)
+		setup     func(t *testing.T, l *requestLogger)
 		teardown  func()
 		expected  []string
 		multiline bool
@@ -89,23 +89,23 @@ func TestRequestLogger(t *testing.T) {
 			expected: nil,
 		},
 		"request": {
-			setup: func(l *requestLogger) {
+			setup: func(t *testing.T, l *requestLogger) {
 				_, resp := l.logRequest(req, proxyCtx)
 				if resp != nil && resp.Body != nil {
-					resp.Body.Close()
+					require.NoError(t, resp.Body.Close())
 				}
 			},
 			expected: []string{"[128] GET https://github.com:443"},
 		},
 		"requests": {
-			setup: func(l *requestLogger) {
+			setup: func(t *testing.T, l *requestLogger) {
 				_, resp := l.logRequest(req, proxyCtx)
 				if resp != nil && resp.Body != nil {
-					resp.Body.Close()
+					require.NoError(t, resp.Body.Close())
 				}
 				_, resp = l.logRequest(req, proxyCtx)
 				if resp != nil && resp.Body != nil {
-					resp.Body.Close()
+					require.NoError(t, resp.Body.Close())
 				}
 			},
 			expected: []string{
@@ -115,7 +115,7 @@ func TestRequestLogger(t *testing.T) {
 		},
 
 		"response on 40x": {
-			setup: func(l *requestLogger) {
+			setup: func(t *testing.T, l *requestLogger) {
 				resp := &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
@@ -133,7 +133,7 @@ func TestRequestLogger(t *testing.T) {
 				}
 				resp = l.logResponse(resp, proxyCtx)
 				if resp != nil && resp.Body != nil {
-					resp.Body.Close()
+					require.NoError(t, resp.Body.Close())
 				}
 			},
 			expected: []string{
@@ -157,7 +157,7 @@ func TestRequestLogger(t *testing.T) {
 			log.SetOutput(&buf)
 			l := NewRequestLogger()
 			if tc.setup != nil {
-				tc.setup(l)
+				tc.setup(t, l)
 			}
 
 			// Check the suffix of each line, to avoid timestamps

--- a/main.go
+++ b/main.go
@@ -34,7 +34,11 @@ func main() {
 	flag.Parse()
 	file := setupLogging()
 	if file != nil {
-		defer file.Close()
+		defer func() {
+			if err := file.Close(); err != nil {
+				log.Printf("failed to close log file: %v", err)
+			}
+		}()
 	}
 	logrus.Info("proxy starting, commit: " + version.GitCommit)
 

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 	if file != nil {
 		defer func() {
 			if err := file.Close(); err != nil {
-				log.Printf("failed to close log file: %v", err)
+				log.New(os.Stderr, log.Prefix(), log.Flags()).Printf("failed to close log file: %v", err)
 			}
 		}()
 	}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -35,19 +35,26 @@ var (
 	}
 )
 
+func closeOnCleanup(t *testing.T, closer io.Closer) {
+	t.Helper()
+	t.Cleanup(func() {
+		require.NoError(t, closer.Close())
+	})
+}
+
 func TestProxyHTTPRequest(t *testing.T) {
 	var blockedIPs []net.IP
 	client, proxy := testProxyServer(t, testProxyConfig, blockedIPs)
-	defer proxy.Close()
+	closeOnCleanup(t, proxy)
 
 	url, httpSrv := testHTTPServer(t)
-	defer httpSrv.Close()
+	closeOnCleanup(t, httpSrv)
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
 	require.NoError(t, err)
 	rsp, err := client.Do(req)
 	require.NoError(t, err)
-	defer rsp.Body.Close()
+	closeOnCleanup(t, rsp.Body)
 	assert.Equal(t, 200, rsp.StatusCode)
 }
 
@@ -61,7 +68,7 @@ func TestProxyHTTPSMITMFixedLengthResponseFraming(t *testing.T) {
 
 	t.Setenv("PROXY_CACHE", "false")
 	client, proxy := testProxyServer(t, testProxyConfig, nil, upstream.Certificate())
-	defer proxy.Close()
+	closeOnCleanup(t, proxy)
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, upstream.URL, nil)
 	require.NoError(t, err)
@@ -114,7 +121,7 @@ func TestProxyHTTPSMITMResponseFraming(t *testing.T) {
 
 	t.Setenv("PROXY_CACHE", "true")
 	client, proxy := testProxyServer(t, testProxyConfig, nil, upstream.Certificate())
-	defer proxy.Close()
+	closeOnCleanup(t, proxy)
 	transport := client.Transport.(*http.Transport)
 	var proxyDials atomic.Int32
 	dialer := &net.Dialer{}
@@ -193,7 +200,7 @@ func TestProxyHTTPSMITMHeadCacheHitPreservesContentLength(t *testing.T) {
 
 	t.Setenv("PROXY_CACHE", "true")
 	client, proxy := testProxyServer(t, testProxyConfig, nil, upstream.Certificate())
-	defer proxy.Close()
+	closeOnCleanup(t, proxy)
 	transport := client.Transport.(*http.Transport)
 	var proxyDials atomic.Int32
 	dialer := &net.Dialer{}
@@ -245,7 +252,7 @@ func TestProxyHTTPSConditionalNotModifiedPreservesCachedResponse(t *testing.T) {
 
 	t.Setenv("PROXY_CACHE", "true")
 	client, proxy := testProxyServer(t, testProxyConfig, nil, upstream.Certificate())
-	defer proxy.Close()
+	closeOnCleanup(t, proxy)
 	transport := client.Transport.(*http.Transport)
 	var proxyDials atomic.Int32
 	dialer := &net.Dialer{}
@@ -319,7 +326,7 @@ func TestProxyUpstreamCloseIsNotCachedAsBodylessResponse(t *testing.T) {
 
 	t.Setenv("PROXY_CACHE", "true")
 	client, proxy := testProxyServer(t, testProxyConfig, nil)
-	defer proxy.Close()
+	closeOnCleanup(t, proxy)
 
 	request := func() *http.Response {
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, upstream.URL, nil)
@@ -351,10 +358,10 @@ func TestProxyUpstreamCloseIsNotCachedAsBodylessResponse(t *testing.T) {
 func TestIPRestrictions(t *testing.T) {
 	blockedIPs = []net.IP{iPV4Localhost, iPV6Localhost}
 	client, proxy := testProxyServer(t, testProxyConfig, blockedIPs)
-	defer proxy.Close()
+	closeOnCleanup(t, proxy)
 
 	_, httpSrv := testHTTPServer(t)
-	defer httpSrv.Close()
+	closeOnCleanup(t, httpSrv)
 
 	httpTestCases := []string{
 		"http://127.0.0.1",
@@ -370,7 +377,7 @@ func TestIPRestrictions(t *testing.T) {
 			require.NoError(t, err)
 			rsp, err := client.Do(req)
 			require.NoError(t, err)
-			defer rsp.Body.Close()
+			closeOnCleanup(t, rsp.Body)
 
 			assert.Equal(t, 403, rsp.StatusCode)
 		})
@@ -399,7 +406,7 @@ func TestIPRestrictions(t *testing.T) {
 func TestMetadataAPIRestriction(t *testing.T) {
 	var blockedIPs []net.IP
 	client, proxy := testProxyServer(t, testProxyConfig, blockedIPs)
-	defer proxy.Close()
+	closeOnCleanup(t, proxy)
 
 	type testCase struct {
 		url  string
@@ -444,7 +451,7 @@ func TestMetadataAPIRestriction(t *testing.T) {
 
 			rsp, err := client.Do(req)
 			require.NoError(t, err)
-			defer rsp.Body.Close()
+			closeOnCleanup(t, rsp.Body)
 
 			assert.Equal(t, 403, rsp.StatusCode)
 		})
@@ -555,16 +562,20 @@ func testCA() config.CaDetails {
 	}
 
 	caPEM := new(bytes.Buffer)
-	pem.Encode(caPEM, &pem.Block{
+	if err := pem.Encode(caPEM, &pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: caBytes,
-	})
+	}); err != nil {
+		panic(err)
+	}
 
 	caPrivKeyPEM := new(bytes.Buffer)
-	pem.Encode(caPrivKeyPEM, &pem.Block{
+	if err := pem.Encode(caPrivKeyPEM, &pem.Block{
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey),
-	})
+	}); err != nil {
+		panic(err)
+	}
 
 	return config.CaDetails{
 		Cert: caPEM.String(),


### PR DESCRIPTION
### What are you trying to accomplish?

Handle every `errcheck` finding instead of discarding errors. Runtime code now returns or logs close failures, while tests assert cleanup and response write errors.

### Anything you want to highlight for special attention from reviewers?

This is layer 4 of 6. API and OIDC response close failures are joined with existing return errors. Test cleanup failures now fail the test clearly.

### How will you know you've accomplished your goal?

`golangci-lint run --enable-only=errcheck --max-issues-per-linter=0 ./...` and the full race-enabled test suite pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.