### PR TITLE
Close all reported response bodies

### DIFF
--- a/internal/cache/handlers_test.go
+++ b/internal/cache/handlers_test.go
@@ -193,6 +193,9 @@ func TestCache_BodylessResponses(t *testing.T) {
 			missReq := httptest.NewRequestWithContext(t.Context(), tc.method, URL, nil)
 			missCtx := &goproxy.ProxyCtx{Req: missReq}
 			_, resp := cacher.OnRequest(missReq, missCtx)
+			if resp != nil && resp.Body != nil {
+				require.NoError(t, resp.Body.Close())
+			}
 			require.Nil(t, resp)
 
 			resp = &http.Response{
@@ -208,6 +211,7 @@ func TestCache_BodylessResponses(t *testing.T) {
 			assert.True(t, resp.Body == http.NoBody,
 				"OnResponse must leave bodyless Body as http.NoBody (not tee-wrapped)")
 			assert.Len(t, cacher.cacheDB, 1, "bodyless response should still be cached")
+			require.NoError(t, resp.Body.Close())
 
 			// --- Cache hit: OnRequest must serve a bodyless response. ---
 			hitReq := httptest.NewRequestWithContext(t.Context(), tc.method, URL, nil)
@@ -218,6 +222,7 @@ func TestCache_BodylessResponses(t *testing.T) {
 				"cache hit must serve bodyless responses with http.NoBody")
 			assert.Equal(t, tc.wantHitContentLen, hit.ContentLength)
 			assert.Empty(t, hit.TransferEncoding)
+			require.NoError(t, hit.Body.Close())
 		})
 	}
 }
@@ -250,6 +255,9 @@ func TestCache_BodylessResponseWithWrappedBodyIsRestored(t *testing.T) {
 			req := httptest.NewRequestWithContext(t.Context(), tc.method, URL, nil)
 			proxyCtx := &goproxy.ProxyCtx{Req: req}
 			_, resp := cacher.OnRequest(req, proxyCtx)
+			if resp != nil && resp.Body != nil {
+				require.NoError(t, resp.Body.Close())
+			}
 			require.Nil(t, resp)
 
 			// Simulate an upstream handler that swapped in a non-NoBody wrapper.
@@ -267,6 +275,7 @@ func TestCache_BodylessResponseWithWrappedBodyIsRestored(t *testing.T) {
 				"OnResponse must restore http.NoBody when a bodyless response was wrapped")
 			assert.True(t, closed, "the replaced wrapper must be closed to avoid leaks")
 			assert.Len(t, cacher.cacheDB, 1, "bodyless response should still be cached")
+			require.NoError(t, resp.Body.Close())
 		})
 	}
 }
@@ -284,6 +293,9 @@ func TestCache_SwitchingProtocolsNotCached(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, URL, nil)
 	proxyCtx := &goproxy.ProxyCtx{Req: req}
 	_, resp := cacher.OnRequest(req, proxyCtx)
+	if resp != nil && resp.Body != nil {
+		require.NoError(t, resp.Body.Close())
+	}
 	require.Nil(t, resp)
 
 	upgraded := io.NopCloser(bytes.NewBufferString("websocket-stream"))
@@ -295,6 +307,7 @@ func TestCache_SwitchingProtocolsNotCached(t *testing.T) {
 	resp = cacher.OnResponse(resp, proxyCtx)
 	assert.True(t, resp.Body == upgraded, "101 body must be passed through untouched")
 	assert.Empty(t, cacher.cacheDB, "101 must not be cached")
+	require.NoError(t, resp.Body.Close())
 }
 
 // TestCache_ZeroByteBodyIsCached verifies a valid 200 response with an empty
@@ -310,6 +323,9 @@ func TestCache_ZeroByteBodyIsCached(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, URL, nil)
 	proxyCtx := &goproxy.ProxyCtx{Req: req}
 	_, resp := cacher.OnRequest(req, proxyCtx)
