### PR TITLE
Document gosec credential fixtures

### DIFF
--- a/internal/handlers/git_server_test.go
+++ b/internal/handlers/git_server_test.go
@@ -583,6 +583,7 @@ func TestGitServerHandler_RequestJITAccess(t *testing.T) {
 	}
 }
 
+//nolint:gosec // The test credentials are intentionally fake fixtures.
 func TestJITEndpointUsesExplicitAuthWhenProvided(t *testing.T) {
 	// jit_access host is different from the endpoint host _AND_ requires separate auth
 	// This test verifies that the explicit username and password that accompany the jit_access cred are used

--- a/internal/oidc/actions_oidc.go
+++ b/internal/oidc/actions_oidc.go
@@ -335,7 +335,7 @@ func GetJFrogAccessToken(ctx context.Context, params JFrogOIDCParameters, github
 		return nil, fmt.Errorf("GitHub token is required")
 	}
 
-	tokenRequest := jfrogTokenRequest{
+	tokenRequest := jfrogTokenRequest{ //nolint:gosec // OIDC token is supplied by the caller, not hardcoded.
 		GrantType:           "urn:ietf:params:oauth:grant-type:token-exchange",
 		SubjectTokenType:    "urn:ietf:params:oauth:token-type:id_token",
 		ProviderType:        "GitHub",
@@ -692,7 +692,7 @@ func GetGCPAccessToken(ctx context.Context, params GCPOIDCParameters, githubToke
 	}
 
 	// Step A: STS token exchange (always)
-	stsReqBody := gcpSTSTokenRequest{
+	stsReqBody := gcpSTSTokenRequest{ //nolint:gosec // OIDC token is supplied by the caller, not hardcoded.
 		Audience:           params.Audience,
 		GrantType:          "urn:ietf:params:oauth:grant-type:token-exchange",
 		RequestedTokenType: "urn:ietf:params:oauth:token-type:access_token",

--- a/internal/oidc/actions_oidc_test.go
+++ b/internal/oidc/actions_oidc_test.go
@@ -97,6 +97,7 @@ func TestIsOIDCConfigured(t *testing.T) {
 	}
 }
 
+//nolint:gosec // The test credentials are intentionally fake fixtures.
 func TestGetToken(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -319,6 +320,7 @@ func TestGetToken_URLParsing(t *testing.T) {
 	}
 }
 
+//nolint:gosec // The test credentials are intentionally fake fixtures.
 func TestGetAzureAccessToken(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -468,6 +470,7 @@ func TestGetAzureAccessToken(t *testing.T) {
 	}
 }
 
+//nolint:gosec // The test credentials are intentionally fake fixtures.
 func TestGetJFrogAccessToken(t *testing.T) {
 	tests := []struct {
 		name                string
@@ -647,6 +650,7 @@ func TestGetJFrogAccessToken(t *testing.T) {
 	}
 }
 
+//nolint:gosec // The test credentials are intentionally fake fixtures.
 func TestGetAWSAccessToken(t *testing.T) {
 	testRegion := "us-east-1"
 	tests := []struct {
@@ -836,6 +840,7 @@ func TestGetAWSAccessToken(t *testing.T) {
 	}
 }
 
+//nolint:gosec // The test credentials are intentionally fake fixtures.
 func TestGetCloudsmithAccessToken(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -1018,6 +1023,7 @@ func TestGetCloudsmithAccessToken(t *testing.T) {
 	}
 }
 
+//nolint:gosec // The test credentials are intentionally fake fixtures.
 func TestGetGCPAccessToken(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/oidc/oidc_credential_test.go
+++ b/internal/oidc/oidc_credential_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dependabot/proxy/internal/config"
 )
 
+//nolint:gosec // The test credentials are intentionally fake fixtures.
 func TestSuccessfulAuthenticationDoesNotMakeARepeatedRequest(t *testing.T) {
 	// these variables are necessary
 	t.Setenv(envActionsIDTokenRequestURL, "https://example.com/token")

--- a/logging_test.go
+++ b/logging_test.go
@@ -24,6 +24,7 @@ import (
 
 var timestamp = regexp.MustCompile(`\d{4}/\d{2}/{2} \d{2}:\d{2}:\d{2} `)
 
+//nolint:gosec // The URL contains intentionally fake credentials for redaction testing.
 func TestURLWithoutCredentials(t *testing.T) {
 	cases := map[string]struct {
 		url      string


### PR DESCRIPTION
### What are you trying to accomplish?

Document `gosec` false positives for caller-supplied OIDC tokens and deliberately fake test credentials so the security lint check passes without changing credential handling.

### Anything you want to highlight for special attention from reviewers?

This is layer 6 of 6. Production suppressions apply only to the two request expressions. Test suppressions apply only to functions built around fake credential fixtures.

### How will you know you've accomplished your goal?

`golangci-lint run --enable-only=gosec --max-issues-per-linter=0 ./...` and the full uncapped lint run pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.