### PR TITLE
Treat automatic package credentials as fallback auth

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,14 @@ func (c Credential) GetString(key string) string {
 	return ""
 }
 
+// GetBool returns a Boolean value or false.
+func (c Credential) GetBool(key string) bool {
+	if val, ok := c[key].(bool); ok {
+		return val
+	}
+	return false
+}
+
 // Host returns the host of the credential, either from the "host" key or from the "url" key. Empty if neither is set.
 func (c Credential) Host() string {
 	if val, ok := c["host"].(string); ok {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -83,6 +83,22 @@ func TestExperimentsEnabled(t *testing.T) {
 	assert.False(t, Experiments(nil).Enabled("enabled"))
 }
 
+func TestCredentialGetBool(t *testing.T) {
+	credential := Credential{
+		"enabled":     true,
+		"disabled":    false,
+		"string_true": "true",
+		"number":      float64(1),
+	}
+
+	assert.True(t, credential.GetBool("enabled"))
+	assert.False(t, credential.GetBool("disabled"))
+	assert.False(t, credential.GetBool("string_true"))
+	assert.False(t, credential.GetBool("number"))
+	assert.False(t, credential.GetBool("missing"))
+	assert.False(t, Credential(nil).GetBool("enabled"))
+}
+
 func TestHost(t *testing.T) {
 	cases := map[string]struct {
 		input    Credential

--- a/internal/handlers/credentials.go
+++ b/internal/handlers/credentials.go
@@ -1,0 +1,39 @@
+package handlers
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strings"
+)
+
+const authorizationPlaceholder = "******"
+
+func hasUsableAuthorization(req *http.Request) bool {
+	authorization := strings.TrimSpace(req.Header.Get("Authorization"))
+	if authorization == "" || authorization == authorizationPlaceholder {
+		return false
+	}
+
+	parts := strings.Fields(authorization)
+	if len(parts) == 2 && parts[1] == authorizationPlaceholder {
+		return false
+	}
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Basic") {
+		return true
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return true
+	}
+	username, password, ok := strings.Cut(string(decoded), ":")
+	if !ok {
+		return true
+	}
+
+	return username != authorizationPlaceholder && password != authorizationPlaceholder
+}
+
+func proxyOnlyCredentialRequestAllowed(req *http.Request) bool {
+	return req.URL.Scheme == "https" && (req.URL.Port() == "" || req.URL.Port() == "443")
+}

--- a/internal/handlers/credentials_test.go
+++ b/internal/handlers/credentials_test.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"encoding/base64"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasUsableAuthorization(t *testing.T) {
+	testCases := []struct {
+		name          string
+		authorization string
+		expected      bool
+	}{
+		{name: "empty", expected: false},
+		{name: "bare placeholder", authorization: "******", expected: false},
+		{name: "scheme-prefixed plaintext placeholder", authorization: "Bearer ******", expected: false},
+		{name: "Basic plaintext placeholder", authorization: "Basic ******", expected: false},
+		{
+			name:          "username placeholder",
+			authorization: "Basic " + base64.StdEncoding.EncodeToString([]byte("******:password")),
+			expected:      false,
+		},
+		{
+			name:          "password placeholder",
+			authorization: "Basic " + base64.StdEncoding.EncodeToString([]byte("username:******")),
+			expected:      false,
+		},
+		{
+			name:          "both placeholders",
+			authorization: "Basic " + base64.StdEncoding.EncodeToString([]byte("******:******")),
+			expected:      false,
+		},
+		{
+			name:          "genuine Basic",
+			authorization: "Basic " + base64.StdEncoding.EncodeToString([]byte("username:password")),
+			expected:      true,
+		},
+		{name: "malformed Basic", authorization: "Basic not-base64", expected: true},
+		{name: "ordinary Bearer", authorization: "Bearer real-token", expected: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(t.Context(), "GET", "https://example.com", nil)
+			if testCase.authorization != "" {
+				req.Header.Set("Authorization", testCase.authorization)
+			}
+
+			assert.Equal(t, testCase.expected, hasUsableAuthorization(req))
+		})
+	}
+}

--- a/internal/handlers/docker_registry.go
+++ b/internal/handlers/docker_registry.go
@@ -3,8 +3,8 @@ package handlers
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -56,22 +56,41 @@ func NewDockerRegistryHandler(creds config.Credentials, client *http.Client, get
 			continue
 		}
 
-		registry := cred.GetString("registry")
-		if registry == "" {
-			registry = cred.Host()
+		registryLocation, matchLocation, matchField, ok := dockerCredentialLocations(cred)
+		if !ok {
+			continue
+		}
+		matchURL, path, ok := dockerRegistryCredentialLocation(matchLocation)
+		if !ok {
+			continue
 		}
 
-		// OIDC credentials are not used as static credentials.
-		if oidcCred, _, _ := handler.oidcRegistry.Register(cred, []string{"registry"}, "docker registry"); oidcCred != nil {
+		proxyOnly := cred.GetBool("proxy-only")
+		if !proxyOnly {
+			// OIDC credentials are not used as static credentials.
+			oidcMatchingCred, urlFields := dockerOIDCMatchingCredential(cred, matchField, matchURL)
+			if oidcCred, _, _ := handler.oidcRegistry.Register(oidcMatchingCred, urlFields, "docker registry"); oidcCred != nil {
+				continue
+			}
+		}
+		if proxyOnly && cred.GetString("username") == "" && cred.GetString("password") == "" {
+			continue
+		}
+
+		parsedRegistry, err := helpers.ParseURLLax(registryLocation)
+		if err != nil || parsedRegistry.Host == "" {
 			continue
 		}
 
 		registryCred := &dockerRegistryCredentials{
-			registry:     registry,
+			matchURL:     matchURL,
+			registry:     parsedRegistry.Host,
+			path:         path,
 			username:     cred.GetString("username"),
 			password:     cred.GetString("password"),
 			httpClient:   client,
 			getECRClient: getECRClient,
+			proxyOnly:    proxyOnly,
 		}
 		handler.credentials = append(handler.credentials, registryCred)
 	}
@@ -108,18 +127,35 @@ func (h *DockerRegistryHandler) HandleRequest(req *http.Request, proxyCtx *gopro
 		return req, nil
 	}
 
-	// Try OIDC credentials first
-	if h.oidcRegistry.TryAuth(req, proxyCtx) {
+	oidcCredential := h.oidcRegistry.CredentialForRequest(req)
+	if h.oidcRegistry.TryAuthCredential(req, proxyCtx, oidcCredential) {
 		return req, nil
 	}
-
-	// Fall back to static credentials
-	if _, _, ok := req.BasicAuth(); ok {
+	if hasUsableAuthorization(req) {
 		return req, nil
 	}
+	if h.authenticateStaticCredential(req, proxyCtx, false) {
+		return req, nil
+	}
+	if oidcCredential != nil {
+		return req, nil
+	}
+	h.authenticateStaticCredential(req, proxyCtx, true)
 
+	return req, nil
+}
+
+func (h *DockerRegistryHandler) authenticateStaticCredential(
+	req *http.Request,
+	proxyCtx *goproxy.ProxyCtx,
+	proxyOnly bool,
+) bool {
 	for _, cred := range h.credentials {
-		if !helpers.UrlMatchesRequest(req, cred.registry, true) {
+		if cred.proxyOnly != proxyOnly {
+			continue
+		}
+		matchedPath, ok := dockerCredentialMatchesRequest(req, cred)
+		if !ok {
 			continue
 		}
 
@@ -134,7 +170,7 @@ func (h *DockerRegistryHandler) HandleRequest(req *http.Request, proxyCtx *gopro
 					Username:  cred.getUsername(),
 					Password:  cred.getPassword(),
 				},
-				URL:      fmt.Sprintf("https://%s", cred.registry),
+				URL:      (&url.URL{Scheme: req.URL.Scheme, Host: req.URL.Host}).String() + matchedPath,
 				Username: cred.getUsername(),
 				Password: cred.getPassword(),
 			}
@@ -143,10 +179,138 @@ func (h *DockerRegistryHandler) HandleRequest(req *http.Request, proxyCtx *gopro
 			}
 		}
 
-		return req, nil
+		return true
 	}
 
-	return req, nil
+	return false
+}
+
+func dockerCredentialMatchesRequest(
+	req *http.Request,
+	cred *dockerRegistryCredentials,
+) (string, bool) {
+	if !helpers.CredentialURLMatchesRequest(req, cred.matchURL, true) {
+		return "", false
+	}
+	return helpers.MatchingPathPrefix(req.URL.EscapedPath(), cred.path)
+}
+
+func dockerOIDCMatchingCredential(
+	cred config.Credential,
+	field string,
+	matchURL string,
+) (config.Credential, []string) {
+	if field == "" {
+		return cred, nil
+	}
+	copy := make(config.Credential, len(cred))
+	for key, value := range cred {
+		copy[key] = value
+	}
+	copy[field] = matchURL
+	return copy, []string{field}
+}
+
+func dockerCredentialLocations(cred config.Credential) (registry, match, matchField string, ok bool) {
+	registry = cred.GetString("registry")
+	configuredURL := cred.GetString("url")
+
+	if registry == "" && configuredURL == "" {
+		registry = cred.Host()
+		if _, _, _, ok := parseDockerCredentialLocation(registry); !ok {
+			return "", "", "", false
+		}
+		return registry, registry, "", true
+	}
+	if registry == "" {
+		if _, _, _, ok := parseDockerCredentialLocation(configuredURL); !ok {
+			return "", "", "", false
+		}
+		return configuredURL, configuredURL, "url", true
+	}
+
+	registryURL, registryPath, registrySpecificity, ok := parseDockerCredentialLocation(registry)
+	if !ok {
+		return "", "", "", false
+	}
+	if configuredURL == "" {
+		return registry, registry, "registry", true
+	}
+
+	url, urlPath, urlSpecificity, ok := parseDockerCredentialLocation(configuredURL)
+	if !ok {
+		return "", "", "", false
+	}
+	if !dockerOriginsEqual(registryURL, url) {
+		return "", "", "", false
+	}
+	if registryPath == urlPath {
+		return registry, registry, "registry", true
+	}
+	if urlSpecificity > registrySpecificity &&
+		helpers.PathMatches(url.EscapedPath(), registryURL.EscapedPath()) {
+		return registry, configuredURL, "url", true
+	}
+	if registrySpecificity > urlSpecificity &&
+		helpers.PathMatches(registryURL.EscapedPath(), url.EscapedPath()) {
+		return registry, registry, "registry", true
+	}
+	return "", "", "", false
+}
+
+func parseDockerCredentialLocation(location string) (*url.URL, string, int, bool) {
+	parsed, err := helpers.ParseURLLax(location)
+	if err != nil || parsed.Host == "" || parsed.User != nil {
+		return nil, "", 0, false
+	}
+	path, ok := helpers.CanonicalPath(parsed.EscapedPath())
+	if !ok {
+		return nil, "", 0, false
+	}
+	return parsed, path, strings.Count(path, "/"), true
+}
+
+func dockerOriginsEqual(a, b *url.URL) bool {
+	scheme := func(url *url.URL) string {
+		if url.Scheme == "" {
+			return "https"
+		}
+		return strings.ToLower(url.Scheme)
+	}
+	port := func(url *url.URL) string {
+		if url.Port() != "" {
+			return url.Port()
+		}
+		if scheme(url) == "http" {
+			return "80"
+		}
+		return "443"
+	}
+
+	return scheme(a) == scheme(b) &&
+		port(a) == port(b) &&
+		helpers.AreHostnamesEqual(a.Hostname(), b.Hostname())
+}
+
+func dockerRegistryCredentialLocation(location string) (matchURL, path string, ok bool) {
+	parsed, err := helpers.ParseURLLax(location)
+	if err != nil || parsed.Host == "" {
+		return "", "", false
+	}
+
+	path = strings.TrimRight(parsed.EscapedPath(), "/")
+	if path == "" {
+		return location, "", true
+	}
+	if path != "/v2" && !strings.HasPrefix(path, "/v2/") {
+		parsed.Path = "/v2" + strings.TrimRight(parsed.Path, "/")
+		if parsed.RawPath != "" {
+			parsed.RawPath = "/v2" + path
+		}
+		path = "/v2" + path
+	}
+
+	return parsed.String(), path, true
 }
 
 func defaultGetECRClient(ctx context.Context, region, keyID, secretKey string, client *http.Client) (ecrClient, error) {
@@ -164,13 +328,16 @@ func defaultGetECRClient(ctx context.Context, region, keyID, secretKey string, c
 }
 
 type dockerRegistryCredentials struct {
+	matchURL     string
 	registry     string
+	path         string
 	username     string
 	password     string
 	ecrUsername  string
 	ecrPassword  string
 	httpClient   *http.Client
 	getECRClient getECRClient
+	proxyOnly    bool
 }
 
 func (c *dockerRegistryCredentials) getECRCredentials(requestCtx context.Context, proxyCtx *goproxy.ProxyCtx) bool {

--- a/internal/handlers/docker_registry.go
+++ b/internal/handlers/docker_registry.go
@@ -150,6 +150,10 @@ func (h *DockerRegistryHandler) authenticateStaticCredential(
 	proxyCtx *goproxy.ProxyCtx,
 	proxyOnly bool,
 ) bool {
+	if proxyOnly && !proxyOnlyCredentialRequestAllowed(req) {
+		return false
+	}
+
 	for _, cred := range h.credentials {
 		if cred.proxyOnly != proxyOnly {
 			continue

--- a/internal/handlers/docker_registry.go
+++ b/internal/handlers/docker_registry.go
@@ -60,12 +60,12 @@ func NewDockerRegistryHandler(creds config.Credentials, client *http.Client, get
 		if !ok {
 			continue
 		}
-		matchURL, path, ok := dockerRegistryCredentialLocation(matchLocation)
+		proxyOnly := cred.GetBool("proxy-only")
+		matchURL, path, ok := dockerRegistryCredentialLocation(matchLocation, proxyOnly)
 		if !ok {
 			continue
 		}
 
-		proxyOnly := cred.GetBool("proxy-only")
 		if !proxyOnly {
 			// OIDC credentials are not used as static credentials.
 			oidcMatchingCred, urlFields := dockerOIDCMatchingCredential(cred, matchField, matchURL)
@@ -296,7 +296,7 @@ func dockerOriginsEqual(a, b *url.URL) bool {
 		helpers.AreHostnamesEqual(a.Hostname(), b.Hostname())
 }
 
-func dockerRegistryCredentialLocation(location string) (matchURL, path string, ok bool) {
+func dockerRegistryCredentialLocation(location string, proxyOnly bool) (matchURL, path string, ok bool) {
 	parsed, err := helpers.ParseURLLax(location)
 	if err != nil || parsed.Host == "" {
 		return "", "", false
@@ -304,7 +304,12 @@ func dockerRegistryCredentialLocation(location string) (matchURL, path string, o
 
 	path = strings.TrimRight(parsed.EscapedPath(), "/")
 	if path == "" {
-		return location, "", true
+		if !proxyOnly {
+			return location, "", true
+		}
+		parsed.Path = "/v2"
+		parsed.RawPath = ""
+		return parsed.String(), "/v2", true
 	}
 	canonicalPath, ok := helpers.CanonicalPath(path)
 	if !ok {

--- a/internal/handlers/docker_registry.go
+++ b/internal/handlers/docker_registry.go
@@ -306,7 +306,11 @@ func dockerRegistryCredentialLocation(location string) (matchURL, path string, o
 	if path == "" {
 		return location, "", true
 	}
-	if path != "/v2" && !strings.HasPrefix(path, "/v2/") {
+	canonicalPath, ok := helpers.CanonicalPath(path)
+	if !ok {
+		return "", "", false
+	}
+	if canonicalPath != "/v2" && !strings.HasPrefix(canonicalPath, "/v2/") {
 		parsed.Path = "/v2" + strings.TrimRight(parsed.Path, "/")
 		if parsed.RawPath != "" {
 			parsed.RawPath = "/v2" + path

--- a/internal/handlers/docker_registry_test.go
+++ b/internal/handlers/docker_registry_test.go
@@ -249,6 +249,20 @@ func TestDockerRegistryHandlerProxyOnlyCredentials(t *testing.T) {
 	proxyCtx = &goproxy.ProxyCtx{}
 	handleRequestAndClose(handler, req, proxyCtx)
 	assert.Nil(t, proxyCtx.RoundTripper, "host mismatch does not configure challenge transport")
+
+	nonDefaultPortHandler := NewDockerRegistryHandler(config.Credentials{
+		{
+			"type":       "docker_registry",
+			"registry":   "https://ghcr.io:8443",
+			"username":   "x-access-token",
+			"password":   "automatic-token",
+			"proxy-only": true,
+		},
+	}, client, nil)
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://ghcr.io:8443/v2/other/image/manifests/latest", nil)
+	proxyCtx = &goproxy.ProxyCtx{}
+	handleRequestAndClose(nonDefaultPortHandler, req, proxyCtx)
+	assert.Nil(t, proxyCtx.RoundTripper, "automatic credential does not authenticate a non-default port")
 }
 
 func TestDockerRegistryHandlerOIDCRepositoryScope(t *testing.T) {

--- a/internal/handlers/docker_registry_test.go
+++ b/internal/handlers/docker_registry_test.go
@@ -344,6 +344,26 @@ func TestDockerRegistryHandlerURLCredentialUsesMatchedRequestOrigin(t *testing.T
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
 	assertHasBasicAuth(t, req, "user", "password", "transport authenticates the matched request form")
+
+	encodedV2Handler := NewDockerRegistryHandler(config.Credentials{
+		{
+			"type":     "docker_registry",
+			"url":      "https://example.com/%76%32/dependabot/core",
+			"username": "encoded-user",
+			"password": "encoded-password",
+		},
+	}, client, nil)
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet,
+		"https://example.com/v2/dependabot/core/manifests/latest", nil)
+	proxyCtx = &goproxy.ProxyCtx{}
+	handleRequestAndClose(encodedV2Handler, req, proxyCtx)
+
+	rt, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
+	require.True(t, ok, "canonically encoded /v2 prefix is not rewritten")
+	transport = rt.transport.(*registry.BasicTransport)
+	assert.Equal(t, "encoded-user", transport.Username)
+	assert.Equal(t, "encoded-password", transport.Password)
+	assert.Equal(t, "https://example.com/v2/dependabot/core", transport.URL)
 }
 
 func TestDockerRegistryHandlerRejectsConflictingCredentialLocations(t *testing.T) {

--- a/internal/handlers/docker_registry_test.go
+++ b/internal/handlers/docker_registry_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/elazarl/goproxy"
+	"github.com/jarcoal/httpmock"
 	"github.com/stackrox/docker-registry-client/registry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -57,7 +58,7 @@ func TestDockerRegistryHandler(t *testing.T) {
 		},
 		config.Credential{
 			"type":     "docker_registry",
-			"url":      "https://example.com:443/reg-path",
+			"url":      "https://example.com:443/dependabot/core",
 			"username": hubUser,
 			"password": hubPassword,
 		},
@@ -76,7 +77,7 @@ func TestDockerRegistryHandler(t *testing.T) {
 	handler := NewDockerRegistryHandler(credentials, httpClient, getECRClient)
 
 	// Regular private registry
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.hub.docker.com/my-repo", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.hub.docker.com/v2/my-repo/manifests/latest", nil)
 	proxyCtx := &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	rt, ok := proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
@@ -86,7 +87,7 @@ func TestDockerRegistryHandler(t *testing.T) {
 	assert.Equal(t, hubPassword, trans.Password, "correct password is set")
 
 	// Registry using URL not registry key
-	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.hub.docker.com/my-repo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://example.com/v2/dependabot/core/manifests/latest", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	rt, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
@@ -94,9 +95,21 @@ func TestDockerRegistryHandler(t *testing.T) {
 	trans = rt.transport.(*registry.BasicTransport)
 	assert.Equal(t, hubUser, trans.Username, "correct username is set")
 	assert.Equal(t, hubPassword, trans.Password, "correct password is set")
+	assert.Equal(t, "https://example.com/v2/dependabot/core", trans.URL, "URL credential keeps its matched path scope")
+
+	for _, requestURL := range []string{
+		"https://example.com:443/v2/dependabot/core-attacker/manifests/latest",
+		"https://example.com/v2/dependabot%2Fcore/manifests/latest",
+		"https://example.com/v2/dependabot/core/%2e%2e%2fattacker/manifests/latest",
+	} {
+		req = httptest.NewRequestWithContext(t.Context(), "GET", requestURL, nil)
+		proxyCtx = &goproxy.ProxyCtx{}
+		_ = handleRequestAndClose(handler, req, proxyCtx)
+		assert.Nil(t, proxyCtx.RoundTripper, "URL credential path scope")
+	}
 
 	// Different private registry
-	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://docker.bigco.com/their-repo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://docker.bigco.com/v2/their-repo/manifests/latest", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	rt, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
@@ -137,28 +150,28 @@ func TestDockerRegistryHandler(t *testing.T) {
 	assertUnauthenticated(t, req, "leaked ecr credentials")
 
 	// Missing repo subdomain
-	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://bigco.com/their-repo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://bigco.com/v2/their-repo/manifests/latest", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	_, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
 	assert.False(t, ok, "different subdomain request isn't assigned a docker registry transport")
 
 	// HTTP, not HTTPS
-	req = httptest.NewRequestWithContext(t.Context(), "GET", "http://docker.bigco.com/their-repo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "http://docker.bigco.com/v2/their-repo/manifests/latest", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	_, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
 	assert.False(t, ok, "request isn't assigned a docker registry transport")
 
 	// Not a GET request
-	req = httptest.NewRequestWithContext(t.Context(), "POST", "https://docker.bigco.com/their-repo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "POST", "https://docker.bigco.com/v2/their-repo/manifests/latest", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	_, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
 	assert.False(t, ok, "request isn't assigned a docker registry transport")
 
 	// Nexus, BasicAuth
-	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://nexus.someco.com/a-repo", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://nexus.someco.com/v2/a-repo/manifests/latest", nil)
 	proxyCtx = &goproxy.ProxyCtx{}
 	_ = handleRequestAndClose(handler, req, proxyCtx)
 	rt, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
@@ -167,6 +180,204 @@ func TestDockerRegistryHandler(t *testing.T) {
 	assert.Equal(t, hubUser, trans.Username, "correct username is set")
 	assert.Equal(t, hubPassword, trans.Password, "correct password is set")
 	assert.Equal(t, "https://nexus.someco.com", trans.URL, "correct URL is set")
+}
+
+func TestDockerRegistryHandlerProxyOnlyCredentials(t *testing.T) {
+	transport := &recordingECRTransport{}
+	client := &http.Client{Transport: transport, Timeout: testOIDCClient.Timeout}
+	handler := NewDockerRegistryHandler(config.Credentials{
+		{
+			"type":       "docker_registry",
+			"registry":   "ghcr.io",
+			"username":   "x-access-token",
+			"password":   "automatic-token",
+			"proxy-only": true,
+		},
+		{
+			"type":     "docker_registry",
+			"registry": "ghcr.io",
+			"url":      "https://ghcr.io/dependabot/core",
+			"username": "explicit-user",
+			"password": "explicit-token",
+		},
+	}, client, nil)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://ghcr.io/v2/other/image/manifests/latest", nil)
+	proxyCtx := &goproxy.ProxyCtx{}
+	handleRequestAndClose(handler, req, proxyCtx)
+	rt, ok := proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
+	require.True(t, ok, "automatic credential configures challenge transport")
+	trans := rt.transport.(*registry.BasicTransport)
+	assert.Equal(t, "x-access-token", trans.Username)
+	assert.Equal(t, "automatic-token", trans.Password)
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://ghcr.io/v2/other/image/manifests/latest", nil)
+	req.SetBasicAuth(authorizationPlaceholder, "placeholder-password")
+	proxyCtx = &goproxy.ProxyCtx{}
+	handleRequestAndClose(handler, req, proxyCtx)
+	require.NotNil(t, proxyCtx.RoundTripper)
+	resp, err := proxyCtx.RoundTripper.RoundTrip(req, proxyCtx)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assertHasBasicAuth(t, req, "x-access-token", "automatic-token", "challenge transport replaces placeholder auth")
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://ghcr.io/v2/other/image/manifests/latest", nil)
+	req.SetBasicAuth("caller", "caller-token")
+	proxyCtx = &goproxy.ProxyCtx{}
+	req = handleRequestAndClose(handler, req, proxyCtx)
+	assertHasBasicAuth(t, req, "caller", "caller-token", "automatic credential preserves genuine auth")
+	assert.Nil(t, proxyCtx.RoundTripper)
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://ghcr.io/v2/dependabot/core/manifests/latest", nil)
+	proxyCtx = &goproxy.ProxyCtx{}
+	handleRequestAndClose(handler, req, proxyCtx)
+	rt, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
+	require.True(t, ok, "explicit credential configures challenge transport")
+	trans = rt.transport.(*registry.BasicTransport)
+	assert.Equal(t, "explicit-user", trans.Username)
+	assert.Equal(t, "explicit-token", trans.Password)
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://ghcr.io/v2/dependabot/core-attacker/manifests/latest", nil)
+	proxyCtx = &goproxy.ProxyCtx{}
+	handleRequestAndClose(handler, req, proxyCtx)
+	rt, ok = proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
+	require.True(t, ok, "sibling path uses host-wide automatic transport")
+	trans = rt.transport.(*registry.BasicTransport)
+	assert.Equal(t, "x-access-token", trans.Username)
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://ghcr.example/v2/other/image/manifests/latest", nil)
+	proxyCtx = &goproxy.ProxyCtx{}
+	handleRequestAndClose(handler, req, proxyCtx)
+	assert.Nil(t, proxyCtx.RoundTripper, "host mismatch does not configure challenge transport")
+}
+
+func TestDockerRegistryHandlerOIDCRepositoryScope(t *testing.T) {
+	const tokenURL = "https://token.actions.example.com" //nolint:gosec // test URL
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", tokenURL)
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "request-token")
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder(http.MethodGet, tokenURL,
+		httpmock.NewStringResponder(http.StatusOK, `{"count":1,"value":"github-token"}`))
+	httpmock.RegisterResponder(
+		http.MethodPost,
+		"https://login.microsoftonline.com/docker-tenant/oauth2/v2.0/token",
+		httpmock.NewStringResponder(
+			http.StatusOK,
+			`{"access_token":"oidc-token","expires_in":3600,"token_type":"Bearer"}`,
+		),
+	)
+
+	handler := NewDockerRegistryHandler(config.Credentials{
+		{
+			"type":       "docker_registry",
+			"registry":   "ghcr.io",
+			"username":   "x-access-token",
+			"password":   "automatic-token",
+			"proxy-only": true,
+		},
+		{
+			"type":      "docker_registry",
+			"registry":  "ghcr.io",
+			"url":       "https://ghcr.io/dependabot/core",
+			"tenant-id": "docker-tenant",
+			"client-id": "docker-client",
+		},
+	}, testOIDCClient, nil)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet,
+		"https://ghcr.io/v2/dependabot/core/manifests/latest", nil)
+	req = handleRequestAndClose(handler, req, &goproxy.ProxyCtx{})
+	assertHasTokenAuth(t, req, "Bearer", "oidc-token", "repository-scoped OIDC credential")
+
+	for _, requestURL := range []string{
+		"https://ghcr.io/v2/other/image/blobs/sha256:abc",
+		"https://ghcr.io/v2/dependabot/core-attacker/manifests/latest",
+	} {
+		req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, requestURL, nil)
+		proxyCtx := &goproxy.ProxyCtx{}
+		handleRequestAndClose(handler, req, proxyCtx)
+		rt, ok := proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
+		require.True(t, ok, "other repositories use host-wide fallback")
+		transport := rt.transport.(*registry.BasicTransport)
+		assert.Equal(t, "x-access-token", transport.Username)
+		assert.Equal(t, "automatic-token", transport.Password)
+	}
+}
+
+func TestDockerRegistryHandlerURLCredentialUsesMatchedRequestOrigin(t *testing.T) {
+	client := &http.Client{Transport: &recordingECRTransport{}, Timeout: testOIDCClient.Timeout}
+	handler := NewDockerRegistryHandler(config.Credentials{
+		{
+			"type":     "docker_registry",
+			"url":      "https://example.com/dependabot/core/",
+			"username": "user",
+			"password": "password",
+		},
+	}, client, nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet,
+		"https://EXAMPLE.com:443/v2/dependabot/core/blobs/sha256:abc", nil)
+	proxyCtx := &goproxy.ProxyCtx{}
+	handleRequestAndClose(handler, req, proxyCtx)
+
+	rt, ok := proxyCtx.RoundTripper.(*dockerRegistryRoundTripper)
+	require.True(t, ok)
+	transport := rt.transport.(*registry.BasicTransport)
+	assert.Equal(t, "https://EXAMPLE.com:443/v2/dependabot/core", transport.URL)
+
+	resp, err := proxyCtx.RoundTripper.RoundTrip(req, proxyCtx)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assertHasBasicAuth(t, req, "user", "password", "transport authenticates the matched request form")
+}
+
+func TestDockerRegistryHandlerRejectsConflictingCredentialLocations(t *testing.T) {
+	tests := []struct {
+		name     string
+		registry string
+		url      string
+		request  string
+	}{
+		{
+			name:     "different origins",
+			registry: "ghcr.io",
+			url:      "https://attacker.example.com/dependabot/core",
+			request:  "https://ghcr.io/v2/other/image/manifests/latest",
+		},
+		{
+			name:     "sibling paths",
+			registry: "https://ghcr.io/team-a",
+			url:      "https://ghcr.io/team-b/core",
+			request:  "https://ghcr.io/v2/team-a/manifests/latest",
+		},
+		{
+			name:     "invalid URL",
+			registry: "ghcr.io",
+			url:      "https://ghcr.io/%zz",
+			request:  "https://ghcr.io/v2/other/image/manifests/latest",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler := NewDockerRegistryHandler(config.Credentials{
+				{
+					"type":     "docker_registry",
+					"registry": test.registry,
+					"url":      test.url,
+					"username": "user",
+					"password": "password",
+				},
+			}, testOIDCClient, nil)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, test.request, nil)
+			proxyCtx := &goproxy.ProxyCtx{}
+			handleRequestAndClose(handler, req, proxyCtx)
+
+			assert.Nil(t, proxyCtx.RoundTripper, "conflicting credential is skipped")
+			assertUnauthenticated(t, req, "conflicting credential is skipped")
+		})
+	}
 }
 
 //nolint:gosec // The test credentials are intentionally fake fixtures.

--- a/internal/handlers/docker_registry_test.go
+++ b/internal/handlers/docker_registry_test.go
@@ -210,6 +210,14 @@ func TestDockerRegistryHandlerProxyOnlyCredentials(t *testing.T) {
 	trans := rt.transport.(*registry.BasicTransport)
 	assert.Equal(t, "x-access-token", trans.Username)
 	assert.Equal(t, "automatic-token", trans.Password)
+	assert.Equal(t, "https://ghcr.io/v2", trans.URL)
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet,
+		"https://ghcr.io/token?service=ghcr.io&scope=repository:private/package:pull", nil)
+	proxyCtx = &goproxy.ProxyCtx{}
+	req = handleRequestAndClose(handler, req, proxyCtx)
+	assert.Nil(t, proxyCtx.RoundTripper, "automatic credential is not applied directly to the token endpoint")
+	assertUnauthenticated(t, req, "automatic credential is not applied directly to the token endpoint")
 
 	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://ghcr.io/v2/other/image/manifests/latest", nil)
 	req.SetBasicAuth(authorizationPlaceholder, "placeholder-password")
@@ -263,6 +271,36 @@ func TestDockerRegistryHandlerProxyOnlyCredentials(t *testing.T) {
 	proxyCtx = &goproxy.ProxyCtx{}
 	handleRequestAndClose(nonDefaultPortHandler, req, proxyCtx)
 	assert.Nil(t, proxyCtx.RoundTripper, "automatic credential does not authenticate a non-default port")
+}
+
+func TestDockerRegistryHandlerProxyOnlyCredentialCompletesTokenChallenge(t *testing.T) {
+	transport := &dockerChallengeTransport{t: t}
+	client := &http.Client{Transport: transport, Timeout: testOIDCClient.Timeout}
+	handler := NewDockerRegistryHandler(config.Credentials{
+		{
+			"type":       "docker_registry",
+			"registry":   "ghcr.io",
+			"username":   "x-access-token",
+			"password":   "automatic-token",
+			"proxy-only": true,
+		},
+	}, client, nil)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet,
+		"https://ghcr.io/v2/private/package/manifests/latest", nil)
+	proxyCtx := &goproxy.ProxyCtx{}
+	handleRequestAndClose(handler, req, proxyCtx)
+
+	require.NotNil(t, proxyCtx.RoundTripper)
+	resp, err := proxyCtx.RoundTripper.RoundTrip(req, proxyCtx)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, []string{
+		"/v2/private/package/manifests/latest",
+		"/token",
+		"/v2/private/package/manifests/latest",
+	}, transport.paths)
 }
 
 func TestDockerRegistryHandlerOIDCRepositoryScope(t *testing.T) {
@@ -441,6 +479,58 @@ func (t *recordingECRTransport) RoundTrip(req *http.Request) (*http.Response, er
 		Header:     make(http.Header),
 		Request:    req,
 	}, nil
+}
+
+type dockerChallengeTransport struct {
+	t     *testing.T
+	paths []string
+}
+
+func (t *dockerChallengeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.paths = append(t.paths, req.URL.Path)
+	const bearerScheme = "Bearer"
+
+	switch req.URL.Path {
+	case "/token":
+		username, password, ok := req.BasicAuth()
+		require.True(t.t, ok)
+		assert.Equal(t.t, "x-access-token", username)
+		assert.Equal(t.t, "automatic-token", password)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"token":"scoped-token"}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	case "/v2/private/package/manifests/latest":
+		if req.Header.Get("Authorization") == bearerScheme+" scoped-token" {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}
+
+		username, password, ok := req.BasicAuth()
+		require.True(t.t, ok)
+		assert.Equal(t.t, "x-access-token", username)
+		assert.Equal(t.t, "automatic-token", password)
+		header := make(http.Header)
+		header.Set(
+			"WWW-Authenticate",
+			bearerScheme+` realm="https://ghcr.io/token",service="ghcr.io",scope="repository:private/package:pull"`,
+		)
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Body:       http.NoBody,
+			Header:     header,
+			Request:    req,
+		}, nil
+	default:
+		t.t.Fatalf("unexpected request path: %s", req.URL.Path)
+		return nil, nil
+	}
 }
 
 type mockECRClient struct {

--- a/internal/handlers/maven_repository.go
+++ b/internal/handlers/maven_repository.go
@@ -18,10 +18,11 @@ type MavenRepositoryHandler struct {
 }
 
 type mavenRepositoryCredentials struct {
-	url      string
-	host     string
-	username string
-	password string
+	url       string
+	host      string
+	username  string
+	password  string
+	proxyOnly bool
 }
 
 // NewMavenRepositoryHandler returns a new MavenRepositoryHandler.
@@ -38,9 +39,12 @@ func NewMavenRepositoryHandler(creds config.Credentials, client *http.Client) *M
 
 		url := cred.GetString("url")
 
-		// OIDC credentials are not used as static credentials.
-		if oidcCred, _, _ := handler.oidcRegistry.Register(cred, []string{"url"}, "maven repository"); oidcCred != nil {
-			continue
+		proxyOnly := cred.GetBool("proxy-only")
+		if !proxyOnly {
+			// OIDC credentials are not used as static credentials.
+			if oidcCred, _, _ := handler.oidcRegistry.Register(cred, []string{"url"}, "maven repository"); oidcCred != nil {
+				continue
+			}
 		}
 
 		username := cred.GetString("username")
@@ -50,10 +54,11 @@ func NewMavenRepositoryHandler(creds config.Credentials, client *http.Client) *M
 		}
 
 		repoCred := mavenRepositoryCredentials{
-			url:      url,
-			host:     cred.GetString("host"),
-			username: username,
-			password: password,
+			url:       url,
+			host:      cred.GetString("host"),
+			username:  username,
+			password:  password,
+			proxyOnly: proxyOnly,
 		}
 		handler.credentials = append(handler.credentials, repoCred)
 	}
@@ -67,22 +72,52 @@ func (h *MavenRepositoryHandler) HandleRequest(req *http.Request, proxyCtx *gopr
 		return req, nil
 	}
 
-	// Try OIDC credentials first
-	if h.oidcRegistry.TryAuth(req, proxyCtx) {
+	var oidcCredential *oidc.OIDCCredential
+	if req.URL.Scheme == "https" {
+		oidcCredential = h.oidcRegistry.CredentialForRequest(req)
+		if h.oidcRegistry.TryAuthCredential(req, proxyCtx, oidcCredential) {
+			return req, nil
+		}
+	}
+	if h.authenticateStaticCredential(req, proxyCtx, false) {
 		return req, nil
 	}
+	if hasUsableAuthorization(req) {
+		return req, nil
+	}
+	if oidcCredential != nil {
+		return req, nil
+	}
+	if !proxyOnlyCredentialRequestAllowed(req) {
+		return req, nil
+	}
+	h.authenticateStaticCredential(req, proxyCtx, true)
 
-	// Fall back to static credentials
+	return req, nil
+}
+
+func (h *MavenRepositoryHandler) authenticateStaticCredential(
+	req *http.Request,
+	proxyCtx *goproxy.ProxyCtx,
+	proxyOnly bool,
+) bool {
+	if proxyOnly && !proxyOnlyCredentialRequestAllowed(req) {
+		return false
+	}
+
 	for _, cred := range h.credentials {
-		if !helpers.UrlMatchesRequest(req, cred.url, true) && !helpers.CheckHost(req, cred.host) {
+		if cred.proxyOnly != proxyOnly {
+			continue
+		}
+		if !helpers.CredentialURLMatchesRequest(req, cred.url, true) &&
+			!helpers.CheckHost(req, cred.host) {
 			continue
 		}
 
 		logging.RequestLogf(proxyCtx, "* authenticating maven repository request (host: %s)", req.URL.Hostname())
 		helpers.SetBasicAuthorization(req, cred.username, cred.password)
-
-		return req, nil
+		return true
 	}
 
-	return req, nil
+	return false
 }

--- a/internal/handlers/maven_repository_test.go
+++ b/internal/handlers/maven_repository_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dependabot/proxy/internal/config"
 )
 
@@ -85,4 +87,57 @@ func TestMavenRepositoryHandler(t *testing.T) {
 	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://PKGS.dev.azure.com/somepkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, deltaForceUser, deltaForcePassword, "azure devops case insensitive registry request")
+}
+
+func TestMavenRepositoryHandlerProxyOnlyCredentials(t *testing.T) {
+	handler := NewMavenRepositoryHandler(config.Credentials{
+		{
+			"type":       "maven_repository",
+			"host":       "maven.pkg.github.com",
+			"username":   "x-access-token",
+			"password":   "automatic-token",
+			"proxy-only": true,
+		},
+		{
+			"type":     "maven_repository",
+			"url":      "https://maven.pkg.github.com/dependabot/core",
+			"username": "explicit-user",
+			"password": "explicit-token",
+		},
+	}, testOIDCClient)
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://maven.pkg.github.com/other/package.jar", nil)
+	req = handleRequestAndClose(handler, req, nil)
+	assertHasBasicAuth(t, req, "x-access-token", "automatic-token", "host-only automatic credential")
+
+	for _, requestURL := range []string{
+		"http://maven.pkg.github.com/other/package.jar",
+		"https://maven.pkg.github.com:8443/other/package.jar",
+	} {
+		req = httptest.NewRequestWithContext(t.Context(), "GET", requestURL, nil)
+		req = handleRequestAndClose(handler, req, nil)
+		assertUnauthenticated(t, req, "automatic credential destination safety")
+	}
+
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://maven.pkg.github.com/other/package.jar", nil)
+	req.Header.Set("Authorization", authorizationPlaceholder)
+	req = handleRequestAndClose(handler, req, nil)
+	assertHasBasicAuth(t, req, "x-access-token", "automatic-token", "automatic credential replaces placeholder auth")
+
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://maven.pkg.github.com/other/package.jar", nil)
+	req.Header.Set("Authorization", "Bearer caller-token")
+	req = handleRequestAndClose(handler, req, nil)
+	assert.Equal(t, "Bearer caller-token", req.Header.Get("Authorization"), "automatic credential preserves request auth")
+
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://maven.pkg.github.com/dependabot/core/package.jar", nil)
+	req = handleRequestAndClose(handler, req, nil)
+	assertHasBasicAuth(t, req, "explicit-user", "explicit-token", "path-specific explicit credential")
+
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://maven.pkg.github.com/dependabot-attacker/package.jar", nil)
+	req = handleRequestAndClose(handler, req, nil)
+	assertHasBasicAuth(t, req, "x-access-token", "automatic-token", "sibling path uses automatic credential")
+
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://maven.pkg.github.example/other/package.jar", nil)
+	req = handleRequestAndClose(handler, req, nil)
+	assertUnauthenticated(t, req, "automatic credential host mismatch")
 }

--- a/internal/handlers/npm_registry.go
+++ b/internal/handlers/npm_registry.go
@@ -20,11 +20,12 @@ type NPMRegistryHandler struct {
 }
 
 type npmRegistryCredentials struct {
-	registry string
-	token    string
-	host     string
-	username string
-	password string
+	registry  string
+	token     string
+	host      string
+	username  string
+	password  string
+	proxyOnly bool
 }
 
 // NewNPMRegistryHandler returns a new NPMRegistryHandler,
@@ -40,18 +41,28 @@ func NewNPMRegistryHandler(creds config.Credentials, client *http.Client) *NPMRe
 		}
 
 		registry := cred.GetString("registry")
+		if registry == "" {
+			registry = cred.GetString("url")
+		}
 
-		// OIDC credentials are not used as static credentials.
-		if oidcCred, _, _ := handler.oidcRegistry.Register(cred, []string{"registry", "url"}, "npm registry"); oidcCred != nil {
+		proxyOnly := cred.GetBool("proxy-only")
+		if !proxyOnly {
+			// OIDC credentials are not used as static credentials.
+			if oidcCred, _, _ := handler.oidcRegistry.Register(cred, []string{"registry", "url"}, "npm registry"); oidcCred != nil {
+				continue
+			}
+		}
+		if proxyOnly && cred.GetString("token") == "" && cred.GetString("password") == "" {
 			continue
 		}
 
 		npmCred := npmRegistryCredentials{
-			registry: registry,
-			token:    cred.GetString("token"),
-			host:     cred.Host(),
-			username: cred.GetString("username"),
-			password: cred.GetString("password"),
+			registry:  registry,
+			token:     cred.GetString("token"),
+			host:      cred.Host(),
+			username:  cred.GetString("username"),
+			password:  cred.GetString("password"),
+			proxyOnly: proxyOnly,
 		}
 		handler.credentials = append(handler.credentials, npmCred)
 	}
@@ -65,47 +76,37 @@ func (h *NPMRegistryHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.
 		return req, nil
 	}
 
-	reqHost := helpers.GetHost(req)
-	reqPort := req.URL.Port()
-	if reqPort == "" {
-		reqPort = "443"
-	}
-
-	// Try OIDC credentials first
-	if h.oidcRegistry.TryAuth(req, proxyCtx) {
+	oidcCredential := h.oidcRegistry.CredentialForRequest(req)
+	if h.oidcRegistry.TryAuthCredential(req, proxyCtx, oidcCredential) {
 		return req, nil
 	}
+	if h.authenticateStaticCredential(req, proxyCtx, false) {
+		return req, nil
+	}
+	if hasUsableAuthorization(req) {
+		return req, nil
+	}
+	if oidcCredential != nil {
+		return req, nil
+	}
+	if !proxyOnlyCredentialRequestAllowed(req) {
+		return req, nil
+	}
+	h.authenticateStaticCredential(req, proxyCtx, true)
 
-	// Fall back to static credentials
+	return req, nil
+}
+
+func (h *NPMRegistryHandler) authenticateStaticCredential(
+	req *http.Request,
+	proxyCtx *goproxy.ProxyCtx,
+	proxyOnly bool,
+) bool {
 	for _, cred := range h.credentials {
-		regURL, err := helpers.ParseURLLax(cred.registry)
-		if err != nil {
+		if cred.proxyOnly != proxyOnly {
 			continue
 		}
-
-		host := cred.host
-		if host == "" {
-			host = regURL.Hostname()
-		}
-
-		if !npmRegistryHostMatches(host, reqHost) {
-			continue
-		}
-
-		regPort := regURL.Port()
-		if regPort == "" {
-			regPort = "443"
-		}
-
-		if regPort != reqPort {
-			continue
-		}
-
-		// Path-segment-aware matching prevents credentials configured for one
-		// path-scoped registry from being applied to sibling paths on the same
-		// host (e.g., /team-a-npm should not match /team-b-npm).
-		regPath := strings.TrimSuffix(regURL.Path, "/")
-		if regPath != "" && !strings.HasPrefix(req.URL.Path, regPath+"/") && req.URL.Path != regPath {
+		if !npmCredentialMatchesRequest(req, cred) {
 			continue
 		}
 
@@ -115,16 +116,42 @@ func (h *NPMRegistryHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.
 
 		username, password, found := strings.Cut(cred.token, ":")
 		if found {
-			logging.RequestLogf(proxyCtx, "* authenticating npm registry request (host: %s, basic auth)", reqHost)
+			logging.RequestLogf(proxyCtx, "* authenticating npm registry request (host: %s, basic auth)", helpers.GetHost(req))
 			helpers.SetBasicAuthorization(req, username, password)
 		} else {
-			logging.RequestLogf(proxyCtx, "* authenticating npm registry request (host: %s, token auth)", reqHost)
+			logging.RequestLogf(proxyCtx, "* authenticating npm registry request (host: %s, token auth)", helpers.GetHost(req))
 			helpers.SetBearerAuthorization(req, cred.token)
 		}
-		return req, nil
+		return true
 	}
 
-	return req, nil
+	return false
+}
+
+func npmCredentialMatchesRequest(req *http.Request, cred npmRegistryCredentials) bool {
+	matchURL := cred.registry
+	if matchURL == "" {
+		matchURL = cred.host
+	}
+	if helpers.CredentialURLMatchesRequest(req, matchURL, true) {
+		return true
+	}
+
+	regURL, err := helpers.ParseURLLax(matchURL)
+	if err != nil || helpers.AreHostnamesEqual(regURL.Hostname(), req.URL.Hostname()) ||
+		!npmRegistryHostMatches(regURL.Hostname(), req.URL.Hostname()) {
+		return false
+	}
+
+	regPort := regURL.Port()
+	if regPort == "" {
+		regPort = "443"
+	}
+	reqPort := req.URL.Port()
+	if reqPort == "" {
+		reqPort = "443"
+	}
+	return regPort == reqPort && helpers.PathMatches(req.URL.EscapedPath(), regURL.EscapedPath())
 }
 
 func npmRegistryHostMatches(regHost, reqHost string) bool {

--- a/internal/handlers/npm_registry.go
+++ b/internal/handlers/npm_registry.go
@@ -166,7 +166,8 @@ func npmRegistryHostMatches(regHost, reqHost string) bool {
 	// We could use areHostnamesEqual here, but that likely isn't necessary
 	// because it was added to better support private registries with custom
 	// domains.
-	if regHost == "registry.npmjs.org" && reqHost == "registry.yarnpkg.com" {
+	if strings.EqualFold(regHost, "registry.npmjs.org") &&
+		strings.EqualFold(reqHost, "registry.yarnpkg.com") {
 		return true
 	}
 

--- a/internal/handlers/npm_registry_test.go
+++ b/internal/handlers/npm_registry_test.go
@@ -18,7 +18,7 @@ func TestNPMRegistryHandler(t *testing.T) {
 	credentials := config.Credentials{
 		config.Credential{
 			"type":     "npm_registry",
-			"registry": "https://registry.npmjs.org",
+			"registry": "https://Registry.Npmjs.Org",
 			"token":    npmjsOrgToken,
 		},
 		config.Credential{

--- a/internal/handlers/npm_registry_test.go
+++ b/internal/handlers/npm_registry_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dependabot/proxy/internal/config"
 )
 
@@ -58,6 +60,10 @@ func TestNPMRegistryHandler(t *testing.T) {
 	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://example.org/reg-path/private-package", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", privateRegToken, "valid registry request with port and path")
+
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://example.org/reg-path-attacker/private-package", nil)
+	req = handleRequestAndClose(handler, req, nil)
+	assertUnauthenticated(t, req, "URL-only registry sibling path")
 
 	// Sibling path on the same host should NOT receive credentials from /reg-path
 	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://example.com/other-path/private-package", nil)
@@ -120,4 +126,46 @@ func TestNPMRegistryHandler_SameHostDifferentPaths(t *testing.T) {
 	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://artifactory.example.com/api/npm/team-c-npm/@scope/pkg", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "unrelated path should not match any credential")
+}
+
+func TestNPMRegistryHandlerProxyOnlyCredentials(t *testing.T) {
+	handler := NewNPMRegistryHandler(config.Credentials{
+		config.Credential{
+			"type":       "npm_registry",
+			"registry":   "https://npm.pkg.github.com",
+			"token":      "x-access-token:automatic-token",
+			"proxy-only": true,
+		},
+		config.Credential{
+			"type":     "npm_registry",
+			"registry": "https://npm.pkg.github.com/dependabot",
+			"token":    "explicit-token",
+		},
+	}, testOIDCClient)
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://npm.pkg.github.com/other/package", nil)
+	req = handleRequestAndClose(handler, req, nil)
+	assertHasBasicAuth(t, req, "x-access-token", "automatic-token", "host-only automatic credential")
+
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://npm.pkg.github.com/other/package", nil)
+	req.Header.Set("Authorization", authorizationPlaceholder)
+	req = handleRequestAndClose(handler, req, nil)
+	assertHasBasicAuth(t, req, "x-access-token", "automatic-token", "automatic credential replaces placeholder auth")
+
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://npm.pkg.github.com/other/package", nil)
+	req.Header.Set("Authorization", "Bearer request-token")
+	req = handleRequestAndClose(handler, req, nil)
+	assert.Equal(t, "Bearer request-token", req.Header.Get("Authorization"), "automatic credential preserves request auth")
+
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://npm.pkg.github.com/dependabot/package", nil)
+	req = handleRequestAndClose(handler, req, nil)
+	assertHasTokenAuth(t, req, "Bearer", "explicit-token", "path-specific explicit credential")
+
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://npm.pkg.github.com/dependabot-attacker/package", nil)
+	req = handleRequestAndClose(handler, req, nil)
+	assertHasBasicAuth(t, req, "x-access-token", "automatic-token", "sibling path uses host-wide automatic credential")
+
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://npm.pkg.github.example/other/package", nil)
+	req = handleRequestAndClose(handler, req, nil)
+	assertUnauthenticated(t, req, "automatic credential host mismatch")
 }

--- a/internal/handlers/nuget_feed.go
+++ b/internal/handlers/nuget_feed.go
@@ -47,11 +47,12 @@ type NugetFeedHandler struct {
 }
 
 type nugetFeedCredentials struct {
-	url      string
-	host     string
-	token    string
-	username string
-	password string
+	url       string
+	host      string
+	token     string
+	username  string
+	password  string
+	proxyOnly bool
 }
 
 type nugetDiscoveryAuth struct {
@@ -82,31 +83,41 @@ func NewNugetFeedHandler(creds config.Credentials, client *http.Client) *NugetFe
 		username := cred.GetString("username")
 		password := cred.GetString("password")
 
-		oidcCredential, _, ok := handler.oidcRegistry.Register(cred, []string{"url"}, "nuget feed")
-		if ok {
-			if url != "" {
-				handler.addDiscoverySource(nugetDiscoveryAuth{
-					serviceIndexURL:      url,
-					oidc:                 oidcCredential,
-					registerRedirectAuth: true,
-				})
+		proxyOnly := cred.GetBool("proxy-only")
+		if proxyOnly {
+			if host == "" {
+				continue
 			}
-			continue
+			url = ""
 		}
-		// OIDC credentials are not used as static credentials.
-		if oidcCredential != nil {
-			continue
+		if !proxyOnly {
+			oidcCredential, _, ok := handler.oidcRegistry.Register(cred, []string{"url"}, "nuget feed")
+			if ok {
+				if url != "" {
+					handler.addDiscoverySource(nugetDiscoveryAuth{
+						serviceIndexURL:      url,
+						oidc:                 oidcCredential,
+						registerRedirectAuth: true,
+					})
+				}
+				continue
+			}
+			// OIDC credentials are not used as static credentials.
+			if oidcCredential != nil {
+				continue
+			}
 		}
 
 		feedCred := nugetFeedCredentials{
-			url:      url,
-			host:     host,
-			token:    token,
-			username: username,
-			password: password,
+			url:       url,
+			host:      host,
+			token:     token,
+			username:  username,
+			password:  password,
+			proxyOnly: proxyOnly,
 		}
 		handler.addStaticCredential(feedCred)
-		if url != "" && (token != "" || password != "") {
+		if !proxyOnly && url != "" && (token != "" || password != "") {
 			handler.addDiscoverySource(nugetDiscoveryAuth{
 				serviceIndexURL:      url,
 				static:               feedCred,
@@ -222,43 +233,29 @@ func (h *NugetFeedHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.Pr
 		return req, nil
 	}
 
-	// Try OIDC credentials first (HTTPS only to avoid leaking tokens over plaintext)
+	var oidcCredential *oidc.OIDCCredential
 	if req.URL.Scheme == "https" {
-		oidcCredential := h.oidcRegistry.CredentialForRequest(req)
+		oidcCredential = h.oidcRegistry.CredentialForRequest(req)
 		if h.oidcRegistry.TryAuthCredential(req, proxyCtx, oidcCredential) {
 			return req, nil
 		}
 	}
 
-	// Prefer the most specific URL credential, with host-only credentials as
-	// fallback. This avoids a broad credential shadowing a narrower feed.
-	h.credentialsMutex.RLock()
-	defer h.credentialsMutex.RUnlock()
-	var urlCredential *nugetFeedCredentials
-	var hostCredential *nugetFeedCredentials
-	bestPathLength := -1
-	for i := range h.credentials {
-		cred := &h.credentials[i]
-		if cred.token == "" && cred.password == "" {
-			continue
-		}
-		if helpers.UrlMatchesRequest(req, cred.url, true) {
-			parsedURL, err := helpers.ParseURLLax(cred.url)
-			if err == nil && len(parsedURL.Path) > bestPathLength {
-				urlCredential = cred
-				bestPathLength = len(parsedURL.Path)
-			}
-		}
-		if hostCredential == nil && helpers.CheckHost(req, cred.host) {
-			hostCredential = cred
-		}
-	}
-	if urlCredential != nil {
-		authenticateNugetRequest(req, *urlCredential, proxyCtx)
+	if credential := h.staticCredentialForRequest(req, false); credential != nil {
+		authenticateNugetRequest(req, *credential, proxyCtx)
 		return req, nil
 	}
-	if hostCredential != nil {
-		authenticateNugetRequest(req, *hostCredential, proxyCtx)
+	if hasUsableAuthorization(req) {
+		return req, nil
+	}
+	if oidcCredential != nil {
+		return req, nil
+	}
+	if !proxyOnlyCredentialRequestAllowed(req) {
+		return req, nil
+	}
+	if credential := h.staticCredentialForRequest(req, true); credential != nil {
+		authenticateNugetRequest(req, *credential, proxyCtx)
 	}
 
 	return req, nil
@@ -371,6 +368,48 @@ func (h *NugetFeedHandler) addStaticCredential(credential nugetFeedCredentials) 
 	return true
 }
 
+func (h *NugetFeedHandler) staticCredentialForRequest(
+	req *http.Request,
+	proxyOnly bool,
+) *nugetFeedCredentials {
+	h.credentialsMutex.RLock()
+	defer h.credentialsMutex.RUnlock()
+
+	var urlCredential *nugetFeedCredentials
+	var hostCredential *nugetFeedCredentials
+	bestSpecificity := -1
+	for i := range h.credentials {
+		cred := &h.credentials[i]
+		if cred.proxyOnly != proxyOnly || (cred.token == "" && cred.password == "") {
+			continue
+		}
+		if !proxyOnly && helpers.CredentialURLMatchesRequest(req, cred.url, true) {
+			parsedURL, err := helpers.ParseURLLax(cred.url)
+			if err == nil {
+				path, ok := helpers.CanonicalPath(parsedURL.EscapedPath())
+				specificity := strings.Count(path, "/")
+				if ok && specificity > bestSpecificity {
+					urlCredential = cred
+					bestSpecificity = specificity
+				}
+			}
+		}
+		if hostCredential == nil && helpers.CheckHost(req, cred.host) {
+			hostCredential = cred
+		}
+	}
+
+	if urlCredential != nil {
+		credential := *urlCredential
+		return &credential
+	}
+	if hostCredential != nil {
+		credential := *hostCredential
+		return &credential
+	}
+	return nil
+}
+
 func (h *NugetFeedHandler) addDiscoverySource(source nugetDiscoveryAuth) bool {
 	h.discoveryMutex.Lock()
 	defer h.discoveryMutex.Unlock()
@@ -408,14 +447,15 @@ func isNugetServiceIndexRequest(req *http.Request, sourceURL string) bool {
 		return false
 	}
 	parsedURL, err := helpers.ParseURLLax(sourceURL)
-	if err != nil || !helpers.UrlMatchesRequest(req, sourceURL, true) {
+	if err != nil || !helpers.CredentialURLMatchesRequest(req, sourceURL, true) {
 		return false
 	}
 	if parsedURL.Scheme != "" && !strings.EqualFold(parsedURL.Scheme, req.URL.Scheme) {
 		return false
 	}
-	return strings.TrimRight(parsedURL.Path, "/") == strings.TrimRight(req.URL.Path, "/") &&
-		parsedURL.RawQuery == req.URL.RawQuery
+	sourcePath, sourceOK := helpers.CanonicalPath(parsedURL.EscapedPath())
+	requestPath, requestOK := helpers.CanonicalPath(req.URL.EscapedPath())
+	return sourceOK && requestOK && sourcePath == requestPath && parsedURL.RawQuery == req.URL.RawQuery
 }
 
 func nugetCredentialURLKey(rawURL string) string {
@@ -423,11 +463,15 @@ func nugetCredentialURLKey(rawURL string) string {
 	if err != nil {
 		return rawURL
 	}
+	path, ok := helpers.CanonicalPath(parsedURL.EscapedPath())
+	if !ok {
+		return rawURL
+	}
 	port := parsedURL.Port()
 	if port == "" {
 		port = "443"
 	}
-	return strings.ToLower(parsedURL.Hostname()) + ":" + port + strings.TrimRight(parsedURL.Path, "/") + "?" + parsedURL.RawQuery
+	return strings.ToLower(parsedURL.Hostname()) + ":" + port + path + "?" + parsedURL.RawQuery
 }
 
 // Discovery matching distinguishes explicit schemes, while static credential

--- a/internal/handlers/nuget_feed_test.go
+++ b/internal/handlers/nuget_feed_test.go
@@ -535,6 +535,43 @@ func TestNugetFeedHandlerConcurrentDiscoveryIsDeduplicated(t *testing.T) {
 	assert.Len(t, handler.credentials, 2)
 }
 
+func TestNugetFeedHandlerCanonicalURLKeys(t *testing.T) {
+	equivalentEncodedURL := "https://nuget.example.com/f%65ed"
+	equivalentPlainURL := "https://nuget.example.com/feed"
+	encodedSlashURL := "https://nuget.example.com/feed%2fencoded"
+	literalSlashURL := "https://nuget.example.com/feed/encoded"
+
+	assert.Equal(t, nugetCredentialURLKey(equivalentEncodedURL), nugetCredentialURLKey(equivalentPlainURL))
+	assert.Equal(t, nugetDiscoverySourceKey(equivalentEncodedURL), nugetDiscoverySourceKey(equivalentPlainURL))
+	assert.NotEqual(t, nugetCredentialURLKey(encodedSlashURL), nugetCredentialURLKey(literalSlashURL))
+	assert.NotEqual(t, nugetDiscoverySourceKey(encodedSlashURL), nugetDiscoverySourceKey(literalSlashURL))
+
+	equivalentHandler := newTestNugetFeedHandler(config.Credentials{
+		testNugetFeedCredential(equivalentEncodedURL, "first-token"),
+		testNugetFeedCredential(equivalentPlainURL, "second-token"),
+	})
+	assert.Len(t, equivalentHandler.credentials, 1, "equivalent encodings deduplicate first-wins")
+	assert.Len(t, equivalentHandler.discoverySources, 1, "equivalent discovery sources deduplicate")
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, equivalentPlainURL+"/package/index.json", nil)
+	req = handleRequestAndClose(equivalentHandler, req, &goproxy.ProxyCtx{})
+	assertHasTokenAuth(t, req, "Bearer", "first-token", "first equivalent credential is retained")
+
+	distinctHandler := newTestNugetFeedHandler(config.Credentials{
+		testNugetFeedCredential(encodedSlashURL, "encoded-token"),
+		testNugetFeedCredential(literalSlashURL, "literal-token"),
+	})
+	assert.Len(t, distinctHandler.credentials, 2, "encoded slash remains distinct from a path separator")
+	assert.Len(t, distinctHandler.discoverySources, 2, "distinct paths retain separate discovery sources")
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, encodedSlashURL+"/package/index.json", nil)
+	req = handleRequestAndClose(distinctHandler, req, &goproxy.ProxyCtx{})
+	assertHasTokenAuth(t, req, "Bearer", "encoded-token", "encoded slash credential")
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, literalSlashURL+"/package/index.json", nil)
+	req = handleRequestAndClose(distinctHandler, req, &goproxy.ProxyCtx{})
+	assertHasTokenAuth(t, req, "Bearer", "literal-token", "literal path separator credential")
+}
+
 func TestNugetFeedHandlerIgnoresUnusableStaticCredentials(t *testing.T) {
 	usableCredential := testNugetFeedCredential("https://nuget.example.com/v3/index.json", "some-token")
 	unusableCredential := config.Credential{
@@ -602,6 +639,56 @@ func TestNugetFeedHandlerPrefersMostSpecificURLCredential(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.example.com/feed/specific/package/index.json", nil)
 	req = handleRequestAndClose(handler, req, &goproxy.ProxyCtx{})
 	assertHasTokenAuth(t, req, "Bearer", "specific-token", "most specific URL credential")
+}
+
+func TestNugetFeedHandlerProxyOnlyCredentials(t *testing.T) {
+	handler := newTestNugetFeedHandler(config.Credentials{
+		{
+			"type":       "nuget_feed",
+			"host":       "nuget.pkg.github.com",
+			"username":   "x-access-token",
+			"password":   "automatic-token",
+			"proxy-only": true,
+		},
+		{
+			"type":  "nuget_feed",
+			"url":   "https://nuget.pkg.github.com/dependabot/index.json",
+			"token": "explicit-token",
+		},
+	})
+
+	assert.Len(t, handler.discoverySources, 1, "proxy-only credentials do not create discovery sources")
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.pkg.github.com/other/package/index.json", nil)
+	req = handleRequestAndClose(handler, req, nil)
+	assertHasBasicAuth(t, req, "x-access-token", "automatic-token", "host-only automatic credential")
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.pkg.github.com/other/package/index.json", nil)
+	req.Header.Set("Authorization", authorizationPlaceholder)
+	req = handleRequestAndClose(handler, req, nil)
+	assertHasBasicAuth(t, req, "x-access-token", "automatic-token", "automatic credential replaces placeholder auth")
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.pkg.github.com/other/package/index.json", nil)
+	req.Header.Set("Authorization", "Bearer caller-token")
+	req = handleRequestAndClose(handler, req, nil)
+	assert.Equal(t, "Bearer caller-token", req.Header.Get("Authorization"), "automatic credential preserves request auth")
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.pkg.github.com/dependabot/index.json", nil)
+	req = handleRequestAndClose(handler, req, nil)
+	assertHasTokenAuth(t, req, "Bearer", "explicit-token", "path-specific explicit credential")
+
+	for _, requestURL := range []string{
+		"http://nuget.pkg.github.com/other/package/index.json",
+		"https://nuget.pkg.github.com:8443/other/package/index.json",
+	} {
+		req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, requestURL, nil)
+		req = handleRequestAndClose(handler, req, nil)
+		assertUnauthenticated(t, req, "automatic credential destination safety")
+	}
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.pkg.github.example/other/package/index.json", nil)
+	req = handleRequestAndClose(handler, req, nil)
+	assertUnauthenticated(t, req, "automatic credential host mismatch")
 }
 
 func TestNugetFeedHandlerDiscoversThroughCrossOriginRedirectWithoutLeakingCredentials(t *testing.T) {

--- a/internal/handlers/oidc_handling_test.go
+++ b/internal/handlers/oidc_handling_test.go
@@ -282,7 +282,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 				"registered aws OIDC credentials for docker registry: https://docker.example.com",
 			},
 			urlsToAuthenticate: []string{
-				"https://docker.example.com/some-package",
+				"https://docker.example.com/v2/some-package/manifests/latest",
 			},
 		},
 		{
@@ -303,7 +303,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 				"registered azure OIDC credentials for docker registry: https://docker.example.com",
 			},
 			urlsToAuthenticate: []string{
-				"https://docker.example.com/some-package",
+				"https://docker.example.com/v2/some-package/manifests/latest",
 			},
 		},
 		{
@@ -315,15 +315,15 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			credentials: config.Credentials{
 				config.Credential{
 					"type":                     "docker_registry",
-					"url":                      "https://jfrog.example.com",
+					"url":                      "https://jfrog.example.com/dependabot",
 					"jfrog-oidc-provider-name": "proxy-test",
 				},
 			},
 			expectedLogLines: []string{
-				"registered jfrog OIDC credentials for docker registry: jfrog.example.com",
+				"registered jfrog OIDC credentials for docker registry: https://jfrog.example.com/v2/dependabot",
 			},
 			urlsToAuthenticate: []string{
-				"https://jfrog.example.com/some-package",
+				"https://jfrog.example.com/v2/dependabot/manifests/latest",
 			},
 		},
 		{
@@ -345,7 +345,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 				"registered cloudsmith OIDC credentials for docker registry: https://cloudsmith.example.com",
 			},
 			urlsToAuthenticate: []string{
-				"https://cloudsmith.example.com/some-package",
+				"https://cloudsmith.example.com/v2/some-package/manifests/latest",
 			},
 		},
 		{
@@ -365,7 +365,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 				"registered gcp OIDC credentials for docker registry: https://us-central1-docker.pkg.dev",
 			},
 			urlsToAuthenticate: []string{
-				"https://us-central1-docker.pkg.dev/some-package",
+				"https://us-central1-docker.pkg.dev/v2/some-package/manifests/latest",
 			},
 		},
 		//
@@ -1594,6 +1594,150 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					assertHasTokenAuth(t, req, "Bearer", "__test_token__", "package url: "+urlToAuth)
 				}
 			}
+		})
+	}
+}
+
+func TestNPMExplicitOIDCBeatsStaticProxyOnlyCredential(t *testing.T) {
+	const tokenURL = "https://token.actions.example.com" //nolint:gosec // test URL
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", tokenURL)
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "request-token")
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder(http.MethodGet, tokenURL,
+		httpmock.NewStringResponder(http.StatusOK, `{"count":1,"value":"github-token"}`))
+	httpmock.RegisterResponder(
+		http.MethodPost,
+		"https://login.microsoftonline.com/explicit-tenant/oauth2/v2.0/token",
+		httpmock.NewStringResponder(
+			http.StatusOK,
+			`{"access_token":"explicit-token","expires_in":3600,"token_type":"Bearer"}`,
+		),
+	)
+
+	handler := NewNPMRegistryHandler(config.Credentials{
+		{
+			"type":       "npm_registry",
+			"registry":   "https://npm.example.com",
+			"token":      "automatic-user:automatic-token",
+			"tenant-id":  "automatic-tenant",
+			"client-id":  "automatic-client",
+			"proxy-only": true,
+		},
+		{
+			"type":      "npm_registry",
+			"registry":  "https://npm.example.com/dependabot",
+			"tenant-id": "explicit-tenant",
+			"client-id": "explicit-client",
+		},
+	}, testOIDCClient)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://npm.example.com/dependabot/package", nil)
+	req = handleRequestAndClose(handler, req, nil)
+	assertHasTokenAuth(t, req, "Bearer", "explicit-token", "explicit OIDC credential")
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://npm.example.com/other/package", nil)
+	assert.Nil(t, handler.oidcRegistry.CredentialForRequest(req), "proxy-only credential is not registered for OIDC")
+	req = handleRequestAndClose(handler, req, nil)
+	assertHasBasicAuth(t, req, "automatic-user", "automatic-token", "static proxy-only credential")
+}
+
+func TestFailedExplicitOIDCBlocksProxyOnlyFallback(t *testing.T) {
+	const tokenURL = "https://token.actions.example.com" //nolint:gosec // test URL
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", tokenURL)
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "request-token")
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder(http.MethodGet, tokenURL,
+		httpmock.NewStringResponder(http.StatusInternalServerError, "failed"))
+
+	oidcCredential := func(credentialType, field, location string) config.Credential {
+		return config.Credential{
+			"type":      credentialType,
+			field:       location,
+			"tenant-id": "failed-tenant",
+			"client-id": "failed-client",
+		}
+	}
+	tests := []struct {
+		name        string
+		requestURL  string
+		credentials config.Credentials
+		handler     func(config.Credentials) oidcHandler
+	}{
+		{
+			name:       "npm",
+			requestURL: "https://registry.example.com/dependabot/package",
+			credentials: config.Credentials{
+				{"type": "npm_registry", "registry": "https://registry.example.com", "token": "automatic-token", "proxy-only": true},
+				oidcCredential("npm_registry", "registry", "https://registry.example.com/dependabot"),
+			},
+			handler: func(credentials config.Credentials) oidcHandler {
+				return NewNPMRegistryHandler(credentials, testOIDCClient)
+			},
+		},
+		{
+			name:       "maven",
+			requestURL: "https://registry.example.com/dependabot/package.jar",
+			credentials: config.Credentials{
+				{"type": "maven_repository", "host": "registry.example.com", "username": "automatic", "password": "token", "proxy-only": true},
+				oidcCredential("maven_repository", "url", "https://registry.example.com/dependabot"),
+			},
+			handler: func(credentials config.Credentials) oidcHandler {
+				return NewMavenRepositoryHandler(credentials, testOIDCClient)
+			},
+		},
+		{
+			name:       "rubygems",
+			requestURL: "https://registry.example.com/dependabot/gem",
+			credentials: config.Credentials{
+				{"type": "rubygems_server", "host": "registry.example.com", "token": "automatic:token", "proxy-only": true},
+				oidcCredential("rubygems_server", "url", "https://registry.example.com/dependabot"),
+			},
+			handler: func(credentials config.Credentials) oidcHandler {
+				return NewRubyGemsServerHandler(credentials, testOIDCClient)
+			},
+		},
+		{
+			name:       "nuget",
+			requestURL: "https://registry.example.com/dependabot/index.json",
+			credentials: config.Credentials{
+				{"type": "nuget_feed", "host": "registry.example.com", "username": "automatic", "password": "token", "proxy-only": true},
+				oidcCredential("nuget_feed", "url", "https://registry.example.com/dependabot"),
+			},
+			handler: func(credentials config.Credentials) oidcHandler {
+				return NewNugetFeedHandler(credentials, testOIDCClient)
+			},
+		},
+		{
+			name:       "docker",
+			requestURL: "https://registry.example.com/v2/dependabot/core/manifests/latest",
+			credentials: config.Credentials{
+				{"type": "docker_registry", "registry": "registry.example.com", "username": "automatic", "password": "token", "proxy-only": true},
+				{
+					"type":      "docker_registry",
+					"registry":  "registry.example.com",
+					"url":       "https://registry.example.com/dependabot/core",
+					"tenant-id": "failed-tenant",
+					"client-id": "failed-client",
+				},
+			},
+			handler: func(credentials config.Credentials) oidcHandler {
+				return NewDockerRegistryHandler(credentials, testOIDCClient, nil)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, test.requestURL, nil)
+			proxyCtx := &goproxy.ProxyCtx{}
+			req = handleRequestAndClose(test.handler(test.credentials), req, proxyCtx)
+
+			assertUnauthenticated(t, req, "failed OIDC blocks automatic auth")
+			assert.Nil(t, proxyCtx.RoundTripper, "failed OIDC blocks automatic transport")
 		})
 	}
 }

--- a/internal/handlers/rubygems_server.go
+++ b/internal/handlers/rubygems_server.go
@@ -19,9 +19,10 @@ type RubyGemsServerHandler struct {
 }
 
 type rubyGemsServerCredentials struct {
-	host  string
-	url   string
-	token string
+	host      string
+	url       string
+	token     string
+	proxyOnly bool
 }
 
 // NewRubyGemsServerHandler returns a new RubyGemsServerHandler.
@@ -39,15 +40,22 @@ func NewRubyGemsServerHandler(creds config.Credentials, client *http.Client) *Ru
 		host := cred.Host()
 		url := cred.GetString("url")
 
-		// OIDC credentials are not used as static credentials.
-		if oidcCred, _, _ := handler.oidcRegistry.Register(cred, []string{"url"}, "rubygems server"); oidcCred != nil {
+		proxyOnly := cred.GetBool("proxy-only")
+		if !proxyOnly {
+			// OIDC credentials are not used as static credentials.
+			if oidcCred, _, _ := handler.oidcRegistry.Register(cred, []string{"url"}, "rubygems server"); oidcCred != nil {
+				continue
+			}
+		}
+		if proxyOnly && cred.GetString("token") == "" {
 			continue
 		}
 
 		serverCred := rubyGemsServerCredentials{
-			host:  host,
-			url:   url,
-			token: cred.GetString("token"),
+			host:      host,
+			url:       url,
+			token:     cred.GetString("token"),
+			proxyOnly: proxyOnly,
 		}
 		handler.credentials = append(handler.credentials, serverCred)
 	}
@@ -61,29 +69,49 @@ func (h *RubyGemsServerHandler) HandleRequest(req *http.Request, proxyCtx *gopro
 		return req, nil
 	}
 
-	// Try OIDC credentials first
-	if h.oidcRegistry.TryAuth(req, proxyCtx) {
+	oidcCredential := h.oidcRegistry.CredentialForRequest(req)
+	if h.oidcRegistry.TryAuthCredential(req, proxyCtx, oidcCredential) {
 		return req, nil
 	}
+	if h.authenticateStaticCredential(req, proxyCtx, false) {
+		return req, nil
+	}
+	if hasUsableAuthorization(req) {
+		return req, nil
+	}
+	if oidcCredential != nil {
+		return req, nil
+	}
+	if !proxyOnlyCredentialRequestAllowed(req) {
+		return req, nil
+	}
+	h.authenticateStaticCredential(req, proxyCtx, true)
 
-	// Fall back to static credentials
+	return req, nil
+}
+
+func (h *RubyGemsServerHandler) authenticateStaticCredential(
+	req *http.Request,
+	proxyCtx *goproxy.ProxyCtx,
+	proxyOnly bool,
+) bool {
 	for _, cred := range h.credentials {
+		if cred.proxyOnly != proxyOnly {
+			continue
+		}
 		matchURL := cred.url
 		if matchURL == "" {
 			matchURL = cred.host
 		}
-		if !helpers.UrlMatchesRequest(req, matchURL, true) {
+		if !helpers.CredentialURLMatchesRequest(req, matchURL, true) {
 			continue
 		}
 
 		logging.RequestLogf(proxyCtx, "* authenticating rubygems server request (host: %s)", req.URL.Hostname())
-
-		// ignore `found` because it's okay for the password to be an empty string
 		username, password, _ := strings.Cut(cred.token, ":")
 		helpers.SetBasicAuthorization(req, username, password)
-
-		return req, nil
+		return true
 	}
 
-	return req, nil
+	return false
 }

--- a/internal/handlers/rubygems_server_test.go
+++ b/internal/handlers/rubygems_server_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dependabot/proxy/internal/config"
 )
 
@@ -74,4 +76,42 @@ func TestRubyGemsServerHandler(t *testing.T) {
 	req = httptest.NewRequestWithContext(t.Context(), "POST", "https://corp.dependabot.com/gems", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertUnauthenticated(t, req, "post request")
+}
+
+func TestRubyGemsServerHandlerProxyOnlyCredentials(t *testing.T) {
+	handler := NewRubyGemsServerHandler(config.Credentials{
+		config.Credential{
+			"type":       "rubygems_server",
+			"host":       "rubygems.pkg.github.com",
+			"token":      "x-access-token:automatic-token",
+			"proxy-only": true,
+		},
+		config.Credential{
+			"type":  "rubygems_server",
+			"url":   "https://rubygems.pkg.github.com/dependabot",
+			"token": "explicit-user:explicit-token",
+		},
+	}, testOIDCClient)
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://rubygems.pkg.github.com/other/gem", nil)
+	req = handleRequestAndClose(handler, req, nil)
+	assertHasBasicAuth(t, req, "x-access-token", "automatic-token", "host-only automatic credential")
+
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://rubygems.pkg.github.com/other/gem", nil)
+	req.Header.Set("Authorization", authorizationPlaceholder)
+	req = handleRequestAndClose(handler, req, nil)
+	assertHasBasicAuth(t, req, "x-access-token", "automatic-token", "automatic credential replaces placeholder auth")
+
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://rubygems.pkg.github.com/other/gem", nil)
+	req.Header.Set("Authorization", "Bearer request-token")
+	req = handleRequestAndClose(handler, req, nil)
+	assert.Equal(t, "Bearer request-token", req.Header.Get("Authorization"), "automatic credential preserves request auth")
+
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://rubygems.pkg.github.com/dependabot/gem", nil)
+	req = handleRequestAndClose(handler, req, nil)
+	assertHasBasicAuth(t, req, "explicit-user", "explicit-token", "path-specific explicit credential")
+
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://rubygems.pkg.github.example/other/gem", nil)
+	req = handleRequestAndClose(handler, req, nil)
+	assertUnauthenticated(t, req, "automatic credential host mismatch")
 }

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -63,26 +63,8 @@ func MethodPermitted(r *http.Request, methods ...string) bool {
 }
 
 func UrlMatchesRequest(req *http.Request, urlStr string, pathMatch bool) bool {
-	parsedURL, err := ParseURLLax(urlStr)
-	if err != nil {
-		return false
-	}
-
-	if !AreHostnamesEqual(parsedURL.Hostname(), req.URL.Hostname()) {
-		return false
-	}
-
-	urlPort := parsedURL.Port()
-	if urlPort == "" {
-		urlPort = "443"
-	}
-
-	reqPort := req.URL.Port()
-	if reqPort == "" {
-		reqPort = "443"
-	}
-
-	if urlPort != reqPort {
+	parsedURL, ok := requestURLMatch(req, urlStr)
+	if !ok {
 		return false
 	}
 
@@ -91,6 +73,115 @@ func UrlMatchesRequest(req *http.Request, urlStr string, pathMatch bool) bool {
 	}
 
 	return strings.HasPrefix(req.URL.Path, strings.TrimRight(parsedURL.Path, "/"))
+}
+
+// CredentialURLMatchesRequest safely matches a request against a credential URL.
+func CredentialURLMatchesRequest(req *http.Request, urlStr string, pathMatch bool) bool {
+	parsedURL, ok := requestURLMatch(req, urlStr)
+	if !ok {
+		return false
+	}
+
+	if !pathMatch {
+		return true
+	}
+
+	return PathMatches(req.URL.EscapedPath(), parsedURL.EscapedPath())
+}
+
+func requestURLMatch(req *http.Request, urlStr string) (*url.URL, bool) {
+	parsedURL, err := ParseURLLax(urlStr)
+	if err != nil || !AreHostnamesEqual(parsedURL.Hostname(), req.URL.Hostname()) {
+		return nil, false
+	}
+
+	urlPort := parsedURL.Port()
+	if urlPort == "" {
+		urlPort = "443"
+	}
+	reqPort := req.URL.Port()
+	if reqPort == "" {
+		reqPort = "443"
+	}
+	return parsedURL, urlPort == reqPort
+}
+
+// PathMatches reports whether an escaped request path is within an escaped configured path scope.
+func PathMatches(requestPath, configuredPath string) bool {
+	_, ok := MatchingPathPrefix(requestPath, configuredPath)
+	return ok
+}
+
+// MatchingPathPrefix returns the request's escaped path prefix corresponding to
+// the configured scope. Encoded separators remain within their original path
+// segment, and ambiguous dot segments do not match path-scoped credentials.
+func MatchingPathPrefix(requestPath, configuredPath string) (string, bool) {
+	_, configuredSegments, ok := canonicalPathSegments(configuredPath)
+	if !ok {
+		return "", false
+	}
+
+	requestRawSegments, requestSegments, ok := canonicalPathSegments(requestPath)
+	if !ok {
+		return "", false
+	}
+	if len(configuredSegments) == 0 {
+		return "", true
+	}
+	if len(requestSegments) < len(configuredSegments) {
+		return "", false
+	}
+
+	for i := range configuredSegments {
+		if requestSegments[i] != configuredSegments[i] {
+			return "", false
+		}
+	}
+
+	return strings.Join(requestRawSegments[:len(configuredSegments)], "/"), true
+}
+
+// CanonicalPath returns a stable escaped representation of a URL path.
+func CanonicalPath(escapedPath string) (string, bool) {
+	_, segments, ok := canonicalPathSegments(escapedPath)
+	if !ok {
+		return "", false
+	}
+
+	canonicalSegments := make([]string, len(segments))
+	for i, segment := range segments {
+		canonicalSegments[i] = url.PathEscape(segment)
+	}
+
+	return strings.Join(canonicalSegments, "/"), true
+}
+
+func canonicalPathSegments(escapedPath string) ([]string, []string, bool) {
+	escapedPath = strings.TrimRight(escapedPath, "/")
+	if escapedPath == "" {
+		return nil, nil, true
+	}
+
+	rawSegments := strings.Split(escapedPath, "/")
+	segments := make([]string, len(rawSegments))
+	for i, rawSegment := range rawSegments {
+		segment, err := url.PathUnescape(rawSegment)
+		if err != nil || containsDotPathComponent(segment) {
+			return nil, nil, false
+		}
+		segments[i] = segment
+	}
+
+	return rawSegments, segments, true
+}
+
+func containsDotPathComponent(segment string) bool {
+	for component := range strings.SplitSeq(segment, "/") {
+		if component == "." || component == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 // https://tools.ietf.org/html/rfc3986#section-3

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -212,3 +212,39 @@ func TestUrlMatchesRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestCredentialURLMatchesRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		request  string
+		expected bool
+	}{
+		{name: "child path", request: "https://example.com/dependabot/package", expected: true},
+		{name: "encoded package child", request: "https://example.com/dependabot/@scope%2Fpackage", expected: true},
+		{name: "sibling path", request: "https://example.com/dependabot-attacker/package"},
+		{name: "encoded separator", request: "https://example.com/dependabot%2Fattacker/package"},
+		{name: "dot traversal", request: "https://example.com/dependabot/../attacker"},
+		{name: "encoded dot traversal", request: "https://example.com/dependabot/%2e%2e%2fattacker"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := newRequest(t, test.request)
+			assert.Equal(
+				t,
+				test.expected,
+				CredentialURLMatchesRequest(req, "https://example.com/dependabot", true),
+			)
+		})
+	}
+}
+
+func TestMatchingPathPrefixPreservesWireEncoding(t *testing.T) {
+	prefix, ok := MatchingPathPrefix(
+		"/npm/@scope%2fpackage/-/package.tgz",
+		"/npm/@scope%2Fpackage/",
+	)
+
+	assert.True(t, ok)
+	assert.Equal(t, "/npm/@scope%2fpackage", prefix)
+}

--- a/internal/oidc/oidc_registry.go
+++ b/internal/oidc/oidc_registry.go
@@ -23,9 +23,10 @@ type OIDCRegistry struct {
 }
 
 type oidcEntry struct {
-	path       string // URL path prefix, e.g. "/org/_packaging/feed-A/npm/registry"
-	port       string // port, defaults to "443"
-	credential *OIDCCredential
+	path        string // Canonical URL path prefix, e.g. "/org/_packaging/feed-A/npm/registry"
+	port        string // port, defaults to "443"
+	specificity int
+	credential  *OIDCCredential
 }
 
 // NewOIDCRegistry creates an empty registry. client is used for every outbound
@@ -124,20 +125,20 @@ func (r *OIDCRegistry) CredentialForRequest(req *http.Request) *OIDCCredential {
 	}
 
 	// Find the most specific matching entry: host is already matched,
-	// select the longest path prefix among entries with the same port.
+	// select the entry with the most canonical path segments.
 	var matched *OIDCCredential
-	bestPathLen := -1
+	bestSpecificity := -1
 	for i := range entries {
 		e := &entries[i]
 		if e.port != reqPort {
 			continue
 		}
-		if !strings.HasPrefix(req.URL.Path, e.path) {
+		if !helpers.PathMatches(req.URL.EscapedPath(), e.path) {
 			continue
 		}
-		if len(e.path) > bestPathLen {
+		if e.specificity > bestSpecificity {
 			matched = e.credential
-			bestPathLen = len(e.path)
+			bestSpecificity = e.specificity
 		}
 	}
 
@@ -190,7 +191,7 @@ func (r *OIDCRegistry) addEntry(urlOrHost string, cred *OIDCCredential, registry
 		logging.RequestLogf(nil, "failed to parse OIDC credential URL: %s", urlOrHost)
 		return false
 	}
-
+	specificity := strings.Count(path, "/")
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
@@ -204,9 +205,10 @@ func (r *OIDCRegistry) addEntry(urlOrHost string, cred *OIDCCredential, registry
 	}
 
 	r.byHost[host] = append(r.byHost[host], oidcEntry{
-		path:       path,
-		port:       port,
-		credential: cred,
+		path:        path,
+		port:        port,
+		specificity: specificity,
+		credential:  cred,
 	})
 
 	logging.RequestLogf(nil, "registered %s OIDC credentials for %s: %s", cred.Provider(), registryType, urlOrHost)
@@ -222,7 +224,10 @@ func parseRegistryURL(urlOrHost string) (host, path, port string) {
 	}
 
 	host = strings.ToLower(parsed.Hostname())
-	path = strings.TrimRight(parsed.Path, "/")
+	path, ok := helpers.CanonicalPath(parsed.EscapedPath())
+	if !ok {
+		return "", "", ""
+	}
 	port = parsed.Port()
 	if port == "" {
 		port = "443"

--- a/internal/oidc/oidc_registry_test.go
+++ b/internal/oidc/oidc_registry_test.go
@@ -3,9 +3,7 @@ package oidc
 import (
 	"bytes"
 	"net/http/httptest"
-	"strconv"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
@@ -252,7 +250,7 @@ func TestOIDCRegistry_TryAuth_WrongPathNoMatch(t *testing.T) {
 	assert.Empty(t, req.Header.Get("Authorization"))
 }
 
-func TestOIDCRegistry_CredentialForRequestConcurrentRegistration(t *testing.T) {
+func TestOIDCRegistry_CredentialForRequestRequiresPathBoundary(t *testing.T) {
 	r := NewOIDCRegistry(testHTTPClient)
 	credential := &OIDCCredential{
 		parameters: &AzureOIDCParameters{
@@ -260,31 +258,70 @@ func TestOIDCRegistry_CredentialForRequestConcurrentRegistration(t *testing.T) {
 			ClientID: "client-1",
 		},
 	}
-	r.RegisterURL("https://registry.example.com/packages", credential, "test registry")
+	r.RegisterURL("https://registry.example.com/dependabot", credential, "test registry")
 
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.example.com/packages/some-package", nil)
-
-	var wg sync.WaitGroup
-	for i := range 50 {
-		wg.Add(2)
-		go func(i int) {
-			defer wg.Done()
-			r.RegisterURL(
-				"https://registry.example.com/packages/feed-"+strconv.Itoa(i),
-				credential,
-				"test registry",
-			)
-		}(i)
-		go func() {
-			defer wg.Done()
-			for range 100 {
-				_ = r.CredentialForRequest(req)
-			}
-		}()
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "exact path", url: "https://registry.example.com/dependabot", want: true},
+		{name: "ordinary child", url: "https://registry.example.com/dependabot/package", want: true},
+		{name: "encoded package child", url: "https://registry.example.com/dependabot/@scope%2Fpackage", want: true},
+		{name: "sibling path", url: "https://registry.example.com/dependabot-attacker/package"},
+		{name: "encoded separator", url: "https://registry.example.com/dependabot%2Fattacker/package"},
+		{name: "encoded separator introducing parent component", url: "https://registry.example.com/dependabot/%2e%2e%2fattacker"},
 	}
-	wg.Wait()
 
-	assert.Same(t, credential, r.CredentialForRequest(req))
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(t.Context(), "GET", test.url, nil)
+			if test.want {
+				assert.Same(t, credential, r.CredentialForRequest(req))
+			} else {
+				assert.Nil(t, r.CredentialForRequest(req))
+			}
+		})
+	}
+
+	encodedCredential := &OIDCCredential{
+		parameters: &AzureOIDCParameters{
+			TenantID: "tenant-encoded",
+			ClientID: "client-encoded",
+		},
+	}
+	r.RegisterURL("https://registry.example.com/npm/@scope%2Fpackage", encodedCredential, "test registry")
+	req := httptest.NewRequestWithContext(t.Context(), "GET",
+		"https://registry.example.com/npm/@scope%2fpackage/-/package.tgz", nil,
+	)
+	assert.Same(t, encodedCredential, r.CredentialForRequest(req))
+}
+
+func TestOIDCRegistry_CredentialForRequestUsesCanonicalPathSpecificity(t *testing.T) {
+	r := NewOIDCRegistry(testHTTPClient)
+	broadCredential := &OIDCCredential{
+		parameters: &AzureOIDCParameters{
+			TenantID: "tenant-broad",
+			ClientID: "client-broad",
+		},
+	}
+	narrowCredential := &OIDCCredential{
+		parameters: &AzureOIDCParameters{
+			TenantID: "tenant-narrow",
+			ClientID: "client-narrow",
+		},
+	}
+	r.RegisterURL("https://registry.example.com/%66%6f%6f", broadCredential, "test registry")
+	r.RegisterURL("https://registry.example.com/foo/b", narrowCredential, "test registry")
+
+	req := httptest.NewRequestWithContext(
+		t.Context(),
+		"GET",
+		"https://registry.example.com/foo/b/package",
+		nil,
+	)
+
+	assert.Same(t, narrowCredential, r.CredentialForRequest(req))
 }
 
 func TestOIDCRegistry_RegisterURL(t *testing.T) {
@@ -396,10 +433,10 @@ func TestOIDCRegistry_TryAuth_CaseInsensitiveHost(t *testing.T) {
 
 	r := NewOIDCRegistry(testHTTPClient)
 
-	cred := azureCredWithURL("tenant-1", "client-1", "https://Registry.Example.COM/packages")
+	cred := azureCredWithURL("tenant-1", "client-1", "https://Registry.Example.COM:443/packages")
 	r.Register(cred, []string{"url"}, "test registry")
 
-	// Request with different casing should still match
+	// Request with different casing and an omitted default port should still match
 	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://REGISTRY.EXAMPLE.COM/packages/something", nil)
 	ok := r.TryAuth(req, nil)
 
@@ -488,10 +525,10 @@ func TestOIDCRegistry_TryAuth_GCP_DockerUsesBasicAuth(t *testing.T) {
 
 	r := NewOIDCRegistry(testHTTPClient)
 
-	cred := gcpCred("projects/123/locations/global/workloadIdentityPools/pool/providers/prov", "https://us-central1-docker.pkg.dev/my-project/my-repo")
+	cred := gcpCred("projects/123/locations/global/workloadIdentityPools/pool/providers/prov", "https://us-central1-docker.pkg.dev/v2/my-project/my-repo")
 	r.Register(cred, []string{"url"}, "docker registry")
 
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://us-central1-docker.pkg.dev/my-project/my-repo/v2/some-image/manifests/latest", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://us-central1-docker.pkg.dev/v2/my-project/my-repo/manifests/latest", nil)
 	ok := r.TryAuth(req, nil)
 
 	assert.True(t, ok, "GCP OIDC should authenticate docker")

--- a/internal/oidc/oidc_registry_test.go
+++ b/internal/oidc/oidc_registry_test.go
@@ -3,7 +3,9 @@ package oidc
 import (
 	"bytes"
 	"net/http/httptest"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
@@ -248,6 +250,41 @@ func TestOIDCRegistry_TryAuth_WrongPathNoMatch(t *testing.T) {
 
 	assert.False(t, ok, "should not match different path")
 	assert.Empty(t, req.Header.Get("Authorization"))
+}
+
+func TestOIDCRegistry_CredentialForRequestConcurrentRegistration(t *testing.T) {
+	r := NewOIDCRegistry(testHTTPClient)
+	credential := &OIDCCredential{
+		parameters: &AzureOIDCParameters{
+			TenantID: "tenant-1",
+			ClientID: "client-1",
+		},
+	}
+	r.RegisterURL("https://registry.example.com/packages", credential, "test registry")
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://registry.example.com/packages/some-package", nil)
+
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			r.RegisterURL(
+				"https://registry.example.com/packages/feed-"+strconv.Itoa(i),
+				credential,
+				"test registry",
+			)
+		}(i)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				_ = r.CredentialForRequest(req)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Same(t, credential, r.CredentialForRequest(req))
 }
 
 func TestOIDCRegistry_CredentialForRequestRequiresPathBoundary(t *testing.T) {


### PR DESCRIPTION
## What changed

Add `proxy-only` credentials for automatic GitHub Packages authentication. They are used only when explicit OIDC credentials, explicit static credentials, and request-provided authentication do not apply.

This covers npm, Maven/Gradle, RubyGems, NuGet, and Docker. It also:

- preserves explicit and native authentication;
- replaces Dependabot's redacted authorization placeholders;
- uses host-only Maven and NuGet fallback credentials, without NuGet discovery;
- adds safe path matching, including Docker `/v2/<repository>` paths;
- stops failed explicit OIDC authentication from falling through to automatic credentials.

This is the proxy prerequisite for dependabot/dependabot-core#15415. The published image must be pinned in `github/dependabot-action` before the feature is re-enabled.

## Validation

Passed the full race, lint, build, vet, container, smoke, and production-image checks.


Security review: automatic Docker credentials are scoped to OCI `/v2` requests, so direct GHCR `/token` requests are not authenticated. The legitimate internal token challenge remains covered by a regression test.