+	if resp != nil && resp.Body != nil {
+		require.NoError(t, resp.Body.Close())
+	}
 	require.Nil(t, resp)
 
 	resp = &http.Response{
@@ -350,6 +366,9 @@ func TestCache_MissingCacheFileIsNotCountedAsHit(t *testing.T) {
 	missReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, URL, nil)
 	missCtx := &goproxy.ProxyCtx{Req: missReq}
 	_, resp := cacher.OnRequest(missReq, missCtx)
+	if resp != nil && resp.Body != nil {
+		require.NoError(t, resp.Body.Close())
+	}
 	require.Nil(t, resp)
 	resp = &http.Response{
 		Request:    missReq,
@@ -370,6 +389,9 @@ func TestCache_MissingCacheFileIsNotCountedAsHit(t *testing.T) {
 	hitReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, URL, nil)
 	hitCtx := &goproxy.ProxyCtx{Req: hitReq}
 	_, hit := cacher.OnRequest(hitReq, hitCtx)
+	if hit != nil && hit.Body != nil {
+		require.NoError(t, hit.Body.Close())
+	}
 
 	assert.Nil(t, hit, "a missing cache file must fall through to upstream")
 	assert.Equal(t, cachedBefore, cacher.cached, "a missing cache file must not be counted as a hit")

--- a/internal/handlers/git_server_test.go
+++ b/internal/handlers/git_server_test.go
@@ -662,7 +662,7 @@ func TestJITEndpointUsesExplicitAuthWhenProvided(t *testing.T) {
 	})
 	proxyCtx := &goproxy.ProxyCtx{Req: req, RoundTripper: roundTripper}
 
-	req, _ = handler.HandleRequest(req, proxyCtx)
+	req = handleRequestAndClose(handler, req, proxyCtx)
 
 	client := &http.Client{
 		Timeout: 10 * time.Second,

--- a/internal/handlers/nuget_feed_test.go
+++ b/internal/handlers/nuget_feed_test.go
@@ -366,12 +366,13 @@ func TestNugetFeedHandlerLeavesBodylessResponseUnchanged(t *testing.T) {
 	for _, statusCode := range []int{http.StatusNoContent, http.StatusResetContent} {
 		proxyCtx := &goproxy.ProxyCtx{}
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.example.com/index.json", nil)
-		handler.PrepareRequest(req, proxyCtx)
+		prepareRequestAndClose(handler, req, proxyCtx)
 		resp := &http.Response{StatusCode: statusCode, Body: http.NoBody}
 
-		handler.HandleResponse(resp, proxyCtx)
+		resp = handler.HandleResponse(resp, proxyCtx)
 
 		assert.True(t, resp.Body == http.NoBody)
+		require.NoError(t, resp.Body.Close())
 	}
 }
 
@@ -381,17 +382,18 @@ func TestNugetFeedHandlerReplaysBodyAfterReadError(t *testing.T) {
 	})
 	proxyCtx := &goproxy.ProxyCtx{}
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.example.com/index.json", nil)
-	handler.PrepareRequest(req, proxyCtx)
+	prepareRequestAndClose(handler, req, proxyCtx)
 	originalBody := &readErrorThenData{
 		first: []byte("first"),
 		rest:  strings.NewReader("second"),
 	}
 	resp := &http.Response{StatusCode: http.StatusOK, Body: originalBody}
 
-	handler.HandleResponse(resp, proxyCtx)
+	resp = handler.HandleResponse(resp, proxyCtx)
 	replayed, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.Equal(t, "firstsecond", string(replayed))
+	require.NoError(t, resp.Body.Close())
 }
 
 func TestNugetFeedHandlerOnlyDiscoversFromConfiguredServiceIndex(t *testing.T) {
@@ -400,13 +402,13 @@ func TestNugetFeedHandlerOnlyDiscoversFromConfiguredServiceIndex(t *testing.T) {
 	})
 	proxyCtx := &goproxy.ProxyCtx{}
 	packageReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.example.com/v3/some-package/index.json", nil)
-	handler.PrepareRequest(packageReq, proxyCtx)
+	prepareRequestAndClose(handler, packageReq, proxyCtx)
 
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
 		Body:       io.NopCloser(strings.NewReader(nugetV3Response("https://untrusted.example.com/packages"))),
 	}
-	handler.HandleResponse(resp, proxyCtx)
+	handleResponseAndClose(handler, resp, proxyCtx)
 
 	untrustedReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://untrusted.example.com/packages/example/index.json", nil)
 	untrustedReq = handleRequestAndClose(handler, untrustedReq, &goproxy.ProxyCtx{})
@@ -453,8 +455,8 @@ func TestNugetFeedHandlerRequiresConfiguredServiceIndexSchemeForDiscovery(t *tes
 			})
 			proxyCtx := &goproxy.ProxyCtx{}
 			indexReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, testCase.requestedURL, nil)
-			handler.PrepareRequest(indexReq, proxyCtx)
-			handler.HandleResponse(&http.Response{
+			prepareRequestAndClose(handler, indexReq, proxyCtx)
+			handleResponseAndClose(handler, &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader(nugetV3Response("https://attacker.example.com/packages"))),
 			}, proxyCtx)
@@ -510,17 +512,19 @@ func TestNugetFeedHandlerConcurrentDiscoveryIsDeduplicated(t *testing.T) {
 			<-start
 			proxyCtx := &goproxy.ProxyCtx{}
 			indexReq := httptest.NewRequestWithContext(ctx, http.MethodGet, "https://nuget.example.com/index.json", nil)
-			handler.PrepareRequest(indexReq, proxyCtx)
-			handler.HandleRequest(indexReq, proxyCtx)
+			indexReq = prepareRequestAndClose(handler, indexReq, proxyCtx)
+			handleRequestAndClose(handler, indexReq, proxyCtx)
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader(responseBody)),
 			}
-			handler.HandleResponse(resp, proxyCtx)
-			mustClose(resp.Body)
+			resp = handler.HandleResponse(resp, proxyCtx)
+			if err := resp.Body.Close(); err != nil {
+				panic(err)
+			}
 
 			packageReq := httptest.NewRequestWithContext(ctx, http.MethodGet, "https://cdn.example.com/packages/example/index.json", nil)
-			handler.HandleRequest(packageReq, &goproxy.ProxyCtx{})
+			handleRequestAndClose(handler, packageReq, &goproxy.ProxyCtx{})
 		}()
 	}
 	close(start)
@@ -607,34 +611,34 @@ func TestNugetFeedHandlerDiscoversThroughCrossOriginRedirectWithoutLeakingCreden
 
 	initialCtx := &goproxy.ProxyCtx{}
 	initialReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.example.com/index.json", nil)
-	handler.PrepareRequest(initialReq, initialCtx)
+	initialReq = prepareRequestAndClose(handler, initialReq, initialCtx)
 	initialReq = handleRequestAndClose(handler, initialReq, initialCtx)
 	assertHasTokenAuth(t, initialReq, "Bearer", "some-token", "configured service index")
-	handler.HandleResponse(&http.Response{
+	handleResponseAndClose(handler, &http.Response{
 		StatusCode: http.StatusFound,
 		Header:     http.Header{"Location": []string{"https://redirect.example.com/index.json"}},
 	}, initialCtx)
 
 	redirectCtx := &goproxy.ProxyCtx{}
 	redirectReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://redirect.example.com/index.json", nil)
-	handler.PrepareRequest(redirectReq, redirectCtx)
+	redirectReq = prepareRequestAndClose(handler, redirectReq, redirectCtx)
 	redirectReq = handleRequestAndClose(handler, redirectReq, redirectCtx)
 	assertUnauthenticated(t, redirectReq, "cross-origin service-index redirect")
-	handler.HandleResponse(&http.Response{
+	handleResponseAndClose(handler, &http.Response{
 		StatusCode: http.StatusTemporaryRedirect,
 		Header:     http.Header{"Location": []string{"/v3/index.json"}},
 	}, redirectCtx)
 
 	finalCtx := &goproxy.ProxyCtx{}
 	finalReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://redirect.example.com/v3/index.json", nil)
-	handler.PrepareRequest(finalReq, finalCtx)
+	finalReq = prepareRequestAndClose(handler, finalReq, finalCtx)
 	finalReq = handleRequestAndClose(handler, finalReq, finalCtx)
 	assertUnauthenticated(t, finalReq, "redirect after cross-origin service-index redirect")
 	finalResp := &http.Response{
 		StatusCode: http.StatusOK,
 		Body:       io.NopCloser(strings.NewReader(nugetV3Response("https://cdn.example.com/packages"))),
 	}
-	handler.HandleResponse(finalResp, finalCtx)
+	handleResponseAndClose(handler, finalResp, finalCtx)
 
 	packageReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://cdn.example.com/packages/example/index.json", nil)
 	packageReq = handleRequestAndClose(handler, packageReq, &goproxy.ProxyCtx{})
@@ -648,9 +652,9 @@ func TestNugetFeedHandlerAuthenticatesSameOriginServiceIndexRedirect(t *testing.
 
 	initialCtx := &goproxy.ProxyCtx{}
 	initialReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.example.com/index.json", nil)
-	handler.PrepareRequest(initialReq, initialCtx)
+	initialReq = prepareRequestAndClose(handler, initialReq, initialCtx)
 	handleRequestAndClose(handler, initialReq, initialCtx)
-	handler.HandleResponse(&http.Response{
+	handleResponseAndClose(handler, &http.Response{
 		StatusCode: http.StatusTemporaryRedirect,
 		Header:     http.Header{"Location": []string{"/v3/index.json"}},
 	}, initialCtx)
@@ -689,16 +693,16 @@ func TestNugetFeedHandlerResolvesRelativeRedirectAgainstRequestedServiceIndexURL
 
 			initialCtx := &goproxy.ProxyCtx{}
 			initialReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, testCase.requestedURL, nil)
-			handler.PrepareRequest(initialReq, initialCtx)
-			handler.HandleResponse(&http.Response{
+			prepareRequestAndClose(handler, initialReq, initialCtx)
+			handleResponseAndClose(handler, &http.Response{
 				StatusCode: http.StatusTemporaryRedirect,
 				Header:     http.Header{"Location": []string{"next.json"}},
 			}, initialCtx)
 
 			redirectCtx := &goproxy.ProxyCtx{}
 			redirectReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, testCase.redirectURL, nil)
-			handler.PrepareRequest(redirectReq, redirectCtx)
-			handler.HandleResponse(&http.Response{
+			prepareRequestAndClose(handler, redirectReq, redirectCtx)
+			handleResponseAndClose(handler, &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader(nugetV3Response("https://cdn.example.com/packages"))),
 			}, redirectCtx)
@@ -724,14 +728,14 @@ func discoverNugetFeed(t *testing.T, handler *NugetFeedHandler, sourceURL string
 	t.Helper()
 	proxyCtx := &goproxy.ProxyCtx{}
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, sourceURL, nil)
-	handler.PrepareRequest(req, proxyCtx)
+	req = prepareRequestAndClose(handler, req, proxyCtx)
 	handleRequestAndClose(handler, req, proxyCtx)
 
 	resp := &http.Response{
 		StatusCode: statusCode,
 		Body:       io.NopCloser(strings.NewReader(responseBody)),
 	}
-	handler.HandleResponse(resp, proxyCtx)
+	resp = handler.HandleResponse(resp, proxyCtx)
 
 	replayedBody, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)

--- a/internal/handlers/oidc_handling_test.go
+++ b/internal/handlers/oidc_handling_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elazarl/goproxy"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dependabot/proxy/internal/config"
 )
@@ -1695,7 +1696,8 @@ func TestPythonOIDCAuthenticatesDiscoveredDownloadPrefix(t *testing.T) {
 			</body></html>
 		`)),
 	}
-	handler.HandleResponse(indexResp, proxyCtx)
+	indexResp = handler.HandleResponse(indexResp, proxyCtx)
+	require.NoError(t, indexResp.Body.Close())
 
 	downloadReq := httptest.NewRequestWithContext(t.Context(),
 		"HEAD",

--- a/internal/handlers/python_index_test.go
+++ b/internal/handlers/python_index_test.go
@@ -148,7 +148,8 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromHTML(t *test
 			</body></html>
 		`)),
 	}
-	handler.HandleResponse(indexResp, proxyCtx)
+	indexResp = handler.HandleResponse(indexResp, proxyCtx)
+	require.NoError(t, indexResp.Body.Close())
 
 	downloadReq := httptest.NewRequestWithContext(t.Context(),
 		"HEAD",
@@ -206,7 +207,8 @@ func TestPythonIndexHandlerAuthenticatesDiscoveredDownloadPrefixFromJSON(t *test
 			]
 		}`)),
 	}
-	handler.HandleResponse(indexResp, proxyCtx)
+	indexResp = handler.HandleResponse(indexResp, proxyCtx)
+	require.NoError(t, indexResp.Body.Close())
 
 	downloadReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
@@ -277,7 +279,8 @@ func TestPythonIndexHandlerSkipsDiscoveryForAuthenticatedNonSimpleResponse(t *te
 			</a>
 		`)),
 	}
-	handler.HandleResponse(indexResp, proxyCtx)
+	indexResp = handler.HandleResponse(indexResp, proxyCtx)
+	require.NoError(t, indexResp.Body.Close())
 
 	downloadReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
@@ -317,7 +320,8 @@ func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixPort(t *testing.T) {
 			</a>
 		`)),
 	}
-	handler.HandleResponse(indexResp, proxyCtx)
+	indexResp = handler.HandleResponse(indexResp, proxyCtx)
+	require.NoError(t, indexResp.Body.Close())
 
 	downloadReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
@@ -365,7 +369,8 @@ func TestPythonIndexHandlerPreservesDiscoveredDownloadPrefixIPv6Host(t *testing.
 			</a>
 		`)),
 	}
-	handler.HandleResponse(indexResp, proxyCtx)
+	indexResp = handler.HandleResponse(indexResp, proxyCtx)
+	require.NoError(t, indexResp.Body.Close())
 
 	downloadReq := httptest.NewRequestWithContext(t.Context(),
 		"GET",
@@ -445,11 +450,12 @@ func TestPythonIndexHandlerSkipsDiscoveryForLargeSimpleResponse(t *testing.T) {
 		},
 		Body: io.NopCloser(strings.NewReader(responseBody)),
 	}
-	handler.HandleResponse(indexResp, proxyCtx)
+	indexResp = handler.HandleResponse(indexResp, proxyCtx)
 
 	replayedBody, err := io.ReadAll(indexResp.Body)
 	require.NoError(t, err)
 	assert.Equal(t, responseBody, string(replayedBody))
+	require.NoError(t, indexResp.Body.Close())
 
 	downloadReq := httptest.NewRequestWithContext(t.Context(), "GET", downloadURL, nil)
 	downloadReq = handleRequestAndClose(handler, downloadReq, &goproxy.ProxyCtx{})

--- a/internal/handlers/test_helpers.go
+++ b/internal/handlers/test_helpers.go
@@ -20,9 +20,34 @@ func handleRequestAndClose(handler interface {
 }, req *http.Request, proxyCtx *goproxy.ProxyCtx) *http.Request {
 	req, resp := handler.HandleRequest(req, proxyCtx)
 	if resp != nil && resp.Body != nil {
-		mustClose(resp.Body)
+		defer func() {
+			mustClose(resp.Body)
+		}()
 	}
 	return req
+}
+
+func prepareRequestAndClose(handler interface {
+	PrepareRequest(*http.Request, *goproxy.ProxyCtx) (*http.Request, *http.Response)
+}, req *http.Request, proxyCtx *goproxy.ProxyCtx) *http.Request {
+	req, resp := handler.PrepareRequest(req, proxyCtx)
+	if resp != nil && resp.Body != nil {
+		defer func() {
+			mustClose(resp.Body)
+		}()
+	}
+	return req
+}
+
+func handleResponseAndClose(handler interface {
+	HandleResponse(*http.Response, *goproxy.ProxyCtx) *http.Response
+}, resp *http.Response, proxyCtx *goproxy.ProxyCtx) {
+	resp = handler.HandleResponse(resp, proxyCtx)
+	if resp != nil && resp.Body != nil {
+		defer func() {
+			mustClose(resp.Body)
+		}()
+	}
 }
 
 func mustClose(closer io.Closer) {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -54,7 +54,9 @@ func TestProxyHTTPRequest(t *testing.T) {
 	require.NoError(t, err)
 	rsp, err := client.Do(req)
 	require.NoError(t, err)
-	closeOnCleanup(t, rsp.Body)
+	defer func() {
+		require.NoError(t, rsp.Body.Close())
+	}()
 	assert.Equal(t, 200, rsp.StatusCode)
 }
 
@@ -377,7 +379,9 @@ func TestIPRestrictions(t *testing.T) {
 			require.NoError(t, err)
 			rsp, err := client.Do(req)
 			require.NoError(t, err)
-			closeOnCleanup(t, rsp.Body)
+			defer func() {
+				require.NoError(t, rsp.Body.Close())
+			}()
 
 			assert.Equal(t, 403, rsp.StatusCode)
 		})
@@ -451,7 +455,9 @@ func TestMetadataAPIRestriction(t *testing.T) {
 
 			rsp, err := client.Do(req)
 			require.NoError(t, err)
-			closeOnCleanup(t, rsp.Body)
+			defer func() {
+				require.NoError(t, rsp.Body.Close())
+			}()
 
 			assert.Equal(t, 403, rsp.StatusCode)
 		})


### PR DESCRIPTION
### What are you trying to accomplish?

Close every response body reported by `bodyclose`, mainly in tests, and add test helpers for handler methods that can return responses.

### Anything you want to highlight for special attention from reviewers?

This is layer 5 of 6. Response bodies remain open until the test finishes reading or asserting against them, then close with checked errors.

### How will you know you've accomplished your goal?

`golangci-lint run --enable-only=bodyclose --max-issues-per-linter=0 ./...` and the full race-enabled test suite pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.