### PR TITLE
Restore eager NuGet service index discovery

### DIFF
--- a/internal/handlers/nuget_feed.go
+++ b/internal/handlers/nuget_feed.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/elazarl/goproxy"
 
@@ -47,12 +48,23 @@ type nugetFeedCredentials struct {
 	proxyOnly bool
 }
 
+const nugetDiscoveryConcurrency = 8
+
+type nugetDiscoveryJob struct {
+	serviceIndexURL     string
+	staticCredential    nugetFeedCredentials
+	staticCredentialSet int
+	oidcCredential      *oidc.OIDCCredential
+}
+
 // NewNugetFeedHandler returns a new NugetFeedHandler.
 func NewNugetFeedHandler(creds config.Credentials, client *http.Client) *NugetFeedHandler {
 	handler := NugetFeedHandler{
 		credentials:  []nugetFeedCredentials{},
 		oidcRegistry: oidc.NewOIDCRegistry(client),
 	}
+	staticCredentialSets := make([][]nugetFeedCredentials, 0)
+	discoveryJobs := make([]nugetDiscoveryJob, 0)
 
 	for _, cred := range creds {
 		if cred["type"] != "nuget_feed" {
@@ -75,53 +87,12 @@ func NewNugetFeedHandler(creds config.Credentials, client *http.Client) *NugetFe
 		} else {
 			oidcCredential, _, ok := handler.oidcRegistry.Register(cred, []string{"url"}, "nuget feed")
 			if ok {
-				// Discover additional resource URLs from the nuget feed index.
 				if url != "" {
-					func() {
-						req, err := http.NewRequestWithContext(context.Background(), "GET", url, nil)
-						if err != nil {
-							logging.RequestLogf(nil, "error creating http request (%s): %v", url, err)
-							return
-						}
-
-						if req.URL.Scheme != "https" {
-							logging.RequestLogf(nil, "refusing to discover nuget feed over non-https URL %s", url)
-							return
-						}
-
-						if !handler.oidcRegistry.TryAuth(req, nil) {
-							return
-						}
-
-						rawRsp, err := client.Do(req)
-						if err != nil {
-							logging.RequestLogf(nil, "error retrieving http response (%s): %v", url, err)
-							return
-						}
-						defer rawRsp.Body.Close()
-
-						body, err := io.ReadAll(rawRsp.Body)
-						if err != nil {
-							logging.RequestLogf(nil, "error reading http response body (%s): %v", url, err)
-							return
-						}
-
-						switch rawRsp.StatusCode {
-						case 401, 403:
-							logging.RequestLogf(nil, "unauthorized for nuget feed %s", url)
-							return
-						}
-
-						if rawRsp.StatusCode >= 400 {
-							logging.RequestLogf(nil, "unexpected http response %d for nuget feed %s", rawRsp.StatusCode, url)
-							return
-						}
-
-						urlsToAuthenticate := extraUrlsFromSourceResponse(body, url)
-						for _, discoveredURL := range urlsToAuthenticate {
-							handler.oidcRegistry.RegisterURL(discoveredURL, oidcCredential, "nuget resource")
-						}
-					}()
+					discoveryJobs = append(discoveryJobs, nugetDiscoveryJob{
+						serviceIndexURL:     url,
+						staticCredentialSet: -1,
+						oidcCredential:      oidcCredential,
+					})
 				}
 				continue
 			}
@@ -139,62 +110,128 @@ func NewNugetFeedHandler(creds config.Credentials, client *http.Client) *NugetFe
 			password:  password,
 			proxyOnly: proxyOnly,
 		}
-		handler.credentials = append(handler.credentials, feedCred)
+		staticCredentialSet := len(staticCredentialSets)
+		staticCredentialSets = append(staticCredentialSets, []nugetFeedCredentials{feedCred})
 
 		// If the credentials are for a specific feed, we query the base url to find all the resources
 		// and authenticate them all
 		if !proxyOnly && url != "" {
 			logging.RequestLogf(nil, "fetching service index for nuget feed %s", url)
-			// Same closure pattern as the OIDC block above — ensures the
-			// HTTP response body is always closed via defer.
-			func() {
-				req, err := http.NewRequestWithContext(context.Background(), "GET", url, nil)
-				if err != nil {
-					logging.RequestLogf(nil, "error creating http request (%s): %v", url, err)
-					return
-				}
-				authenticateNugetRequest(req, feedCred, nil)
-
-				rawRsp, err := client.Do(req)
-				if err != nil {
-					logging.RequestLogf(nil, "error retrieving http response (%s): %v", url, err)
-					return
-				}
-				defer rawRsp.Body.Close()
-
-				body, err := io.ReadAll(rawRsp.Body)
-				if err != nil {
-					logging.RequestLogf(nil, "error reading http response body (%s): %v", url, err)
-					return
-				}
-
-				switch rawRsp.StatusCode {
-				case 401, 403:
-					logging.RequestLogf(nil, "unauthorized for nuget feed %s", url)
-					return
-				}
-
-				if rawRsp.StatusCode >= 400 {
-					logging.RequestLogf(nil, "unexpected http response %d for nuget feed %s", rawRsp.StatusCode, url)
-					return
-				}
-
-				urlsToAuthenticate := extraUrlsFromSourceResponse(body, url)
-				for _, discoveredURL := range urlsToAuthenticate {
-					feedCred := nugetFeedCredentials{
-						url:      discoveredURL,
-						token:    token,
-						username: username,
-						password: password,
-					}
-					handler.credentials = append(handler.credentials, feedCred)
-					logging.RequestLogf(nil, "  added url to authentication list: %s", discoveredURL)
-				}
-			}()
+			discoveryJobs = append(discoveryJobs, nugetDiscoveryJob{
+				serviceIndexURL:     url,
+				staticCredential:    feedCred,
+				staticCredentialSet: staticCredentialSet,
+			})
 		}
 	}
 
+	discoveredURLs := discoverNugetFeedURLs(discoveryJobs, client, handler.oidcRegistry)
+	for i, job := range discoveryJobs {
+		if job.oidcCredential != nil {
+			for _, discoveredURL := range discoveredURLs[i] {
+				handler.oidcRegistry.RegisterURL(discoveredURL, job.oidcCredential, "nuget resource")
+			}
+			continue
+		}
+
+		for _, discoveredURL := range discoveredURLs[i] {
+			staticCredentialSets[job.staticCredentialSet] = append(
+				staticCredentialSets[job.staticCredentialSet],
+				nugetFeedCredentials{
+					url:      discoveredURL,
+					token:    job.staticCredential.token,
+					username: job.staticCredential.username,
+					password: job.staticCredential.password,
+				},
+			)
+			logging.RequestLogf(nil, "  added url to authentication list: %s", discoveredURL)
+		}
+	}
+	for _, credentialSet := range staticCredentialSets {
+		handler.credentials = append(handler.credentials, credentialSet...)
+	}
+
 	return &handler
+}
+
+func discoverNugetFeedURLs(
+	jobs []nugetDiscoveryJob,
+	client *http.Client,
+	oidcRegistry *oidc.OIDCRegistry,
+) [][]string {
+	results := make([][]string, len(jobs))
+	if len(jobs) == 0 {
+		return results
+	}
+
+	jobIndexes := make(chan int)
+	workerCount := min(nugetDiscoveryConcurrency, len(jobs))
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for jobIndex := range jobIndexes {
+				results[jobIndex] = discoverNugetFeedURLsForJob(jobs[jobIndex], client, oidcRegistry)
+			}
+		}()
+	}
+	for jobIndex := range jobs {
+		jobIndexes <- jobIndex
+	}
+	close(jobIndexes)
+	workers.Wait()
+
+	return results
+}
+
+func discoverNugetFeedURLsForJob(
+	job nugetDiscoveryJob,
+	client *http.Client,
+	oidcRegistry *oidc.OIDCRegistry,
+) []string {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, job.serviceIndexURL, nil)
+	if err != nil {
+		logging.RequestLogf(nil, "error creating http request (%s): %v", job.serviceIndexURL, err)
+		return nil
+	}
+
+	if job.oidcCredential != nil {
+		if req.URL.Scheme != "https" {
+			logging.RequestLogf(nil, "refusing to discover nuget feed over non-https URL %s", job.serviceIndexURL)
+			return nil
+		}
+		if !oidcRegistry.TryAuthCredential(req, nil, job.oidcCredential) {
+			return nil
+		}
+	} else {
+		authenticateNugetRequest(req, job.staticCredential, nil)
+	}
+
+	rawRsp, err := client.Do(req)
+	if err != nil {
+		logging.RequestLogf(nil, "error retrieving http response (%s): %v", job.serviceIndexURL, err)
+		return nil
+	}
+	defer rawRsp.Body.Close()
+
+	body, err := io.ReadAll(rawRsp.Body)
+	if err != nil {
+		logging.RequestLogf(nil, "error reading http response body (%s): %v", job.serviceIndexURL, err)
+		return nil
+	}
+
+	switch rawRsp.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		logging.RequestLogf(nil, "unauthorized for nuget feed %s", job.serviceIndexURL)
+		return nil
+	}
+	if rawRsp.StatusCode >= http.StatusBadRequest {
+		logging.RequestLogf(nil, "unexpected http response %d for nuget feed %s", rawRsp.StatusCode, job.serviceIndexURL)
+		return nil
+	}
+
+	return extraUrlsFromSourceResponse(body, job.serviceIndexURL)
 }
 
 func extraUrlsFromSourceResponse(body []byte, url string) []string {

--- a/internal/handlers/nuget_feed.go
+++ b/internal/handlers/nuget_feed.go
@@ -226,7 +226,7 @@ func discoverNugetFeedURLsForJob(
 		logging.RequestLogf(nil, "unauthorized for nuget feed %s", job.serviceIndexURL)
 		return nil
 	}
-	if rawRsp.StatusCode >= http.StatusBadRequest {
+	if rawRsp.StatusCode != http.StatusOK {
 		logging.RequestLogf(nil, "unexpected http response %d for nuget feed %s", rawRsp.StatusCode, job.serviceIndexURL)
 		return nil
 	}
@@ -237,6 +237,10 @@ func discoverNugetFeedURLsForJob(
 func extraUrlsFromSourceResponse(body []byte, url string) []string {
 	var urls []string
 	bodyString := strings.TrimSpace(string(body))
+	if bodyString == "" {
+		logging.RequestLogf(nil, "empty API response from NuGet feed %s", url)
+		return nil
+	}
 	bodyReader := bytes.NewReader(body)
 	switch {
 	case strings.HasPrefix(bodyString, "<"):
@@ -246,7 +250,7 @@ func extraUrlsFromSourceResponse(body []byte, url string) []string {
 		// JSON v3 API
 		urls = handleV3Response(bodyReader, url)
 	default:
-		logging.RequestLogf(nil, "unknown API response: %s...", bodyString[:10])
+		logging.RequestLogf(nil, "unknown API response: %.10s...", bodyString)
 	}
 
 	var result []string

--- a/internal/handlers/nuget_feed.go
+++ b/internal/handlers/nuget_feed.go
@@ -2,13 +2,13 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"encoding/xml"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 
 	"github.com/elazarl/goproxy"
 
@@ -16,10 +16,7 @@ import (
 	"github.com/dependabot/proxy/internal/helpers"
 	"github.com/dependabot/proxy/internal/logging"
 	"github.com/dependabot/proxy/internal/oidc"
-	"github.com/dependabot/proxy/internal/proxyctx"
 )
-
-const nugetDiscoveryCtxKey = "nuget.discovery-auth"
 
 type nugetV2IndexResponse struct {
 	Base string `xml:"base,attr"`
@@ -37,13 +34,8 @@ type nugetV3IndexResponse struct {
 
 // NugetFeedHandler handles requests to nuget feeds, adding auth.
 type NugetFeedHandler struct {
-	credentials         []nugetFeedCredentials
-	credentialURLs      map[string]struct{}
-	credentialsMutex    sync.RWMutex
-	discoverySources    []nugetDiscoveryAuth
-	discoverySourceURLs map[string]struct{}
-	discoveryMutex      sync.RWMutex
-	oidcRegistry        *oidc.OIDCRegistry
+	credentials  []nugetFeedCredentials
+	oidcRegistry *oidc.OIDCRegistry
 }
 
 type nugetFeedCredentials struct {
@@ -55,20 +47,11 @@ type nugetFeedCredentials struct {
 	proxyOnly bool
 }
 
-type nugetDiscoveryAuth struct {
-	serviceIndexURL      string
-	static               nugetFeedCredentials
-	oidc                 *oidc.OIDCCredential
-	registerRedirectAuth bool
-}
-
 // NewNugetFeedHandler returns a new NugetFeedHandler.
 func NewNugetFeedHandler(creds config.Credentials, client *http.Client) *NugetFeedHandler {
 	handler := NugetFeedHandler{
-		credentials:         []nugetFeedCredentials{},
-		credentialURLs:      make(map[string]struct{}),
-		discoverySourceURLs: make(map[string]struct{}),
-		oidcRegistry:        oidc.NewOIDCRegistry(client),
+		credentials:  []nugetFeedCredentials{},
+		oidcRegistry: oidc.NewOIDCRegistry(client),
 	}
 
 	for _, cred := range creds {
@@ -89,16 +72,56 @@ func NewNugetFeedHandler(creds config.Credentials, client *http.Client) *NugetFe
 				continue
 			}
 			url = ""
-		}
-		if !proxyOnly {
+		} else {
 			oidcCredential, _, ok := handler.oidcRegistry.Register(cred, []string{"url"}, "nuget feed")
 			if ok {
+				// Discover additional resource URLs from the nuget feed index.
 				if url != "" {
-					handler.addDiscoverySource(nugetDiscoveryAuth{
-						serviceIndexURL:      url,
-						oidc:                 oidcCredential,
-						registerRedirectAuth: true,
-					})
+					func() {
+						req, err := http.NewRequestWithContext(context.Background(), "GET", url, nil)
+						if err != nil {
+							logging.RequestLogf(nil, "error creating http request (%s): %v", url, err)
+							return
+						}
+
+						if req.URL.Scheme != "https" {
+							logging.RequestLogf(nil, "refusing to discover nuget feed over non-https URL %s", url)
+							return
+						}
+
+						if !handler.oidcRegistry.TryAuth(req, nil) {
+							return
+						}
+
+						rawRsp, err := client.Do(req)
+						if err != nil {
+							logging.RequestLogf(nil, "error retrieving http response (%s): %v", url, err)
+							return
+						}
+						defer rawRsp.Body.Close()
+
+						body, err := io.ReadAll(rawRsp.Body)
+						if err != nil {
+							logging.RequestLogf(nil, "error reading http response body (%s): %v", url, err)
+							return
+						}
+
+						switch rawRsp.StatusCode {
+						case 401, 403:
+							logging.RequestLogf(nil, "unauthorized for nuget feed %s", url)
+							return
+						}
+
+						if rawRsp.StatusCode >= 400 {
+							logging.RequestLogf(nil, "unexpected http response %d for nuget feed %s", rawRsp.StatusCode, url)
+							return
+						}
+
+						urlsToAuthenticate := extraUrlsFromSourceResponse(body, url)
+						for _, discoveredURL := range urlsToAuthenticate {
+							handler.oidcRegistry.RegisterURL(discoveredURL, oidcCredential, "nuget resource")
+						}
+					}()
 				}
 				continue
 			}
@@ -116,13 +139,58 @@ func NewNugetFeedHandler(creds config.Credentials, client *http.Client) *NugetFe
 			password:  password,
 			proxyOnly: proxyOnly,
 		}
-		handler.addStaticCredential(feedCred)
-		if !proxyOnly && url != "" && (token != "" || password != "") {
-			handler.addDiscoverySource(nugetDiscoveryAuth{
-				serviceIndexURL:      url,
-				static:               feedCred,
-				registerRedirectAuth: true,
-			})
+		handler.credentials = append(handler.credentials, feedCred)
+
+		// If the credentials are for a specific feed, we query the base url to find all the resources
+		// and authenticate them all
+		if !proxyOnly && url != "" {
+			logging.RequestLogf(nil, "fetching service index for nuget feed %s", url)
+			// Same closure pattern as the OIDC block above — ensures the
+			// HTTP response body is always closed via defer.
+			func() {
+				req, err := http.NewRequestWithContext(context.Background(), "GET", url, nil)
+				if err != nil {
+					logging.RequestLogf(nil, "error creating http request (%s): %v", url, err)
+					return
+				}
+				authenticateNugetRequest(req, feedCred, nil)
+
+				rawRsp, err := client.Do(req)
+				if err != nil {
+					logging.RequestLogf(nil, "error retrieving http response (%s): %v", url, err)
+					return
+				}
+				defer rawRsp.Body.Close()
+
+				body, err := io.ReadAll(rawRsp.Body)
+				if err != nil {
+					logging.RequestLogf(nil, "error reading http response body (%s): %v", url, err)
+					return
+				}
+
+				switch rawRsp.StatusCode {
+				case 401, 403:
+					logging.RequestLogf(nil, "unauthorized for nuget feed %s", url)
+					return
+				}
+
+				if rawRsp.StatusCode >= 400 {
+					logging.RequestLogf(nil, "unexpected http response %d for nuget feed %s", rawRsp.StatusCode, url)
+					return
+				}
+
+				urlsToAuthenticate := extraUrlsFromSourceResponse(body, url)
+				for _, discoveredURL := range urlsToAuthenticate {
+					feedCred := nugetFeedCredentials{
+						url:      discoveredURL,
+						token:    token,
+						username: username,
+						password: password,
+					}
+					handler.credentials = append(handler.credentials, feedCred)
+					logging.RequestLogf(nil, "  added url to authentication list: %s", discoveredURL)
+				}
+			}()
 		}
 	}
 
@@ -132,10 +200,6 @@ func NewNugetFeedHandler(creds config.Credentials, client *http.Client) *NugetFe
 func extraUrlsFromSourceResponse(body []byte, url string) []string {
 	var urls []string
 	bodyString := strings.TrimSpace(string(body))
-	if bodyString == "" {
-		logging.RequestLogf(nil, "empty API response from NuGet feed %s", url)
-		return nil
-	}
 	bodyReader := bytes.NewReader(body)
 	switch {
 	case strings.HasPrefix(bodyString, "<"):
@@ -145,7 +209,7 @@ func extraUrlsFromSourceResponse(body []byte, url string) []string {
 		// JSON v3 API
 		urls = handleV3Response(bodyReader, url)
 	default:
-		logging.RequestLogf(nil, "unknown API response: %.10s...", bodyString)
+		logging.RequestLogf(nil, "unknown API response: %s...", bodyString[:10])
 	}
 
 	var result []string
@@ -202,32 +266,7 @@ func handleV3Response(body io.Reader, url string) (v3Urls []string) {
 	return
 }
 
-// PrepareRequest marks configured service-index requests for response-time
-// discovery. It is registered before the cache handler so cached indexes can
-// teach the same resource routes as live responses.
-func (h *NugetFeedHandler) PrepareRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-	if proxyCtx == nil || req.Method != http.MethodGet || (req.URL.Scheme != "http" && req.URL.Scheme != "https") {
-		return req, nil
-	}
-
-	h.discoveryMutex.RLock()
-	defer h.discoveryMutex.RUnlock()
-	for _, source := range h.discoverySources {
-		if source.oidc != nil && req.URL.Scheme != "https" {
-			continue
-		}
-		if isNugetServiceIndexRequest(req, source.serviceIndexURL) {
-			matchedSource := source
-			matchedSource.serviceIndexURL = req.URL.String()
-			markNugetDiscovery(proxyCtx, matchedSource)
-			return req, nil
-		}
-	}
-
-	return req, nil
-}
-
-// HandleRequest adds auth to a NuGet feed request.
+// HandleRequest adds auth to an nuget feed request
 func (h *NugetFeedHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	if (req.URL.Scheme != "http" && req.URL.Scheme != "https") || !helpers.MethodPermitted(req, "GET", "HEAD") {
 		return req, nil
@@ -245,13 +284,7 @@ func (h *NugetFeedHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.Pr
 		authenticateNugetRequest(req, *credential, proxyCtx)
 		return req, nil
 	}
-	if hasUsableAuthorization(req) {
-		return req, nil
-	}
-	if oidcCredential != nil {
-		return req, nil
-	}
-	if !proxyOnlyCredentialRequestAllowed(req) {
+	if hasUsableAuthorization(req) || oidcCredential != nil || !proxyOnlyCredentialRequestAllowed(req) {
 		return req, nil
 	}
 	if credential := h.staticCredentialForRequest(req, true); credential != nil {
@@ -261,120 +294,7 @@ func (h *NugetFeedHandler) HandleRequest(req *http.Request, proxyCtx *goproxy.Pr
 	return req, nil
 }
 
-func (h *NugetFeedHandler) HandleResponse(resp *http.Response, proxyCtx *goproxy.ProxyCtx) *http.Response {
-	if resp == nil {
-		return resp
-	}
-
-	discoveryAuth, ok := nugetDiscoveryAuthFromContext(proxyCtx)
-	if !ok {
-		return resp
-	}
-	if resp.StatusCode >= http.StatusMultipleChoices && resp.StatusCode < http.StatusBadRequest {
-		h.registerServiceIndexRedirect(resp, discoveryAuth, proxyCtx)
-		return resp
-	}
-	if resp.Body == nil || resp.Body == http.NoBody || resp.StatusCode == http.StatusNoContent ||
-		resp.StatusCode == http.StatusResetContent || resp.StatusCode < http.StatusOK ||
-		resp.StatusCode >= http.StatusMultipleChoices {
-		return resp
-	}
-
-	originalBody := resp.Body
-	body, err := io.ReadAll(originalBody)
-	resp.Body = &replayReadCloser{
-		Reader: io.MultiReader(bytes.NewReader(body), originalBody),
-		Closer: originalBody,
-	}
-	if err != nil {
-		return resp
-	}
-
-	for _, discoveredURL := range extraUrlsFromSourceResponse(body, discoveryAuth.serviceIndexURL) {
-		if discoveryAuth.oidc != nil {
-			h.oidcRegistry.RegisterURL(discoveredURL, discoveryAuth.oidc, "nuget resource")
-			continue
-		}
-
-		credential := discoveryAuth.static
-		credential.url = discoveredURL
-		credential.host = ""
-		if h.addStaticCredential(credential) {
-			logging.RequestLogf(proxyCtx, "  added url to authentication list: %s", discoveredURL)
-		}
-	}
-
-	return resp
-}
-
-func (h *NugetFeedHandler) registerServiceIndexRedirect(resp *http.Response, source nugetDiscoveryAuth, proxyCtx *goproxy.ProxyCtx) {
-	location := resp.Header.Get("Location")
-	if location == "" {
-		return
-	}
-	baseURL, err := url.Parse(source.serviceIndexURL)
-	if err != nil {
-		return
-	}
-	locationURL, err := url.Parse(location)
-	if err != nil {
-		return
-	}
-	redirectURL := baseURL.ResolveReference(locationURL)
-	if redirectURL.User != nil || (redirectURL.Scheme != "http" && redirectURL.Scheme != "https") {
-		return
-	}
-	if source.oidc != nil && redirectURL.Scheme != "https" {
-		return
-	}
-
-	redirectedSource := source
-	redirectedSource.serviceIndexURL = redirectURL.String()
-	redirectedSource.registerRedirectAuth = source.registerRedirectAuth && sameOrigin(baseURL, redirectURL)
-	if !h.addDiscoverySource(redirectedSource) {
-		return
-	}
-
-	if redirectedSource.registerRedirectAuth {
-		if source.oidc != nil {
-			h.oidcRegistry.RegisterURL(redirectURL.String(), source.oidc, "nuget service-index redirect")
-		} else {
-			credential := source.static
-			credential.url = redirectURL.String()
-			credential.host = ""
-			h.addStaticCredential(credential)
-		}
-	}
-	logging.RequestLogf(proxyCtx, "  registered nuget service-index redirect: %s", redirectURL.String())
-}
-
-func (h *NugetFeedHandler) addStaticCredential(credential nugetFeedCredentials) bool {
-	if credential.token == "" && credential.password == "" {
-		return false
-	}
-
-	h.credentialsMutex.Lock()
-	defer h.credentialsMutex.Unlock()
-
-	if credential.url != "" {
-		key := nugetCredentialURLKey(credential.url)
-		if _, ok := h.credentialURLs[key]; ok {
-			logging.RequestLogf(nil, "skipping duplicate NuGet credential URL because it is already registered: %s", credential.url)
-			return false
-		}
-		h.credentialURLs[key] = struct{}{}
-	}
-	h.credentials = append(h.credentials, credential)
-	return true
-}
-
-func (h *NugetFeedHandler) staticCredentialForRequest(
-	req *http.Request,
-	proxyOnly bool,
-) *nugetFeedCredentials {
-	h.credentialsMutex.RLock()
-	defer h.credentialsMutex.RUnlock()
-
+func (h *NugetFeedHandler) staticCredentialForRequest(req *http.Request, proxyOnly bool) *nugetFeedCredentials {
 	var urlCredential *nugetFeedCredentials
 	var hostCredential *nugetFeedCredentials
 	bestSpecificity := -1
@@ -408,84 +328,6 @@ func (h *NugetFeedHandler) staticCredentialForRequest(
 		return &credential
 	}
 	return nil
-}
-
-func (h *NugetFeedHandler) addDiscoverySource(source nugetDiscoveryAuth) bool {
-	h.discoveryMutex.Lock()
-	defer h.discoveryMutex.Unlock()
-
-	key := nugetDiscoverySourceKey(source.serviceIndexURL)
-	if _, ok := h.discoverySourceURLs[key]; ok {
-		return false
-	}
-	h.discoverySourceURLs[key] = struct{}{}
-	h.discoverySources = append(h.discoverySources, source)
-	logging.RequestLogf(nil, "registered NuGet service index for deferred discovery: %s", source.serviceIndexURL)
-	return true
-}
-
-func markNugetDiscovery(proxyCtx *goproxy.ProxyCtx, auth nugetDiscoveryAuth) {
-	if proxyCtx != nil {
-		proxyctx.SetValue(proxyCtx, nugetDiscoveryCtxKey, auth)
-	}
-}
-
-func nugetDiscoveryAuthFromContext(proxyCtx *goproxy.ProxyCtx) (nugetDiscoveryAuth, bool) {
-	if proxyCtx == nil {
-		return nugetDiscoveryAuth{}, false
-	}
-	value, ok := proxyctx.GetValue(proxyCtx, nugetDiscoveryCtxKey)
-	if !ok {
-		return nugetDiscoveryAuth{}, false
-	}
-	auth, ok := value.(nugetDiscoveryAuth)
-	return auth, ok
-}
-
-func isNugetServiceIndexRequest(req *http.Request, sourceURL string) bool {
-	if req.Method != http.MethodGet {
-		return false
-	}
-	parsedURL, err := helpers.ParseURLLax(sourceURL)
-	if err != nil || !helpers.CredentialURLMatchesRequest(req, sourceURL, true) {
-		return false
-	}
-	if parsedURL.Scheme != "" && !strings.EqualFold(parsedURL.Scheme, req.URL.Scheme) {
-		return false
-	}
-	sourcePath, sourceOK := helpers.CanonicalPath(parsedURL.EscapedPath())
-	requestPath, requestOK := helpers.CanonicalPath(req.URL.EscapedPath())
-	return sourceOK && requestOK && sourcePath == requestPath && parsedURL.RawQuery == req.URL.RawQuery
-}
-
-func nugetCredentialURLKey(rawURL string) string {
-	parsedURL, err := helpers.ParseURLLax(rawURL)
-	if err != nil {
-		return rawURL
-	}
-	path, ok := helpers.CanonicalPath(parsedURL.EscapedPath())
-	if !ok {
-		return rawURL
-	}
-	port := parsedURL.Port()
-	if port == "" {
-		port = "443"
-	}
-	return strings.ToLower(parsedURL.Hostname()) + ":" + port + path + "?" + parsedURL.RawQuery
-}
-
-// Discovery matching distinguishes explicit schemes, while static credential
-// matching intentionally remains scheme-agnostic for backwards compatibility.
-func nugetDiscoverySourceKey(rawURL string) string {
-	parsedURL, err := helpers.ParseURLLax(rawURL)
-	if err != nil {
-		return rawURL
-	}
-	scheme := strings.ToLower(parsedURL.Scheme)
-	if scheme == "" {
-		scheme = "*"
-	}
-	return scheme + "|" + nugetCredentialURLKey(rawURL)
 }
 
 func authenticateNugetRequest(req *http.Request, cred nugetFeedCredentials, proxyCtx *goproxy.ProxyCtx) {

--- a/internal/handlers/nuget_feed.go
+++ b/internal/handlers/nuget_feed.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -55,6 +56,11 @@ type nugetDiscoveryJob struct {
 	serviceIndexURL  string
 	staticCredential nugetFeedCredentials
 	oidcCredential   *oidc.OIDCCredential
+}
+
+type nugetDiscoveryResult struct {
+	resourceURLs              []string
+	authenticatedRedirectURLs []string
 }
 
 // NewNugetFeedHandler returns a new NugetFeedHandler.
@@ -110,9 +116,10 @@ func NewNugetFeedHandler(creds config.Credentials, client *http.Client) *NugetFe
 			password:  password,
 			proxyOnly: proxyOnly,
 		}
-		if !handler.addStaticCredential(feedCred) {
+		if feedCred.token == "" && feedCred.password == "" {
 			continue
 		}
+		handler.addStaticCredential(feedCred)
 
 		// If the credentials are for a specific feed, we query the base url to find all the resources
 		// and authenticate them all
@@ -127,14 +134,26 @@ func NewNugetFeedHandler(creds config.Credentials, client *http.Client) *NugetFe
 
 	discoveredURLs := discoverNugetFeedURLs(discoveryJobs, client, handler.oidcRegistry)
 	for i, job := range discoveryJobs {
+		for _, redirectURL := range discoveredURLs[i].authenticatedRedirectURLs {
+			if job.oidcCredential != nil {
+				handler.oidcRegistry.RegisterURL(redirectURL, job.oidcCredential, "nuget service-index redirect")
+				continue
+			}
+
+			credential := job.staticCredential
+			credential.url = redirectURL
+			credential.host = ""
+			handler.addStaticCredential(credential)
+		}
+
 		if job.oidcCredential != nil {
-			for _, discoveredURL := range discoveredURLs[i] {
+			for _, discoveredURL := range discoveredURLs[i].resourceURLs {
 				handler.oidcRegistry.RegisterURL(discoveredURL, job.oidcCredential, "nuget resource")
 			}
 			continue
 		}
 
-		for _, discoveredURL := range discoveredURLs[i] {
+		for _, discoveredURL := range discoveredURLs[i].resourceURLs {
 			credential := job.staticCredential
 			credential.url = discoveredURL
 			credential.host = ""
@@ -165,8 +184,8 @@ func discoverNugetFeedURLs(
 	jobs []nugetDiscoveryJob,
 	client *http.Client,
 	oidcRegistry *oidc.OIDCRegistry,
-) [][]string {
-	results := make([][]string, len(jobs))
+) []nugetDiscoveryResult {
+	results := make([]nugetDiscoveryResult, len(jobs))
 	if len(jobs) == 0 {
 		return results
 	}
@@ -196,49 +215,75 @@ func discoverNugetFeedURLsForJob(
 	job nugetDiscoveryJob,
 	client *http.Client,
 	oidcRegistry *oidc.OIDCRegistry,
-) []string {
+) nugetDiscoveryResult {
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, job.serviceIndexURL, nil)
 	if err != nil {
 		logging.RequestLogf(nil, "error creating http request (%s): %v", job.serviceIndexURL, err)
-		return nil
+		return nugetDiscoveryResult{}
 	}
 
 	if job.oidcCredential != nil {
 		if req.URL.Scheme != "https" {
 			logging.RequestLogf(nil, "refusing to discover nuget feed over non-https URL %s", job.serviceIndexURL)
-			return nil
+			return nugetDiscoveryResult{}
 		}
 		if !oidcRegistry.TryAuthCredential(req, nil, job.oidcCredential) {
-			return nil
+			return nugetDiscoveryResult{}
 		}
 	} else {
 		authenticateNugetRequest(req, job.staticCredential, nil)
 	}
 
-	rawRsp, err := client.Do(req)
+	result := nugetDiscoveryResult{}
+	redirectAuthAllowed := true
+	responseURL := req.URL
+	discoveryClient := *client
+	originalCheckRedirect := client.CheckRedirect
+	discoveryClient.CheckRedirect = func(redirectReq *http.Request, via []*http.Request) error {
+		if originalCheckRedirect != nil {
+			if err := originalCheckRedirect(redirectReq, via); err != nil {
+				return err
+			}
+		} else if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+
+		responseURL = redirectReq.URL
+		redirectAuthAllowed = redirectAuthAllowed && sameOrigin(via[len(via)-1].URL, redirectReq.URL)
+		if !redirectAuthAllowed {
+			redirectReq.Header.Del("Authorization")
+			redirectReq.Header.Del("X-Api-Key")
+			return nil
+		}
+		result.authenticatedRedirectURLs = append(result.authenticatedRedirectURLs, redirectReq.URL.String())
+		return nil
+	}
+
+	rawRsp, err := discoveryClient.Do(req)
 	if err != nil {
 		logging.RequestLogf(nil, "error retrieving http response (%s): %v", job.serviceIndexURL, err)
-		return nil
+		return result
 	}
 	defer rawRsp.Body.Close()
 
 	body, err := io.ReadAll(rawRsp.Body)
 	if err != nil {
 		logging.RequestLogf(nil, "error reading http response body (%s): %v", job.serviceIndexURL, err)
-		return nil
+		return result
 	}
 
 	switch rawRsp.StatusCode {
 	case http.StatusUnauthorized, http.StatusForbidden:
 		logging.RequestLogf(nil, "unauthorized for nuget feed %s", job.serviceIndexURL)
-		return nil
+		return result
 	}
 	if rawRsp.StatusCode != http.StatusOK {
 		logging.RequestLogf(nil, "unexpected http response %d for nuget feed %s", rawRsp.StatusCode, job.serviceIndexURL)
-		return nil
+		return result
 	}
 
-	return extraUrlsFromSourceResponse(body, job.serviceIndexURL)
+	result.resourceURLs = extraUrlsFromSourceResponse(body, responseURL.String())
+	return result
 }
 
 func extraUrlsFromSourceResponse(body []byte, url string) []string {

--- a/internal/handlers/nuget_feed.go
+++ b/internal/handlers/nuget_feed.go
@@ -35,8 +35,9 @@ type nugetV3IndexResponse struct {
 
 // NugetFeedHandler handles requests to nuget feeds, adding auth.
 type NugetFeedHandler struct {
-	credentials  []nugetFeedCredentials
-	oidcRegistry *oidc.OIDCRegistry
+	credentials    []nugetFeedCredentials
+	credentialURLs map[string]struct{}
+	oidcRegistry   *oidc.OIDCRegistry
 }
 
 type nugetFeedCredentials struct {
@@ -51,20 +52,20 @@ type nugetFeedCredentials struct {
 const nugetDiscoveryConcurrency = 8
 
 type nugetDiscoveryJob struct {
-	serviceIndexURL     string
-	staticCredential    nugetFeedCredentials
-	staticCredentialSet int
-	oidcCredential      *oidc.OIDCCredential
+	serviceIndexURL  string
+	staticCredential nugetFeedCredentials
+	oidcCredential   *oidc.OIDCCredential
 }
 
 // NewNugetFeedHandler returns a new NugetFeedHandler.
 func NewNugetFeedHandler(creds config.Credentials, client *http.Client) *NugetFeedHandler {
 	handler := NugetFeedHandler{
-		credentials:  []nugetFeedCredentials{},
-		oidcRegistry: oidc.NewOIDCRegistry(client),
+		credentials:    []nugetFeedCredentials{},
+		credentialURLs: make(map[string]struct{}),
+		oidcRegistry:   oidc.NewOIDCRegistry(client),
 	}
-	staticCredentialSets := make([][]nugetFeedCredentials, 0)
 	discoveryJobs := make([]nugetDiscoveryJob, 0)
+	discoverySourceURLs := make(map[string]struct{})
 
 	for _, cred := range creds {
 		if cred["type"] != "nuget_feed" {
@@ -88,10 +89,9 @@ func NewNugetFeedHandler(creds config.Credentials, client *http.Client) *NugetFe
 			oidcCredential, _, ok := handler.oidcRegistry.Register(cred, []string{"url"}, "nuget feed")
 			if ok {
 				if url != "" {
-					discoveryJobs = append(discoveryJobs, nugetDiscoveryJob{
-						serviceIndexURL:     url,
-						staticCredentialSet: -1,
-						oidcCredential:      oidcCredential,
+					addNugetDiscoveryJob(&discoveryJobs, discoverySourceURLs, nugetDiscoveryJob{
+						serviceIndexURL: url,
+						oidcCredential:  oidcCredential,
 					})
 				}
 				continue
@@ -110,17 +110,17 @@ func NewNugetFeedHandler(creds config.Credentials, client *http.Client) *NugetFe
 			password:  password,
 			proxyOnly: proxyOnly,
 		}
-		staticCredentialSet := len(staticCredentialSets)
-		staticCredentialSets = append(staticCredentialSets, []nugetFeedCredentials{feedCred})
+		if !handler.addStaticCredential(feedCred) {
+			continue
+		}
 
 		// If the credentials are for a specific feed, we query the base url to find all the resources
 		// and authenticate them all
 		if !proxyOnly && url != "" {
 			logging.RequestLogf(nil, "fetching service index for nuget feed %s", url)
-			discoveryJobs = append(discoveryJobs, nugetDiscoveryJob{
-				serviceIndexURL:     url,
-				staticCredential:    feedCred,
-				staticCredentialSet: staticCredentialSet,
+			addNugetDiscoveryJob(&discoveryJobs, discoverySourceURLs, nugetDiscoveryJob{
+				serviceIndexURL:  url,
+				staticCredential: feedCred,
 			})
 		}
 	}
@@ -135,23 +135,30 @@ func NewNugetFeedHandler(creds config.Credentials, client *http.Client) *NugetFe
 		}
 
 		for _, discoveredURL := range discoveredURLs[i] {
-			staticCredentialSets[job.staticCredentialSet] = append(
-				staticCredentialSets[job.staticCredentialSet],
-				nugetFeedCredentials{
-					url:      discoveredURL,
-					token:    job.staticCredential.token,
-					username: job.staticCredential.username,
-					password: job.staticCredential.password,
-				},
-			)
-			logging.RequestLogf(nil, "  added url to authentication list: %s", discoveredURL)
+			credential := job.staticCredential
+			credential.url = discoveredURL
+			credential.host = ""
+			if handler.addStaticCredential(credential) {
+				logging.RequestLogf(nil, "  added url to authentication list: %s", discoveredURL)
+			}
 		}
-	}
-	for _, credentialSet := range staticCredentialSets {
-		handler.credentials = append(handler.credentials, credentialSet...)
 	}
 
 	return &handler
+}
+
+func addNugetDiscoveryJob(
+	jobs *[]nugetDiscoveryJob,
+	sourceURLs map[string]struct{},
+	job nugetDiscoveryJob,
+) {
+	key := nugetDiscoverySourceKey(job.serviceIndexURL)
+	if _, ok := sourceURLs[key]; ok {
+		logging.RequestLogf(nil, "skipping duplicate NuGet service index because it is already registered: %s", job.serviceIndexURL)
+		return
+	}
+	sourceURLs[key] = struct{}{}
+	*jobs = append(*jobs, job)
 }
 
 func discoverNugetFeedURLs(
@@ -369,6 +376,51 @@ func (h *NugetFeedHandler) staticCredentialForRequest(req *http.Request, proxyOn
 		return &credential
 	}
 	return nil
+}
+
+func (h *NugetFeedHandler) addStaticCredential(credential nugetFeedCredentials) bool {
+	if credential.token == "" && credential.password == "" {
+		return false
+	}
+
+	if credential.url != "" {
+		key := nugetCredentialURLKey(credential.url)
+		if _, ok := h.credentialURLs[key]; ok {
+			logging.RequestLogf(nil, "skipping duplicate NuGet credential URL because it is already registered: %s", credential.url)
+			return false
+		}
+		h.credentialURLs[key] = struct{}{}
+	}
+	h.credentials = append(h.credentials, credential)
+	return true
+}
+
+func nugetCredentialURLKey(rawURL string) string {
+	parsedURL, err := helpers.ParseURLLax(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	path, ok := helpers.CanonicalPath(parsedURL.EscapedPath())
+	if !ok {
+		return rawURL
+	}
+	port := parsedURL.Port()
+	if port == "" {
+		port = "443"
+	}
+	return strings.ToLower(parsedURL.Hostname()) + ":" + port + path + "?" + parsedURL.RawQuery
+}
+
+func nugetDiscoverySourceKey(rawURL string) string {
+	parsedURL, err := helpers.ParseURLLax(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	scheme := strings.ToLower(parsedURL.Scheme)
+	if scheme == "" {
+		scheme = "*"
+	}
+	return scheme + "|" + nugetCredentialURLKey(rawURL)
 }
 
 func authenticateNugetRequest(req *http.Request, cred nugetFeedCredentials, proxyCtx *goproxy.ProxyCtx) {

--- a/internal/handlers/nuget_feed_test.go
+++ b/internal/handlers/nuget_feed_test.go
@@ -9,9 +9,11 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/elazarl/goproxy"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,6 +26,18 @@ type nugetRoundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f nugetRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+func newTestNugetFeedHandler(credentials config.Credentials) *NugetFeedHandler {
+	return NewNugetFeedHandler(credentials, &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: nugetRoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusNoContent,
+				Body:       http.NoBody,
+			}, nil
+		}),
+	})
 }
 
 func TestNugetFeedHandler(t *testing.T) {
@@ -141,7 +155,7 @@ func TestNugetFeedHandler(t *testing.T) {
 	handler := NewNugetFeedHandler(credentials, testOIDCClient)
 	logContents := buf.String()
 	assert.False(t, strings.Contains(logContents, "* authenticating nuget feed request (host: api.nuget.org, bearer auth)"), "don't authenticate a feed without a token or password")
-	assert.True(t, strings.Contains(logContents, "unauthorized for nuget feed https://nuget.example.com/auth-required/v3"), "authentication failure is reported")
+	assert.NotContains(t, logContents, "https://nuget.example.com/auth-required/v3", "don't query a feed without usable credentials")
 
 	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://corp.dependabot.com/nuget", nil)
 	req = handleRequestAndClose(handler, req, nil)
@@ -405,6 +419,171 @@ func TestNugetFeedHandlerProxyOnlyCredentials(t *testing.T) {
 	}
 }
 
+func TestNugetFeedHandlerPrefersMostSpecificURLCredential(t *testing.T) {
+	broadCredential := config.Credential{
+		"type":  "nuget_feed",
+		"url":   "https://nuget.example.com/feed",
+		"token": "broad-token",
+	}
+	specificCredential := config.Credential{
+		"type":  "nuget_feed",
+		"url":   "https://nuget.example.com/feed/specific",
+		"token": "specific-token",
+	}
+	hostCredential := config.Credential{
+		"type":     "nuget_feed",
+		"host":     "nuget.example.com",
+		"username": "host-user",
+		"password": "host-password",
+	}
+
+	for _, credentials := range []config.Credentials{
+		{broadCredential, specificCredential, hostCredential},
+		{specificCredential, hostCredential, broadCredential},
+	} {
+		handler := newTestNugetFeedHandler(credentials)
+		req := httptest.NewRequestWithContext(
+			t.Context(),
+			http.MethodGet,
+			"https://nuget.example.com/feed/specific/package/index.json",
+			nil,
+		)
+		req = handleRequestAndClose(handler, req, &goproxy.ProxyCtx{})
+		assertHasTokenAuth(t, req, "Bearer", "specific-token", "most specific URL credential")
+	}
+}
+
+func TestNugetFeedHandlerCanonicalURLKeys(t *testing.T) {
+	equivalentEncodedURL := "https://nuget.example.com/f%65ed"
+	equivalentPlainURL := "https://nuget.example.com/feed"
+	encodedSlashURL := "https://nuget.example.com/feed%2fencoded"
+	literalSlashURL := "https://nuget.example.com/feed/encoded"
+
+	assert.Equal(t, nugetCredentialURLKey(equivalentEncodedURL), nugetCredentialURLKey(equivalentPlainURL))
+	assert.Equal(t, nugetDiscoverySourceKey(equivalentEncodedURL), nugetDiscoverySourceKey(equivalentPlainURL))
+	assert.NotEqual(t, nugetCredentialURLKey(encodedSlashURL), nugetCredentialURLKey(literalSlashURL))
+	assert.NotEqual(t, nugetDiscoverySourceKey(encodedSlashURL), nugetDiscoverySourceKey(literalSlashURL))
+
+	equivalentHandler := newTestNugetFeedHandler(config.Credentials{
+		{"type": "nuget_feed", "url": equivalentEncodedURL, "token": "first-token"},
+		{"type": "nuget_feed", "url": equivalentPlainURL, "token": "second-token"},
+	})
+	require.Len(t, equivalentHandler.credentials, 1)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, equivalentPlainURL+"/package/index.json", nil)
+	req = handleRequestAndClose(equivalentHandler, req, &goproxy.ProxyCtx{})
+	assertHasTokenAuth(t, req, "Bearer", "first-token", "first equivalent credential is retained")
+
+	distinctHandler := newTestNugetFeedHandler(config.Credentials{
+		{"type": "nuget_feed", "url": encodedSlashURL, "token": "encoded-token"},
+		{"type": "nuget_feed", "url": literalSlashURL, "token": "literal-token"},
+	})
+	require.Len(t, distinctHandler.credentials, 2)
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, encodedSlashURL+"/package/index.json", nil)
+	req = handleRequestAndClose(distinctHandler, req, &goproxy.ProxyCtx{})
+	assertHasTokenAuth(t, req, "Bearer", "encoded-token", "encoded slash credential")
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, literalSlashURL+"/package/index.json", nil)
+	req = handleRequestAndClose(distinctHandler, req, &goproxy.ProxyCtx{})
+	assertHasTokenAuth(t, req, "Bearer", "literal-token", "literal path separator credential")
+}
+
+func TestNugetFeedHandlerIgnoresUnusableStaticCredentials(t *testing.T) {
+	const credentialURL = "https://nuget.example.com/v3/index.json"
+	unusableCredential := config.Credential{
+		"type": "nuget_feed",
+		"url":  credentialURL,
+	}
+	usableCredential := config.Credential{
+		"type":  "nuget_feed",
+		"url":   credentialURL,
+		"token": "some-token",
+	}
+
+	var discoveryCalls atomic.Int32
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: nugetRoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			discoveryCalls.Add(1)
+			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+		}),
+	}
+	handler := NewNugetFeedHandler(config.Credentials{unusableCredential}, client)
+	assert.Empty(t, handler.credentials)
+	assert.Zero(t, discoveryCalls.Load())
+
+	for _, credentials := range []config.Credentials{
+		{unusableCredential, usableCredential},
+		{usableCredential, unusableCredential},
+	} {
+		handler = newTestNugetFeedHandler(credentials)
+		require.Len(t, handler.credentials, 1)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, credentialURL, nil)
+		req = handleRequestAndClose(handler, req, &goproxy.ProxyCtx{})
+		assertHasTokenAuth(t, req, "Bearer", "some-token", "usable duplicate credential")
+	}
+}
+
+func TestNugetFeedHandlerConfiguredCredentialPrecedesDiscoveredCredential(t *testing.T) {
+	const configuredURL = "https://cdn.example.com/packages"
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: nugetRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Hostname() == "source.example.com" {
+				return nugetDiscoveryResponse(configuredURL), nil
+			}
+			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+		}),
+	}
+	handler := NewNugetFeedHandler(config.Credentials{
+		{"type": "nuget_feed", "url": "https://source.example.com/index.json", "token": "discovery-token"},
+		{"type": "nuget_feed", "url": configuredURL, "token": "configured-token"},
+	}, client)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, configuredURL+"/example/index.json", nil)
+	req = handleRequestAndClose(handler, req, &goproxy.ProxyCtx{})
+	assertHasTokenAuth(t, req, "Bearer", "configured-token", "configured credential")
+}
+
+func TestNugetFeedHandlerUnusableCredentialDoesNotBlockDiscoveredCredential(t *testing.T) {
+	const resourceURL = "https://cdn.example.com/packages"
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: nugetRoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nugetDiscoveryResponse(resourceURL), nil
+		}),
+	}
+	handler := NewNugetFeedHandler(config.Credentials{
+		{"type": "nuget_feed", "url": resourceURL},
+		{"type": "nuget_feed", "url": "https://source.example.com/index.json", "token": "some-token"},
+	}, client)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, resourceURL+"/example/index.json", nil)
+	req = handleRequestAndClose(handler, req, &goproxy.ProxyCtx{})
+	assertHasTokenAuth(t, req, "Bearer", "some-token", "discovered credential replacing unusable entry")
+}
+
+func TestNugetFeedHandlerLogsIgnoredDuplicateResourceURL(t *testing.T) {
+	const resourceURL = "https://shared.example.com/packages"
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: nugetRoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nugetDiscoveryResponse(resourceURL), nil
+		}),
+	}
+	var buf bytes.Buffer
+	testhelpers.CaptureStandardLog(t, &buf)
+	handler := NewNugetFeedHandler(config.Credentials{
+		{"type": "nuget_feed", "url": "https://first.example.com/index.json", "token": "first-token"},
+		{"type": "nuget_feed", "url": "https://second.example.com/index.json", "token": "second-token"},
+	}, client)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, resourceURL+"/example/index.json", nil)
+	req = handleRequestAndClose(handler, req, &goproxy.ProxyCtx{})
+	assertHasTokenAuth(t, req, "Bearer", "first-token", "first credential registered for shared resource")
+	assert.Contains(t, buf.String(), "skipping duplicate NuGet credential URL because it is already registered: "+resourceURL)
+}
+
 func TestNugetFeedHandlerDiscoversFeedsConcurrentlyInCredentialOrder(t *testing.T) {
 	firstRequestStarted := make(chan struct{})
 	secondRequestCompleted := make(chan struct{})
@@ -469,8 +648,8 @@ func TestNugetFeedHandlerDiscoversFeedsConcurrentlyInCredentialOrder(t *testing.
 	require.Len(t, handler.credentials, 4)
 	assert.Equal(t, []string{
 		"https://first.example.com/index.json",
-		"https://first-cdn.example.com/packages",
 		"https://second.example.com/index.json",
+		"https://first-cdn.example.com/packages",
 		"https://second-cdn.example.com/packages",
 	}, []string{
 		handler.credentials[0].url,

--- a/internal/handlers/nuget_feed_test.go
+++ b/internal/handlers/nuget_feed_test.go
@@ -311,17 +311,9 @@ func TestUrlsCanBeDeterminedFromNuGetFeeds(t *testing.T) {
 				]
 			}`,
 			[]string{"https://nuget.example.com/v3/query", "https://nuget.example.com/v3/unknown"}},
-		{"EmptyResponse",
-			"https://nuget.example.com/v3",
-			"",
-			[]string{}},
 		{"WhitespaceResponse",
 			"https://nuget.example.com/v3",
 			" \n\t",
-			[]string{}},
-		{"ShortUnknownResponse",
-			"https://nuget.example.com/v3",
-			"short",
 			[]string{}},
 	}
 	for _, tc := range testCases {
@@ -331,6 +323,16 @@ func TestUrlsCanBeDeterminedFromNuGetFeeds(t *testing.T) {
 			assert.ElementsMatch(t, tc.expectedExtraUrls, actualExtraUrls)
 		})
 	}
+}
+
+func TestExtraUrlsFromSourceResponseHandlesShortUnknownBody(t *testing.T) {
+	assert.NotPanics(t, func() {
+		assert.Empty(t, extraUrlsFromSourceResponse([]byte("x"), "https://nuget.example.com/index.json"))
+	})
+}
+
+func TestExtraUrlsFromSourceResponseHandlesBlankBody(t *testing.T) {
+	assert.Empty(t, extraUrlsFromSourceResponse(nil, "https://nuget.example.com/index.json"))
 }
 
 func TestExtraAuthenticatedURLsAreReportedInTheLog(t *testing.T) {
@@ -373,6 +375,23 @@ func TestExtraAuthenticatedURLsAreReportedInTheLog(t *testing.T) {
 	assert.True(t, strings.Contains(logContents, "  added url to authentication list: https://nuget.example.com/v3/packages"), "include PackageBaseAddress")
 	assert.True(t, strings.Contains(logContents, "  added url to authentication list: https://nuget.example.com/v3/query"), "include SearchQueryService")
 	assert.True(t, strings.Contains(logContents, "  added url to authentication list: https://nuget.example.com/v3/unknown"), "include SomeUnknownServiceTypeButShouldStillBeIncluded")
+}
+
+func TestNewNugetFeedHandlerDiscoversResources(t *testing.T) {
+	const resourceURL = "https://cdn.example.com/packages"
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: nugetRoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nugetDiscoveryResponse(resourceURL), nil
+		}),
+	}
+	handler := NewNugetFeedHandler(config.Credentials{
+		{"type": "nuget_feed", "url": "https://nuget.example.com/index.json", "token": "some-token"},
+	}, client)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, resourceURL+"/example/1.0.0/example.nupkg", nil)
+	req = handleRequestAndClose(handler, req, &goproxy.ProxyCtx{})
+	assertHasTokenAuth(t, req, "Bearer", "some-token", "resource discovered during construction")
 }
 
 func TestNugetFeedHandlerProxyOnlyCredentials(t *testing.T) {
@@ -659,11 +678,189 @@ func TestNugetFeedHandlerDiscoversFeedsConcurrentlyInCredentialOrder(t *testing.
 	})
 }
 
-func TestNugetFeedHandlerOnlyDiscoversFromOKResponses(t *testing.T) {
+func TestNugetFeedHandlerKeepsHTTPAndHTTPSDiscoverySourcesDistinct(t *testing.T) {
+	var httpCalls atomic.Int32
+	var httpsCalls atomic.Int32
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: nugetRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Scheme == "http" {
+				httpCalls.Add(1)
+				return nugetDiscoveryResponse("https://http-cdn.example.com/packages"), nil
+			}
+			httpsCalls.Add(1)
+			return nugetDiscoveryResponse("https://https-cdn.example.com/packages"), nil
+		}),
+	}
+	handler := NewNugetFeedHandler(config.Credentials{
+		{"type": "nuget_feed", "url": "http://nuget.example.com/index.json", "token": "http-token"},
+		{"type": "nuget_feed", "url": "https://nuget.example.com/index.json", "token": "https-token"},
+	}, client)
+
+	assert.Equal(t, int32(1), httpCalls.Load())
+	assert.Equal(t, int32(1), httpsCalls.Load())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://http-cdn.example.com/packages/example/index.json", nil)
+	req = handleRequestAndClose(handler, req, &goproxy.ProxyCtx{})
+	assertHasTokenAuth(t, req, "Bearer", "http-token", "resource discovered from HTTP source")
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://https-cdn.example.com/packages/example/index.json", nil)
+	req = handleRequestAndClose(handler, req, &goproxy.ProxyCtx{})
+	assertHasTokenAuth(t, req, "Bearer", "https-token", "resource discovered from HTTPS source")
+}
+
+func TestNugetFeedHandlerConcurrentDiscoveryIsDeduplicated(t *testing.T) {
+	const sourceCount = 50
+	const resourceURL = "https://shared.example.com/packages"
+	var calls atomic.Int32
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: nugetRoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return nugetDiscoveryResponse(resourceURL), nil
+		}),
+	}
+	credentials := make(config.Credentials, 0, sourceCount)
+	for i := range sourceCount {
+		credentials = append(credentials, config.Credential{
+			"type":  "nuget_feed",
+			"url":   fmt.Sprintf("https://source-%d.example.com/index.json", i),
+			"token": fmt.Sprintf("token-%d", i),
+		})
+	}
+
+	handler := NewNugetFeedHandler(credentials, client)
+
+	assert.Equal(t, int32(sourceCount), calls.Load())
+	require.Len(t, handler.credentials, sourceCount+1)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, resourceURL+"/example/index.json", nil)
+	req = handleRequestAndClose(handler, req, &goproxy.ProxyCtx{})
+	assertHasTokenAuth(t, req, "Bearer", "token-0", "first discovered credential")
+}
+
+func TestNugetFeedHandlerDiscoversThroughCrossOriginRedirectWithoutLeakingCredentials(t *testing.T) {
+	const resourceURL = "https://cdn.example.com/packages"
+	var firstRedirectAuth string
+	var finalRedirectAuth string
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: nugetRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			switch {
+			case req.URL.Hostname() == "nuget.example.com":
+				return nugetRedirectResponse("https://redirect.example.com/index.json"), nil
+			case req.URL.Path == "/index.json":
+				firstRedirectAuth = req.Header.Get("Authorization")
+				return nugetRedirectResponse("/v3/index.json"), nil
+			case req.URL.Path == "/v3/index.json":
+				finalRedirectAuth = req.Header.Get("Authorization")
+				return nugetDiscoveryResponse(resourceURL), nil
+			default:
+				return nil, fmt.Errorf("unexpected discovery URL %s", req.URL)
+			}
+		}),
+	}
+	handler := NewNugetFeedHandler(config.Credentials{
+		{"type": "nuget_feed", "url": "https://nuget.example.com/index.json", "token": "some-token"},
+	}, client)
+
+	assert.Empty(t, firstRedirectAuth)
+	assert.Empty(t, finalRedirectAuth)
+	for _, redirectURL := range []string{
+		"https://redirect.example.com/index.json",
+		"https://redirect.example.com/v3/index.json",
+	} {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, redirectURL, nil)
+		req = handleRequestAndClose(handler, req, &goproxy.ProxyCtx{})
+		assertUnauthenticated(t, req, "cross-origin service-index redirect")
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, resourceURL+"/example/index.json", nil)
+	req = handleRequestAndClose(handler, req, &goproxy.ProxyCtx{})
+	assertHasTokenAuth(t, req, "Bearer", "some-token", "resource discovered after cross-origin redirect")
+}
+
+func TestNugetFeedHandlerAuthenticatesSameOriginServiceIndexRedirect(t *testing.T) {
+	testCases := []struct {
+		name          string
+		configuredURL string
+		location      string
+		redirectURL   string
+	}{
+		{
+			name:          "absolute path",
+			configuredURL: "https://nuget.example.com/index.json",
+			location:      "/v3/index.json",
+			redirectURL:   "https://nuget.example.com/v3/index.json",
+		},
+		{
+			name:          "relative path",
+			configuredURL: "https://nuget.example.com/feed/index.json",
+			location:      "v3/index.json",
+			redirectURL:   "https://nuget.example.com/feed/v3/index.json",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			const resourceURL = "https://cdn.example.com/packages"
+			var redirectAuth string
+			client := &http.Client{
+				Timeout: 5 * time.Second,
+				Transport: nugetRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					if req.URL.String() == testCase.configuredURL {
+						return nugetRedirectResponse(testCase.location), nil
+					}
+					if req.URL.String() == testCase.redirectURL {
+						redirectAuth = req.Header.Get("Authorization")
+						return nugetDiscoveryResponse(resourceURL), nil
+					}
+					return nil, fmt.Errorf("unexpected discovery URL %s", req.URL)
+				}),
+			}
+			handler := NewNugetFeedHandler(config.Credentials{
+				{"type": "nuget_feed", "url": testCase.configuredURL, "token": "some-token"},
+			}, client)
+
+			assert.Equal(t, "Bearer some-token", redirectAuth)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, testCase.redirectURL, nil)
+			req = handleRequestAndClose(handler, req, &goproxy.ProxyCtx{})
+			assertHasTokenAuth(t, req, "Bearer", "some-token", "same-origin service-index redirect")
+		})
+	}
+}
+
+func TestNugetFeedHandlerResolvesRelativeRedirectAgainstConfiguredServiceIndexURL(t *testing.T) {
+	const configuredURL = "https://nuget.example.com/feed/index.json"
+	const redirectURL = "https://nuget.example.com/feed/next.json"
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: nugetRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() == configuredURL {
+				return nugetRedirectResponse("next.json"), nil
+			}
+			if req.URL.String() == redirectURL {
+				return nugetDiscoveryResponse("https://cdn.example.com/packages"), nil
+			}
+			return nil, fmt.Errorf("unexpected discovery URL %s", req.URL)
+		}),
+	}
+	handler := NewNugetFeedHandler(config.Credentials{
+		{"type": "nuget_feed", "url": configuredURL, "token": "some-token"},
+	}, client)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, redirectURL, nil)
+	req = handleRequestAndClose(handler, req, &goproxy.ProxyCtx{})
+	assertHasTokenAuth(t, req, "Bearer", "some-token", "relative service-index redirect")
+}
+
+func TestNugetFeedHandlerSkipsDiscoveryFromUnsuccessfulResponse(t *testing.T) {
 	for _, statusCode := range []int{
+		http.StatusUnauthorized,
+		http.StatusForbidden,
 		http.StatusNoContent,
 		http.StatusResetContent,
 		http.StatusFound,
+		http.StatusInternalServerError,
 	} {
 		t.Run(http.StatusText(statusCode), func(t *testing.T) {
 			client := &http.Client{
@@ -686,6 +883,14 @@ func TestNugetFeedHandlerOnlyDiscoversFromOKResponses(t *testing.T) {
 			require.Len(t, handler.credentials, 1)
 			assert.Equal(t, "https://nuget.example.com/index.json", handler.credentials[0].url)
 		})
+	}
+}
+
+func nugetRedirectResponse(location string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusTemporaryRedirect,
+		Header:     http.Header{"Location": []string{location}},
+		Body:       http.NoBody,
 	}
 }
 

--- a/internal/handlers/nuget_feed_test.go
+++ b/internal/handlers/nuget_feed_test.go
@@ -2,17 +2,12 @@ package handlers
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
-	"sync"
 	"testing"
 
-	"github.com/elazarl/goproxy"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,6 +62,9 @@ func TestNugetFeedHandler(t *testing.T) {
 		},
 	}
 
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
 	rsp := nugetV3IndexResponse{
 		Resource: []nugetV3IndexResource{
 			{
@@ -84,6 +82,10 @@ func TestNugetFeedHandler(t *testing.T) {
 		},
 	}
 
+	jsonResponder, err := httpmock.NewJsonResponder(200, rsp)
+	require.NoError(t, err)
+	httpmock.RegisterResponder("GET", "https://corp.dependabot.com/nuget/", jsonResponder)
+
 	xmlResponse := `
 <service xmlns="http://www.w3.org/2007/app" xmlns:atom="http://www.w3.org/2005/Atom" xml:base="https://redirected.example.com/v2">
   <workspace>
@@ -93,6 +95,9 @@ func TestNugetFeedHandler(t *testing.T) {
   </workspace>
 </service>
 `
+	xmlResponder := httpmock.NewStringResponder(200, xmlResponse)
+	httpmock.RegisterResponder("GET", "https://nuget.example.com/v2", xmlResponder)
+	httpmock.RegisterResponder("GET", "https://nuget.example.com/auth-required/v3", httpmock.NewStringResponder(401, "missing authentication"))
 
 	azureDevOpsRsp := nugetV3IndexResponse{
 		Resource: []nugetV3IndexResource{
@@ -103,6 +108,10 @@ func TestNugetFeedHandler(t *testing.T) {
 		},
 	}
 
+	azureDevOpsJsonResponder, err := httpmock.NewJsonResponder(200, azureDevOpsRsp)
+	require.NoError(t, err)
+	httpmock.RegisterResponder("GET", "https://pkgs.dev.azure.com/example/public/_packaging/some-feed/nuget/v3/index.json", azureDevOpsJsonResponder)
+
 	azureDevOpsRsp2 := nugetV3IndexResponse{
 		Resource: []nugetV3IndexResource{
 			{
@@ -112,14 +121,17 @@ func TestNugetFeedHandler(t *testing.T) {
 		},
 	}
 
+	azureDevOpsJsonResponder2, err := httpmock.NewJsonResponder(200, azureDevOpsRsp2)
+	require.NoError(t, err)
+	httpmock.RegisterResponder("GET", "https://pkgs.dev.azure.com/example/public/_packaging/some-feed2/nuget/v3/index.json", azureDevOpsJsonResponder2)
+
+	// Log for initial authentication contains appropriate information
 	var buf bytes.Buffer
 	testhelpers.CaptureStandardLog(t, &buf)
-	handler := newTestNugetFeedHandler(credentials)
-
-	discoverNugetFeed(t, handler, "https://corp.dependabot.com/nuget/", http.StatusOK, mustMarshalJSON(t, rsp))
-	discoverNugetFeed(t, handler, "https://nuget.example.com/v2", http.StatusOK, xmlResponse)
-	discoverNugetFeed(t, handler, "https://pkgs.dev.azure.com/example/public/_packaging/some-feed/nuget/v3/index.json", http.StatusOK, mustMarshalJSON(t, azureDevOpsRsp))
-	discoverNugetFeed(t, handler, "https://pkgs.dev.azure.com/example/public/_packaging/some-feed2/nuget/v3/index.json", http.StatusOK, mustMarshalJSON(t, azureDevOpsRsp2))
+	handler := NewNugetFeedHandler(credentials, testOIDCClient)
+	logContents := buf.String()
+	assert.False(t, strings.Contains(logContents, "* authenticating nuget feed request (host: api.nuget.org, bearer auth)"), "don't authenticate a feed without a token or password")
+	assert.True(t, strings.Contains(logContents, "unauthorized for nuget feed https://nuget.example.com/auth-required/v3"), "authentication failure is reported")
 
 	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://corp.dependabot.com/nuget", nil)
 	req = handleRequestAndClose(handler, req, nil)
@@ -194,7 +206,7 @@ func TestNugetFeedHandler(t *testing.T) {
 	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://pkgs.dev.azure.com/example/public/_packaging/some-feed/nuget/v3/some.package/index.json", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, "", dependabotToken, "Azure DevOps token handling")
-	logContents := buf.String()
+	logContents = buf.String()
 	assert.True(t, strings.Contains(logContents, ", basic auth for Azure DevOps)"), "expected Azure DevOps token handling")
 
 	// Check Azure token edge case in which it has a prepended ":" and is treated as a password successfully
@@ -294,6 +306,9 @@ func TestExtraAuthenticatedURLsAreReportedInTheLog(t *testing.T) {
 		},
 	}
 
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
 	jsonResponse := `{
 		"version": "3.0.0",
 		"resources": [
@@ -311,11 +326,12 @@ func TestExtraAuthenticatedURLsAreReportedInTheLog(t *testing.T) {
 			}
 		]
 	}`
+	jsonResponder := httpmock.NewStringResponder(200, jsonResponse)
+	httpmock.RegisterResponder("GET", "https://nuget.example.com/index.json", jsonResponder)
 
 	var buf bytes.Buffer
 	testhelpers.CaptureStandardLog(t, &buf)
-	handler := newTestNugetFeedHandler(credentials)
-	discoverNugetFeed(t, handler, "https://nuget.example.com/index.json", http.StatusOK, jsonResponse)
+	NewNugetFeedHandler(credentials, testOIDCClient)
 	logContents := buf.String()
 
 	assert.True(t, strings.Contains(logContents, "  added url to authentication list: https://nuget.example.com/v3/packages"), "include PackageBaseAddress")
@@ -323,326 +339,8 @@ func TestExtraAuthenticatedURLsAreReportedInTheLog(t *testing.T) {
 	assert.True(t, strings.Contains(logContents, "  added url to authentication list: https://nuget.example.com/v3/unknown"), "include SomeUnknownServiceTypeButShouldStillBeIncluded")
 }
 
-func TestNewNugetFeedHandlerDoesNotMakeHTTPRequests(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-
-	newTestNugetFeedHandler(config.Credentials{
-		testNugetFeedCredential("https://unreachable.example.com/index.json", "some-token"),
-	})
-
-	assert.Zero(t, httpmock.GetTotalCallCount())
-}
-
-func TestNugetFeedHandlerDiscoversFromPreparedResponse(t *testing.T) {
-	handler := newTestNugetFeedHandler(config.Credentials{
-		testNugetFeedCredential("https://nuget.example.com/index.json", "some-token"),
-	})
-	discoverNugetFeed(t, handler, "https://nuget.example.com/index.json", http.StatusOK,
-		nugetV3Response("https://cdn.example.com/packages"))
-
-	packageReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://cdn.example.com/packages/example/1.0.0/example.nupkg", nil)
-	packageReq = handleRequestAndClose(handler, packageReq, &goproxy.ProxyCtx{})
-	assertHasTokenAuth(t, packageReq, "Bearer", "some-token", "resource learned from prepared response")
-}
-
-func TestNugetFeedHandlerSkipsDiscoveryFromUnsuccessfulResponse(t *testing.T) {
-	handler := newTestNugetFeedHandler(config.Credentials{
-		testNugetFeedCredential("https://nuget.example.com/index.json", "some-token"),
-	})
-	discoverNugetFeed(t, handler, "https://nuget.example.com/index.json", http.StatusUnauthorized,
-		nugetV3Response("https://cdn.example.com/packages"))
-
-	packageReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://cdn.example.com/packages/example/index.json", nil)
-	packageReq = handleRequestAndClose(handler, packageReq, &goproxy.ProxyCtx{})
-	assertUnauthenticated(t, packageReq, "resource from unsuccessful response")
-}
-
-func TestNugetFeedHandlerLeavesBodylessResponseUnchanged(t *testing.T) {
-	handler := newTestNugetFeedHandler(config.Credentials{
-		testNugetFeedCredential("https://nuget.example.com/index.json", "some-token"),
-	})
-
-	for _, statusCode := range []int{http.StatusNoContent, http.StatusResetContent} {
-		proxyCtx := &goproxy.ProxyCtx{}
-		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.example.com/index.json", nil)
-		prepareRequestAndClose(handler, req, proxyCtx)
-		resp := &http.Response{StatusCode: statusCode, Body: http.NoBody}
-
-		resp = handler.HandleResponse(resp, proxyCtx)
-
-		assert.True(t, resp.Body == http.NoBody)
-		require.NoError(t, resp.Body.Close())
-	}
-}
-
-func TestNugetFeedHandlerReplaysBodyAfterReadError(t *testing.T) {
-	handler := newTestNugetFeedHandler(config.Credentials{
-		testNugetFeedCredential("https://nuget.example.com/index.json", "some-token"),
-	})
-	proxyCtx := &goproxy.ProxyCtx{}
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.example.com/index.json", nil)
-	prepareRequestAndClose(handler, req, proxyCtx)
-	originalBody := &readErrorThenData{
-		first: []byte("first"),
-		rest:  strings.NewReader("second"),
-	}
-	resp := &http.Response{StatusCode: http.StatusOK, Body: originalBody}
-
-	resp = handler.HandleResponse(resp, proxyCtx)
-	replayed, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	assert.Equal(t, "firstsecond", string(replayed))
-	require.NoError(t, resp.Body.Close())
-}
-
-func TestNugetFeedHandlerOnlyDiscoversFromConfiguredServiceIndex(t *testing.T) {
-	handler := newTestNugetFeedHandler(config.Credentials{
-		testNugetFeedCredential("https://nuget.example.com/v3/", "some-token"),
-	})
-	proxyCtx := &goproxy.ProxyCtx{}
-	packageReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.example.com/v3/some-package/index.json", nil)
-	prepareRequestAndClose(handler, packageReq, proxyCtx)
-
-	resp := &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(strings.NewReader(nugetV3Response("https://untrusted.example.com/packages"))),
-	}
-	handleResponseAndClose(handler, resp, proxyCtx)
-
-	untrustedReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://untrusted.example.com/packages/example/index.json", nil)
-	untrustedReq = handleRequestAndClose(handler, untrustedReq, &goproxy.ProxyCtx{})
-	assertUnauthenticated(t, untrustedReq, "resource from non-index response")
-}
-
-func TestNugetFeedHandlerRequiresConfiguredServiceIndexSchemeForDiscovery(t *testing.T) {
-	testCases := []struct {
-		name              string
-		configuredURL     string
-		requestedURL      string
-		expectCredentials bool
-	}{
-		{
-			name:              "HTTPS source does not trust HTTP response",
-			configuredURL:     "https://nuget.example.com/v3/index.json",
-			requestedURL:      "http://nuget.example.com/v3/index.json",
-			expectCredentials: false,
-		},
-		{
-			name:              "HTTP source does not trust HTTPS response",
-			configuredURL:     "http://nuget.example.com/v3/index.json",
-			requestedURL:      "https://nuget.example.com/v3/index.json",
-			expectCredentials: false,
-		},
-		{
-			name:              "scheme-less source trusts HTTP response",
-			configuredURL:     "nuget.example.com/v3/index.json",
-			requestedURL:      "http://nuget.example.com/v3/index.json",
-			expectCredentials: true,
-		},
-		{
-			name:              "scheme-less source trusts HTTPS response",
-			configuredURL:     "nuget.example.com/v3/index.json",
-			requestedURL:      "https://nuget.example.com/v3/index.json",
-			expectCredentials: true,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			handler := newTestNugetFeedHandler(config.Credentials{
-				testNugetFeedCredential(testCase.configuredURL, "some-token"),
-			})
-			proxyCtx := &goproxy.ProxyCtx{}
-			indexReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, testCase.requestedURL, nil)
-			prepareRequestAndClose(handler, indexReq, proxyCtx)
-			handleResponseAndClose(handler, &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader(nugetV3Response("https://attacker.example.com/packages"))),
-			}, proxyCtx)
-
-			packageReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://attacker.example.com/packages/example/index.json", nil)
-			packageReq = handleRequestAndClose(handler, packageReq, &goproxy.ProxyCtx{})
-			if testCase.expectCredentials {
-				assertHasTokenAuth(t, packageReq, "Bearer", "some-token", "resource from scheme-less service index")
-			} else {
-				assertUnauthenticated(t, packageReq, "resource from mismatched service-index scheme")
-			}
-		})
-	}
-}
-
-func TestNugetFeedHandlerKeepsHTTPAndHTTPSDiscoverySourcesDistinct(t *testing.T) {
-	httpCredential := testNugetFeedCredential("http://nuget.example.com/v3/index.json", "http-token")
-	httpsCredential := testNugetFeedCredential("https://nuget.example.com/v3/index.json", "https-token")
-
-	for _, credentials := range []config.Credentials{
-		{httpCredential, httpsCredential},
-		{httpsCredential, httpCredential},
-	} {
-		handler := newTestNugetFeedHandler(credentials)
-		discoverNugetFeed(t, handler, "http://nuget.example.com/v3/index.json", http.StatusOK,
-			nugetV3Response("https://http-resource.example.com/packages"))
-		discoverNugetFeed(t, handler, "https://nuget.example.com/v3/index.json", http.StatusOK,
-			nugetV3Response("https://https-resource.example.com/packages"))
-
-		httpResourceReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://http-resource.example.com/packages/example/index.json", nil)
-		httpResourceReq = handleRequestAndClose(handler, httpResourceReq, &goproxy.ProxyCtx{})
-		assertHasTokenAuth(t, httpResourceReq, "Bearer", "http-token", "resource discovered from HTTP index")
-
-		httpsResourceReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://https-resource.example.com/packages/example/index.json", nil)
-		httpsResourceReq = handleRequestAndClose(handler, httpsResourceReq, &goproxy.ProxyCtx{})
-		assertHasTokenAuth(t, httpsResourceReq, "Bearer", "https-token", "resource discovered from HTTPS index")
-	}
-}
-
-func TestNugetFeedHandlerConcurrentDiscoveryIsDeduplicated(t *testing.T) {
-	handler := newTestNugetFeedHandler(config.Credentials{
-		testNugetFeedCredential("https://nuget.example.com/index.json", "some-token"),
-	})
-	const workers = 50
-	responseBody := nugetV3Response("https://cdn.example.com/packages")
-	start := make(chan struct{})
-	ctx := t.Context()
-	var waitGroup sync.WaitGroup
-	for range workers {
-		waitGroup.Add(1)
-		go func() {
-			defer waitGroup.Done()
-			<-start
-			proxyCtx := &goproxy.ProxyCtx{}
-			indexReq := httptest.NewRequestWithContext(ctx, http.MethodGet, "https://nuget.example.com/index.json", nil)
-			indexReq = prepareRequestAndClose(handler, indexReq, proxyCtx)
-			handleRequestAndClose(handler, indexReq, proxyCtx)
-			resp := &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader(responseBody)),
-			}
-			resp = handler.HandleResponse(resp, proxyCtx)
-			if err := resp.Body.Close(); err != nil {
-				panic(err)
-			}
-
-			packageReq := httptest.NewRequestWithContext(ctx, http.MethodGet, "https://cdn.example.com/packages/example/index.json", nil)
-			handleRequestAndClose(handler, packageReq, &goproxy.ProxyCtx{})
-		}()
-	}
-	close(start)
-	waitGroup.Wait()
-
-	handler.credentialsMutex.RLock()
-	defer handler.credentialsMutex.RUnlock()
-	assert.Len(t, handler.credentials, 2)
-}
-
-func TestNugetFeedHandlerCanonicalURLKeys(t *testing.T) {
-	equivalentEncodedURL := "https://nuget.example.com/f%65ed"
-	equivalentPlainURL := "https://nuget.example.com/feed"
-	encodedSlashURL := "https://nuget.example.com/feed%2fencoded"
-	literalSlashURL := "https://nuget.example.com/feed/encoded"
-
-	assert.Equal(t, nugetCredentialURLKey(equivalentEncodedURL), nugetCredentialURLKey(equivalentPlainURL))
-	assert.Equal(t, nugetDiscoverySourceKey(equivalentEncodedURL), nugetDiscoverySourceKey(equivalentPlainURL))
-	assert.NotEqual(t, nugetCredentialURLKey(encodedSlashURL), nugetCredentialURLKey(literalSlashURL))
-	assert.NotEqual(t, nugetDiscoverySourceKey(encodedSlashURL), nugetDiscoverySourceKey(literalSlashURL))
-
-	equivalentHandler := newTestNugetFeedHandler(config.Credentials{
-		testNugetFeedCredential(equivalentEncodedURL, "first-token"),
-		testNugetFeedCredential(equivalentPlainURL, "second-token"),
-	})
-	assert.Len(t, equivalentHandler.credentials, 1, "equivalent encodings deduplicate first-wins")
-	assert.Len(t, equivalentHandler.discoverySources, 1, "equivalent discovery sources deduplicate")
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, equivalentPlainURL+"/package/index.json", nil)
-	req = handleRequestAndClose(equivalentHandler, req, &goproxy.ProxyCtx{})
-	assertHasTokenAuth(t, req, "Bearer", "first-token", "first equivalent credential is retained")
-
-	distinctHandler := newTestNugetFeedHandler(config.Credentials{
-		testNugetFeedCredential(encodedSlashURL, "encoded-token"),
-		testNugetFeedCredential(literalSlashURL, "literal-token"),
-	})
-	assert.Len(t, distinctHandler.credentials, 2, "encoded slash remains distinct from a path separator")
-	assert.Len(t, distinctHandler.discoverySources, 2, "distinct paths retain separate discovery sources")
-
-	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, encodedSlashURL+"/package/index.json", nil)
-	req = handleRequestAndClose(distinctHandler, req, &goproxy.ProxyCtx{})
-	assertHasTokenAuth(t, req, "Bearer", "encoded-token", "encoded slash credential")
-
-	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, literalSlashURL+"/package/index.json", nil)
-	req = handleRequestAndClose(distinctHandler, req, &goproxy.ProxyCtx{})
-	assertHasTokenAuth(t, req, "Bearer", "literal-token", "literal path separator credential")
-}
-
-func TestNugetFeedHandlerIgnoresUnusableStaticCredentials(t *testing.T) {
-	usableCredential := testNugetFeedCredential("https://nuget.example.com/v3/index.json", "some-token")
-	unusableCredential := config.Credential{
-		"type": "nuget_feed",
-		"url":  "https://nuget.example.com/v3/index.json",
-	}
-
-	for _, credentials := range []config.Credentials{
-		{unusableCredential, usableCredential},
-		{usableCredential, unusableCredential},
-	} {
-		handler := newTestNugetFeedHandler(credentials)
-		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.example.com/v3/index.json", nil)
-		req = handleRequestAndClose(handler, req, &goproxy.ProxyCtx{})
-		assertHasTokenAuth(t, req, "Bearer", "some-token", "usable duplicate credential")
-	}
-}
-
-func TestNugetFeedHandlerLogsIgnoredDuplicateResourceURL(t *testing.T) {
-	var buf bytes.Buffer
-	testhelpers.CaptureStandardLog(t, &buf)
-	handler := newTestNugetFeedHandler(config.Credentials{
-		testNugetFeedCredential("https://first.example.com/index.json", "first-token"),
-		testNugetFeedCredential("https://second.example.com/index.json", "second-token"),
-	})
-
-	const resourceURL = "https://shared.example.com/packages"
-	discoverNugetFeed(t, handler, "https://first.example.com/index.json", http.StatusOK, nugetV3Response(resourceURL))
-	discoverNugetFeed(t, handler, "https://second.example.com/index.json", http.StatusOK, nugetV3Response(resourceURL))
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, resourceURL+"/example/index.json", nil)
-	req = handleRequestAndClose(handler, req, &goproxy.ProxyCtx{})
-	assertHasTokenAuth(t, req, "Bearer", "first-token", "first credential registered for shared resource")
-	assert.Contains(t, buf.String(), "skipping duplicate NuGet credential URL because it is already registered: "+resourceURL)
-}
-
-func TestNugetFeedHandlerUnusableCredentialDoesNotBlockDiscoveredCredential(t *testing.T) {
-	handler := newTestNugetFeedHandler(config.Credentials{
-		config.Credential{
-			"type": "nuget_feed",
-			"url":  "https://cdn.example.com/packages",
-		},
-		testNugetFeedCredential("https://nuget.example.com/v3/index.json", "some-token"),
-	})
-	discoverNugetFeed(t, handler, "https://nuget.example.com/v3/index.json", http.StatusOK,
-		nugetV3Response("https://cdn.example.com/packages"))
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://cdn.example.com/packages/example/index.json", nil)
-	req = handleRequestAndClose(handler, req, &goproxy.ProxyCtx{})
-	assertHasTokenAuth(t, req, "Bearer", "some-token", "discovered credential replacing unusable entry")
-}
-
-func TestNugetFeedHandlerPrefersMostSpecificURLCredential(t *testing.T) {
-	handler := newTestNugetFeedHandler(config.Credentials{
-		testNugetFeedCredential("https://nuget.example.com/feed", "broad-token"),
-		testNugetFeedCredential("https://nuget.example.com/feed/specific", "specific-token"),
-		config.Credential{
-			"type":     "nuget_feed",
-			"host":     "nuget.example.com",
-			"username": "host-user",
-			"password": "host-password",
-		},
-	})
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.example.com/feed/specific/package/index.json", nil)
-	req = handleRequestAndClose(handler, req, &goproxy.ProxyCtx{})
-	assertHasTokenAuth(t, req, "Bearer", "specific-token", "most specific URL credential")
-}
-
 func TestNugetFeedHandlerProxyOnlyCredentials(t *testing.T) {
-	handler := newTestNugetFeedHandler(config.Credentials{
+	handler := NewNugetFeedHandler(config.Credentials{
 		{
 			"type":       "nuget_feed",
 			"host":       "nuget.pkg.github.com",
@@ -655,25 +353,23 @@ func TestNugetFeedHandlerProxyOnlyCredentials(t *testing.T) {
 			"url":   "https://nuget.pkg.github.com/dependabot/index.json",
 			"token": "explicit-token",
 		},
-	})
+	}, testOIDCClient)
 
-	assert.Len(t, handler.discoverySources, 1, "proxy-only credentials do not create discovery sources")
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.pkg.github.com/other/package/index.json", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "https://nuget.pkg.github.com/other/package/index.json", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, "x-access-token", "automatic-token", "host-only automatic credential")
 
-	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.pkg.github.com/other/package/index.json", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://nuget.pkg.github.com/other/package/index.json", nil)
 	req.Header.Set("Authorization", authorizationPlaceholder)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasBasicAuth(t, req, "x-access-token", "automatic-token", "automatic credential replaces placeholder auth")
 
-	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.pkg.github.com/other/package/index.json", nil)
-	req.Header.Set("Authorization", "Bearer caller-token")
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://nuget.pkg.github.com/other/package/index.json", nil)
+	req.Header.Set("Authorization", "existing-token")
 	req = handleRequestAndClose(handler, req, nil)
-	assert.Equal(t, "Bearer caller-token", req.Header.Get("Authorization"), "automatic credential preserves request auth")
+	assert.Equal(t, "existing-token", req.Header.Get("Authorization"), "automatic credential preserves request auth")
 
-	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.pkg.github.com/dependabot/index.json", nil)
+	req = httptest.NewRequestWithContext(t.Context(), "GET", "https://nuget.pkg.github.com/dependabot/index.json", nil)
 	req = handleRequestAndClose(handler, req, nil)
 	assertHasTokenAuth(t, req, "Bearer", "explicit-token", "path-specific explicit credential")
 
@@ -681,190 +377,8 @@ func TestNugetFeedHandlerProxyOnlyCredentials(t *testing.T) {
 		"http://nuget.pkg.github.com/other/package/index.json",
 		"https://nuget.pkg.github.com:8443/other/package/index.json",
 	} {
-		req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, requestURL, nil)
+		req = httptest.NewRequestWithContext(t.Context(), "GET", requestURL, nil)
 		req = handleRequestAndClose(handler, req, nil)
 		assertUnauthenticated(t, req, "automatic credential destination safety")
 	}
-
-	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.pkg.github.example/other/package/index.json", nil)
-	req = handleRequestAndClose(handler, req, nil)
-	assertUnauthenticated(t, req, "automatic credential host mismatch")
-}
-
-func TestNugetFeedHandlerDiscoversThroughCrossOriginRedirectWithoutLeakingCredentials(t *testing.T) {
-	handler := newTestNugetFeedHandler(config.Credentials{
-		testNugetFeedCredential("https://nuget.example.com/index.json", "some-token"),
-	})
-
-	initialCtx := &goproxy.ProxyCtx{}
-	initialReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.example.com/index.json", nil)
-	initialReq = prepareRequestAndClose(handler, initialReq, initialCtx)
-	initialReq = handleRequestAndClose(handler, initialReq, initialCtx)
-	assertHasTokenAuth(t, initialReq, "Bearer", "some-token", "configured service index")
-	handleResponseAndClose(handler, &http.Response{
-		StatusCode: http.StatusFound,
-		Header:     http.Header{"Location": []string{"https://redirect.example.com/index.json"}},
-	}, initialCtx)
-
-	redirectCtx := &goproxy.ProxyCtx{}
-	redirectReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://redirect.example.com/index.json", nil)
-	redirectReq = prepareRequestAndClose(handler, redirectReq, redirectCtx)
-	redirectReq = handleRequestAndClose(handler, redirectReq, redirectCtx)
-	assertUnauthenticated(t, redirectReq, "cross-origin service-index redirect")
-	handleResponseAndClose(handler, &http.Response{
-		StatusCode: http.StatusTemporaryRedirect,
-		Header:     http.Header{"Location": []string{"/v3/index.json"}},
-	}, redirectCtx)
-
-	finalCtx := &goproxy.ProxyCtx{}
-	finalReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://redirect.example.com/v3/index.json", nil)
-	finalReq = prepareRequestAndClose(handler, finalReq, finalCtx)
-	finalReq = handleRequestAndClose(handler, finalReq, finalCtx)
-	assertUnauthenticated(t, finalReq, "redirect after cross-origin service-index redirect")
-	finalResp := &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(strings.NewReader(nugetV3Response("https://cdn.example.com/packages"))),
-	}
-	handleResponseAndClose(handler, finalResp, finalCtx)
-
-	packageReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://cdn.example.com/packages/example/index.json", nil)
-	packageReq = handleRequestAndClose(handler, packageReq, &goproxy.ProxyCtx{})
-	assertHasTokenAuth(t, packageReq, "Bearer", "some-token", "resource learned through cross-origin redirect")
-}
-
-func TestNugetFeedHandlerAuthenticatesSameOriginServiceIndexRedirect(t *testing.T) {
-	handler := newTestNugetFeedHandler(config.Credentials{
-		testNugetFeedCredential("https://nuget.example.com/index.json", "some-token"),
-	})
-
-	initialCtx := &goproxy.ProxyCtx{}
-	initialReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.example.com/index.json", nil)
-	initialReq = prepareRequestAndClose(handler, initialReq, initialCtx)
-	handleRequestAndClose(handler, initialReq, initialCtx)
-	handleResponseAndClose(handler, &http.Response{
-		StatusCode: http.StatusTemporaryRedirect,
-		Header:     http.Header{"Location": []string{"/v3/index.json"}},
-	}, initialCtx)
-
-	redirectReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://nuget.example.com/v3/index.json", nil)
-	redirectReq = handleRequestAndClose(handler, redirectReq, &goproxy.ProxyCtx{})
-	assertHasTokenAuth(t, redirectReq, "Bearer", "some-token", "same-origin service-index redirect")
-}
-
-func TestNugetFeedHandlerResolvesRelativeRedirectAgainstRequestedServiceIndexURL(t *testing.T) {
-	testCases := []struct {
-		name          string
-		configuredURL string
-		requestedURL  string
-		redirectURL   string
-	}{
-		{
-			name:          "configured URL has trailing slash",
-			configuredURL: "https://nuget.example.com/v3/",
-			requestedURL:  "https://nuget.example.com/v3",
-			redirectURL:   "https://nuget.example.com/next.json",
-		},
-		{
-			name:          "requested URL has trailing slash",
-			configuredURL: "https://nuget.example.com/v3",
-			requestedURL:  "https://nuget.example.com/v3/",
-			redirectURL:   "https://nuget.example.com/v3/next.json",
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			handler := newTestNugetFeedHandler(config.Credentials{
-				testNugetFeedCredential(testCase.configuredURL, "some-token"),
-			})
-
-			initialCtx := &goproxy.ProxyCtx{}
-			initialReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, testCase.requestedURL, nil)
-			prepareRequestAndClose(handler, initialReq, initialCtx)
-			handleResponseAndClose(handler, &http.Response{
-				StatusCode: http.StatusTemporaryRedirect,
-				Header:     http.Header{"Location": []string{"next.json"}},
-			}, initialCtx)
-
-			redirectCtx := &goproxy.ProxyCtx{}
-			redirectReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, testCase.redirectURL, nil)
-			prepareRequestAndClose(handler, redirectReq, redirectCtx)
-			handleResponseAndClose(handler, &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader(nugetV3Response("https://cdn.example.com/packages"))),
-			}, redirectCtx)
-
-			packageReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://cdn.example.com/packages/example/index.json", nil)
-			packageReq = handleRequestAndClose(handler, packageReq, &goproxy.ProxyCtx{})
-			assertHasTokenAuth(t, packageReq, "Bearer", "some-token", "resource learned through relative redirect")
-		})
-	}
-}
-
-func TestExtraUrlsFromSourceResponseHandlesShortUnknownBody(t *testing.T) {
-	assert.NotPanics(t, func() {
-		assert.Empty(t, extraUrlsFromSourceResponse([]byte("x"), "https://nuget.example.com/index.json"))
-	})
-}
-
-func TestExtraUrlsFromSourceResponseHandlesBlankBody(t *testing.T) {
-	assert.Empty(t, extraUrlsFromSourceResponse(nil, "https://nuget.example.com/index.json"))
-}
-
-func discoverNugetFeed(t *testing.T, handler *NugetFeedHandler, sourceURL string, statusCode int, responseBody string) {
-	t.Helper()
-	proxyCtx := &goproxy.ProxyCtx{}
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, sourceURL, nil)
-	req = prepareRequestAndClose(handler, req, proxyCtx)
-	handleRequestAndClose(handler, req, proxyCtx)
-
-	resp := &http.Response{
-		StatusCode: statusCode,
-		Body:       io.NopCloser(strings.NewReader(responseBody)),
-	}
-	resp = handler.HandleResponse(resp, proxyCtx)
-
-	replayedBody, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	assert.Equal(t, responseBody, string(replayedBody))
-	require.NoError(t, resp.Body.Close())
-}
-
-func testNugetFeedCredential(rawURL, token string) config.Credential {
-	return config.Credential{
-		"type":  "nuget_feed",
-		"url":   rawURL,
-		"token": token,
-	}
-}
-
-func nugetV3Response(resourceURL string) string {
-	return fmt.Sprintf(`{"version":"3.0.0","resources":[{"@id":%q,"@type":"PackageBaseAddress/3.0.0"}]}`, resourceURL)
-}
-
-func mustMarshalJSON(t *testing.T, value any) string {
-	t.Helper()
-	body, err := json.Marshal(value)
-	require.NoError(t, err)
-	return string(body)
-}
-
-type readErrorThenData struct {
-	first []byte
-	rest  io.Reader
-}
-
-func (r *readErrorThenData) Read(p []byte) (int, error) {
-	if r.first != nil {
-		n := copy(p, r.first)
-		r.first = nil
-		return n, assert.AnError
-	}
-	return r.rest.Read(p)
-}
-
-func (r *readErrorThenData) Close() error { return nil }
-
-func newTestNugetFeedHandler(credentials config.Credentials) *NugetFeedHandler {
-	return NewNugetFeedHandler(credentials, testOIDCClient)
 }

--- a/internal/handlers/nuget_feed_test.go
+++ b/internal/handlers/nuget_feed_test.go
@@ -3,10 +3,14 @@ package handlers
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
@@ -15,6 +19,12 @@ import (
 	"github.com/dependabot/proxy/internal/config"
 	"github.com/dependabot/proxy/internal/testhelpers"
 )
+
+type nugetRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f nugetRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestNugetFeedHandler(t *testing.T) {
 	dependabotToken := "123"
@@ -380,5 +390,90 @@ func TestNugetFeedHandlerProxyOnlyCredentials(t *testing.T) {
 		req = httptest.NewRequestWithContext(t.Context(), "GET", requestURL, nil)
 		req = handleRequestAndClose(handler, req, nil)
 		assertUnauthenticated(t, req, "automatic credential destination safety")
+	}
+}
+
+func TestNugetFeedHandlerDiscoversFeedsConcurrentlyInCredentialOrder(t *testing.T) {
+	firstRequestStarted := make(chan struct{})
+	secondRequestCompleted := make(chan struct{})
+	releaseFirstRequest := make(chan struct{})
+	var closeFirstStarted sync.Once
+	var closeSecondCompleted sync.Once
+
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: nugetRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Hostname() {
+			case "first.example.com":
+				closeFirstStarted.Do(func() { close(firstRequestStarted) })
+				<-releaseFirstRequest
+				return nugetDiscoveryResponse("https://first-cdn.example.com/packages"), nil
+			case "second.example.com":
+				closeSecondCompleted.Do(func() { close(secondRequestCompleted) })
+				return nugetDiscoveryResponse("https://second-cdn.example.com/packages"), nil
+			default:
+				return nil, fmt.Errorf("unexpected NuGet discovery host %s", req.URL.Hostname())
+			}
+		}),
+	}
+
+	handlerResult := make(chan *NugetFeedHandler, 1)
+	go func() {
+		handlerResult <- NewNugetFeedHandler(config.Credentials{
+			{
+				"type":  "nuget_feed",
+				"url":   "https://first.example.com/index.json",
+				"token": "first-token",
+			},
+			{
+				"type":  "nuget_feed",
+				"url":   "https://second.example.com/index.json",
+				"token": "second-token",
+			},
+		}, client)
+	}()
+
+	select {
+	case <-firstRequestStarted:
+	case <-time.After(time.Second):
+		close(releaseFirstRequest)
+		require.FailNow(t, "first NuGet discovery request did not start")
+	}
+	select {
+	case <-secondRequestCompleted:
+	case <-time.After(time.Second):
+		close(releaseFirstRequest)
+		require.FailNow(t, "second NuGet discovery request did not complete while the first was blocked")
+	}
+	close(releaseFirstRequest)
+
+	var handler *NugetFeedHandler
+	select {
+	case handler = <-handlerResult:
+	case <-time.After(time.Second):
+		require.FailNow(t, "NuGet feed handler construction did not complete")
+	}
+
+	require.Len(t, handler.credentials, 4)
+	assert.Equal(t, []string{
+		"https://first.example.com/index.json",
+		"https://first-cdn.example.com/packages",
+		"https://second.example.com/index.json",
+		"https://second-cdn.example.com/packages",
+	}, []string{
+		handler.credentials[0].url,
+		handler.credentials[1].url,
+		handler.credentials[2].url,
+		handler.credentials[3].url,
+	})
+}
+
+func nugetDiscoveryResponse(resourceURL string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(fmt.Sprintf(
+			`{"version":"3.0.0","resources":[{"@id":%q,"@type":"PackageBaseAddress/3.0.0"}]}`,
+			resourceURL,
+		))),
 	}
 }

--- a/internal/handlers/nuget_feed_test.go
+++ b/internal/handlers/nuget_feed_test.go
@@ -297,6 +297,18 @@ func TestUrlsCanBeDeterminedFromNuGetFeeds(t *testing.T) {
 				]
 			}`,
 			[]string{"https://nuget.example.com/v3/query", "https://nuget.example.com/v3/unknown"}},
+		{"EmptyResponse",
+			"https://nuget.example.com/v3",
+			"",
+			[]string{}},
+		{"WhitespaceResponse",
+			"https://nuget.example.com/v3",
+			" \n\t",
+			[]string{}},
+		{"ShortUnknownResponse",
+			"https://nuget.example.com/v3",
+			"short",
+			[]string{}},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -466,6 +478,36 @@ func TestNugetFeedHandlerDiscoversFeedsConcurrentlyInCredentialOrder(t *testing.
 		handler.credentials[2].url,
 		handler.credentials[3].url,
 	})
+}
+
+func TestNugetFeedHandlerOnlyDiscoversFromOKResponses(t *testing.T) {
+	for _, statusCode := range []int{
+		http.StatusNoContent,
+		http.StatusResetContent,
+		http.StatusFound,
+	} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			client := &http.Client{
+				Timeout: 5 * time.Second,
+				Transport: nugetRoundTripperFunc(func(*http.Request) (*http.Response, error) {
+					response := nugetDiscoveryResponse("https://cdn.example.com/packages")
+					response.StatusCode = statusCode
+					return response, nil
+				}),
+			}
+
+			handler := NewNugetFeedHandler(config.Credentials{
+				{
+					"type":  "nuget_feed",
+					"url":   "https://nuget.example.com/index.json",
+					"token": "some-token",
+				},
+			}, client)
+
+			require.Len(t, handler.credentials, 1)
+			assert.Equal(t, "https://nuget.example.com/index.json", handler.credentials[0].url)
+		})
+	}
 }
 
 func nugetDiscoveryResponse(resourceURL string) *http.Response {

--- a/internal/handlers/oidc_handling_test.go
+++ b/internal/handlers/oidc_handling_test.go
@@ -22,6 +22,12 @@ type oidcHandler interface {
 	HandleRequest(req *http.Request, proxyCtx *goproxy.ProxyCtx) (*http.Request, *http.Response)
 }
 
+type mockHttpRequest struct {
+	verb     string
+	url      string
+	response string
+}
+
 func TestOIDCURLsAreAuthenticated(t *testing.T) {
 	testTenantId := "12345678-1234-1234-1234-123456789012"
 	testClientId := "87654321-4321-4321-4321-210987654321"
@@ -31,8 +37,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 		provider           string
 		handlerFactory     func(creds config.Credentials) oidcHandler
 		credentials        config.Credentials
-		serviceIndexURL    string
-		resourceURL        string
+		urlMocks           []mockHttpRequest
 		expectedLogLines   []string
 		urlsToAuthenticate []string
 	}{
@@ -56,6 +61,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"domain-owner": "9876543210",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered aws OIDC credentials for cargo registry: https://cargo.example.com/packages",
 			},
@@ -77,6 +83,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"client-id": testClientId,
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered azure OIDC credentials for cargo registry: https://cargo.example.com/packages",
 			},
@@ -97,6 +104,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"jfrog-oidc-provider-name": "proxy-test",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered jfrog OIDC credentials for cargo registry: https://jfrog.example.com/packages",
 			},
@@ -119,6 +127,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"audience":     "my-audience",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered cloudsmith OIDC credentials for cargo registry: https://cloudsmith.example.com",
 			},
@@ -139,6 +148,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"workload-identity-provider": "projects/123/locations/global/workloadIdentityPools/pool/providers/prov",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered gcp OIDC credentials for cargo registry: https://us-central1-cargo.pkg.dev/my-project/my-repo",
 			},
@@ -166,6 +176,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"domain-owner": "9876543210",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered aws OIDC credentials for composer repository: https://composer.example.com",
 			},
@@ -187,6 +198,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"client-id": testClientId,
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered azure OIDC credentials for composer repository: https://composer.example.com",
 			},
@@ -208,6 +220,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"jfrog-oidc-provider-name": "proxy-test",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered jfrog OIDC credentials for composer repository: https://jfrog.example.com",
 			},
@@ -230,6 +243,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"audience":     "my-audience",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered cloudsmith OIDC credentials for composer repository: https://cloudsmith.example.com",
 			},
@@ -250,6 +264,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"workload-identity-provider": "projects/123/locations/global/workloadIdentityPools/pool/providers/prov",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered gcp OIDC credentials for composer repository: https://us-central1-composer.pkg.dev/my-project/my-repo",
 			},
@@ -278,6 +293,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"domain-owner": "9876543210",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered aws OIDC credentials for docker registry: https://docker.example.com",
 			},
@@ -299,6 +315,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"client-id": testClientId,
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered azure OIDC credentials for docker registry: https://docker.example.com",
 			},
@@ -319,6 +336,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"jfrog-oidc-provider-name": "proxy-test",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered jfrog OIDC credentials for docker registry: https://jfrog.example.com/v2/dependabot",
 			},
@@ -341,6 +359,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"audience":     "my-audience",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered cloudsmith OIDC credentials for docker registry: https://cloudsmith.example.com",
 			},
@@ -361,6 +380,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"workload-identity-provider": "projects/123/locations/global/workloadIdentityPools/pool/providers/prov",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered gcp OIDC credentials for docker registry: https://us-central1-docker.pkg.dev",
 			},
@@ -388,6 +408,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"domain-owner": "9876543210",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered aws OIDC credentials for goproxy server: https://goproxy.example.com",
 			},
@@ -409,6 +430,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"client-id": testClientId,
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered azure OIDC credentials for goproxy server: goproxy.example.com",
 			},
@@ -429,6 +451,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"jfrog-oidc-provider-name": "proxy-test",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered jfrog OIDC credentials for goproxy server: https://jfrog.example.com",
 			},
@@ -451,6 +474,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"audience":     "my-audience",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered cloudsmith OIDC credentials for goproxy server: https://cloudsmith.example.com",
 			},
@@ -471,6 +495,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"workload-identity-provider": "projects/123/locations/global/workloadIdentityPools/pool/providers/prov",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered gcp OIDC credentials for goproxy server: https://us-central1-go.pkg.dev/my-project/my-repo",
 			},
@@ -498,6 +523,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"domain-owner": "9876543210",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered aws OIDC credentials for helm registry: https://helm.example.com",
 			},
@@ -519,6 +545,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"client-id": testClientId,
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered azure OIDC credentials for helm registry: https://helm.example.com",
 			},
@@ -539,6 +566,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"jfrog-oidc-provider-name": "proxy-test",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered jfrog OIDC credentials for helm registry: jfrog.example.com",
 			},
@@ -561,6 +589,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"audience":     "my-audience",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered cloudsmith OIDC credentials for helm registry: https://cloudsmith.example.com",
 			},
@@ -581,6 +610,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"workload-identity-provider": "projects/123/locations/global/workloadIdentityPools/pool/providers/prov",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered gcp OIDC credentials for helm registry: https://us-central1-helm.pkg.dev/my-project/my-repo",
 			},
@@ -608,6 +638,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"domain-owner": "9876543210",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered aws OIDC credentials for hex repository: https://hex.example.com",
 			},
@@ -629,6 +660,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"client-id": testClientId,
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered azure OIDC credentials for hex repository: https://hex.example.com",
 			},
@@ -649,6 +681,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"jfrog-oidc-provider-name": "proxy-test",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered jfrog OIDC credentials for hex repository: https://jfrog.example.com",
 			},
@@ -671,6 +704,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"audience":     "my-audience",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered cloudsmith OIDC credentials for hex repository: https://cloudsmith.example.com",
 			},
@@ -691,6 +725,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"workload-identity-provider": "projects/123/locations/global/workloadIdentityPools/pool/providers/prov",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered gcp OIDC credentials for hex repository: https://us-central1-hex.pkg.dev/my-project/my-repo",
 			},
@@ -718,6 +753,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"domain-owner": "9876543210",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered aws OIDC credentials for maven repository: https://maven.example.com/packages",
 			},
@@ -739,6 +775,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"client-id": testClientId,
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered azure OIDC credentials for maven repository: https://maven.example.com/packages",
 			},
@@ -759,6 +796,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"jfrog-oidc-provider-name": "proxy-test",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered jfrog OIDC credentials for maven repository: https://jfrog.example.com/packages",
 			},
@@ -781,6 +819,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"audience":     "my-audience",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered cloudsmith OIDC credentials for maven repository: https://cloudsmith.example.com",
 			},
@@ -801,6 +840,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"workload-identity-provider": "projects/123/locations/global/workloadIdentityPools/pool/providers/prov",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered gcp OIDC credentials for maven repository: https://us-central1-maven.pkg.dev/my-project/my-repo",
 			},
@@ -828,6 +868,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"domain-owner": "9876543210",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered aws OIDC credentials for npm registry: https://npm.example.com",
 			},
@@ -849,6 +890,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"client-id": testClientId,
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered azure OIDC credentials for npm registry: https://npm.example.com",
 			},
@@ -869,6 +911,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"jfrog-oidc-provider-name": "proxy-test",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered jfrog OIDC credentials for npm registry: https://jfrog.example.com",
 			},
@@ -891,6 +934,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"audience":     "my-audience",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered cloudsmith OIDC credentials for npm registry: https://cloudsmith.example.com",
 			},
@@ -911,6 +955,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"workload-identity-provider": "projects/123/locations/global/workloadIdentityPools/pool/providers/prov",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered gcp OIDC credentials for npm registry: https://us-central1-npm.pkg.dev/my-project/my-repo",
 			},
@@ -938,10 +983,16 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"domain-owner": "9876543210",
 				},
 			},
-			serviceIndexURL: "https://nuget.example.com/index.json",
-			resourceURL:     "https://nuget.example.com/v3/packages",
+			urlMocks: []mockHttpRequest{
+				{
+					verb:     "GET",
+					url:      "https://nuget.example.com/index.json",
+					response: `{"version":"3.0.0","resources":[{"@id":"https://nuget.example.com/v3/packages","@type":"PackageBaseAddress/3.0.0"}]}`,
+				},
+			},
 			expectedLogLines: []string{
 				"registered aws OIDC credentials for nuget feed: https://nuget.example.com/index.json",
+				"registered aws OIDC credentials for nuget resource: https://nuget.example.com/v3/packages",
 			},
 			urlsToAuthenticate: []string{
 				"https://nuget.example.com/index.json",                          // base url
@@ -962,10 +1013,16 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"client-id": testClientId,
 				},
 			},
-			serviceIndexURL: "https://nuget.example.com/index.json",
-			resourceURL:     "https://nuget.example.com/v3/packages",
+			urlMocks: []mockHttpRequest{
+				{
+					verb:     "GET",
+					url:      "https://nuget.example.com/index.json",
+					response: `{"version":"3.0.0","resources":[{"@id":"https://nuget.example.com/v3/packages","@type":"PackageBaseAddress/3.0.0"}]}`,
+				},
+			},
 			expectedLogLines: []string{
 				"registered azure OIDC credentials for nuget feed: https://nuget.example.com/index.json",
+				"registered azure OIDC credentials for nuget resource: https://nuget.example.com/v3/packages",
 			},
 			urlsToAuthenticate: []string{
 				"https://nuget.example.com/index.json",                          // base url
@@ -985,10 +1042,16 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"jfrog-oidc-provider-name": "proxy-test",
 				},
 			},
-			serviceIndexURL: "https://jfrog.example.com/index.json",
-			resourceURL:     "https://jfrog.example.com/v3/packages",
+			urlMocks: []mockHttpRequest{
+				{
+					verb:     "GET",
+					url:      "https://jfrog.example.com/index.json",
+					response: `{"version":"3.0.0","resources":[{"@id":"https://jfrog.example.com/v3/packages","@type":"PackageBaseAddress/3.0.0"}]}`,
+				},
+			},
 			expectedLogLines: []string{
 				"registered jfrog OIDC credentials for nuget feed: https://jfrog.example.com/index.json",
+				"registered jfrog OIDC credentials for nuget resource: https://jfrog.example.com/v3/packages",
 			},
 			urlsToAuthenticate: []string{
 				"https://jfrog.example.com/index.json",                          // base url
@@ -1010,10 +1073,16 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"audience":     "my-audience",
 				},
 			},
-			serviceIndexURL: "https://cloudsmith.example.com/v3/index.json",
-			resourceURL:     "https://cloudsmith.example.com/v3/packages",
+			urlMocks: []mockHttpRequest{
+				{
+					verb:     "GET",
+					url:      "https://cloudsmith.example.com/v3/index.json",
+					response: `{"version":"3.0.0","resources":[{"@id":"https://cloudsmith.example.com/v3/packages","@type":"PackageBaseAddress/3.0.0"}]}`,
+				},
+			},
 			expectedLogLines: []string{
 				"registered cloudsmith OIDC credentials for nuget feed: https://cloudsmith.example.com/v3/index.json",
+				"registered cloudsmith OIDC credentials for nuget resource: https://cloudsmith.example.com/v3/packages",
 			},
 			urlsToAuthenticate: []string{
 				"https://cloudsmith.example.com/v3/index.json",                       // base url
@@ -1033,10 +1102,16 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"workload-identity-provider": "projects/123/locations/global/workloadIdentityPools/pool/providers/prov",
 				},
 			},
-			serviceIndexURL: "https://us-central1-nuget.pkg.dev/my-project/my-repo/index.json",
-			resourceURL:     "https://us-central1-nuget.pkg.dev/my-project/my-repo/v3/packages",
+			urlMocks: []mockHttpRequest{
+				{
+					verb:     "GET",
+					url:      "https://us-central1-nuget.pkg.dev/my-project/my-repo/index.json",
+					response: `{"version":"3.0.0","resources":[{"@id":"https://us-central1-nuget.pkg.dev/my-project/my-repo/v3/packages","@type":"PackageBaseAddress/3.0.0"}]}`,
+				},
+			},
 			expectedLogLines: []string{
 				"registered gcp OIDC credentials for nuget feed: https://us-central1-nuget.pkg.dev/my-project/my-repo/index.json",
+				"registered gcp OIDC credentials for nuget resource: https://us-central1-nuget.pkg.dev/my-project/my-repo/v3/packages",
 			},
 			urlsToAuthenticate: []string{
 				"https://us-central1-nuget.pkg.dev/my-project/my-repo/index.json",                          // base url
@@ -1063,6 +1138,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"domain-owner": "9876543210",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered aws OIDC credentials for pub repository: https://pub.example.com",
 			},
@@ -1084,6 +1160,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"client-id": testClientId,
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered azure OIDC credentials for pub repository: https://pub.example.com",
 			},
@@ -1104,6 +1181,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"jfrog-oidc-provider-name": "proxy-test",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered jfrog OIDC credentials for pub repository: https://jfrog.example.com",
 			},
@@ -1126,6 +1204,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"audience":     "my-audience",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered cloudsmith OIDC credentials for pub repository: https://cloudsmith.example.com",
 			},
@@ -1146,6 +1225,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"workload-identity-provider": "projects/123/locations/global/workloadIdentityPools/pool/providers/prov",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered gcp OIDC credentials for pub repository: https://us-central1-pub.pkg.dev/my-project/my-repo",
 			},
@@ -1173,6 +1253,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"domain-owner": "9876543210",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered aws OIDC credentials for python index: https://python.example.com",
 			},
@@ -1194,6 +1275,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"client-id": testClientId,
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered azure OIDC credentials for python index: https://python.example.com",
 			},
@@ -1214,6 +1296,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"jfrog-oidc-provider-name": "proxy-test",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered jfrog OIDC credentials for python index: https://jfrog.example.com",
 			},
@@ -1236,6 +1319,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"audience":     "my-audience",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered cloudsmith OIDC credentials for python index: https://cloudsmith.example.com",
 			},
@@ -1256,6 +1340,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"workload-identity-provider": "projects/123/locations/global/workloadIdentityPools/pool/providers/prov",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered gcp OIDC credentials for python index: https://us-central1-python.pkg.dev/my-project/my-repo/",
 			},
@@ -1283,6 +1368,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"domain-owner": "9876543210",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered aws OIDC credentials for rubygems server: https://rubygems.example.com",
 			},
@@ -1304,6 +1390,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"client-id": testClientId,
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered azure OIDC credentials for rubygems server: https://rubygems.example.com",
 			},
@@ -1325,6 +1412,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"jfrog-oidc-provider-name": "proxy-test",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered jfrog OIDC credentials for rubygems server: https://jfrog.example.com",
 			},
@@ -1348,6 +1436,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"audience":     "my-audience",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered cloudsmith OIDC credentials for rubygems server: https://cloudsmith.example.com",
 			},
@@ -1369,6 +1458,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"workload-identity-provider": "projects/123/locations/global/workloadIdentityPools/pool/providers/prov",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered gcp OIDC credentials for rubygems server: https://us-central1-ruby.pkg.dev/my-project/my-repo",
 			},
@@ -1396,6 +1486,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"domain-owner": "9876543210",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered aws OIDC credentials for terraform registry: https://terraform.example.com",
 			},
@@ -1417,6 +1508,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"client-id": testClientId,
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered azure OIDC credentials for terraform registry: https://terraform.example.com",
 			},
@@ -1437,6 +1529,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"jfrog-oidc-provider-name": "proxy-test",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered jfrog OIDC credentials for terraform registry: https://jfrog.example.com",
 			},
@@ -1459,6 +1552,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"audience":     "my-audience",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered cloudsmith OIDC credentials for terraform registry: https://cloudsmith.example.com",
 			},
@@ -1479,6 +1573,7 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 					"workload-identity-provider": "projects/123/locations/global/workloadIdentityPools/pool/providers/prov",
 				},
 			},
+			urlMocks: []mockHttpRequest{},
 			expectedLogLines: []string{
 				"registered gcp OIDC credentials for terraform registry: https://us-central1-terraform.pkg.dev/my-project/my-repo",
 			},
@@ -1491,6 +1586,12 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 		t.Run(fmt.Sprintf("%s - %s", tc.name, tc.provider), func(t *testing.T) {
 			httpmock.Activate()
 			defer httpmock.DeactivateAndReset()
+
+			// mock URLs
+			for _, mockReq := range tc.urlMocks {
+				httpmock.RegisterResponder(mockReq.verb, mockReq.url,
+					httpmock.NewStringResponder(200, mockReq.response))
+			}
 
 			// mock GitHub OIDC token request
 			tokenUrl := "https://token.actions.example.com" //nolint:gosec // test URL
@@ -1559,13 +1660,6 @@ func TestOIDCURLsAreAuthenticated(t *testing.T) {
 			var buf bytes.Buffer
 			testhelpers.CaptureStandardLog(t, &buf)
 			handler := tc.handlerFactory(tc.credentials)
-			if tc.serviceIndexURL != "" {
-				nugetHandler, ok := handler.(*NugetFeedHandler)
-				if !assert.True(t, ok, "handler with a service index should be a NuGet handler") {
-					return
-				}
-				discoverNugetFeed(t, nugetHandler, tc.serviceIndexURL, http.StatusOK, nugetV3Response(tc.resourceURL))
-			}
 			logContents := buf.String()
 
 			// check expected log lines

--- a/proxy.go
+++ b/proxy.go
@@ -76,9 +76,6 @@ func newProxyWithCacheDir(envSettings config.ProxyEnvSettings, cfg *config.Confi
 	egressAllowlistHandler := handlers.NewEgressAllowlistHandler(cfg, envSettings)
 	proxy.OnRequest().DoFunc(egressAllowlistHandler.HandleRequest)
 
-	nugetFeedHandler := handlers.NewNugetFeedHandler(cfg.Credentials, oidcClient)
-	proxy.OnRequest().DoFunc(nugetFeedHandler.PrepareRequest)
-
 	enableCache := os.Getenv("PROXY_CACHE") == "true"
 	cacher, err := cache.New(enableCache, cacheDir)
 	if err != nil {
@@ -128,8 +125,8 @@ func newProxyWithCacheDir(envSettings config.ProxyEnvSettings, cfg *config.Confi
 	rubyGemsServerHandler := handlers.NewRubyGemsServerHandler(cfg.Credentials, oidcClient)
 	proxy.OnRequest().DoFunc(rubyGemsServerHandler.HandleRequest)
 
+	nugetFeedHandler := handlers.NewNugetFeedHandler(cfg.Credentials, oidcClient)
 	proxy.OnRequest().DoFunc(nugetFeedHandler.HandleRequest)
-	proxy.OnResponse().DoFunc(nugetFeedHandler.HandleResponse)
 
 	mavenRepositoryHandler := handlers.NewMavenRepositoryHandler(cfg.Credentials, oidcClient)
 	proxy.OnRequest().DoFunc(mavenRepositoryHandler.HandleRequest)


### PR DESCRIPTION
### Short description

Restore eager NuGet service-index discovery while retaining the useful credential matching and deduplication behavior introduced after the original implementation.

Paged v2 feeds and v3 service indexes can identify authenticated endpoints that differ from the configured repository URL. The proxy must discover those endpoints before the updater starts, otherwise requests can be made before the proxy knows which credentials to inject.

### What are you trying to accomplish?

PR #203 changed NuGet discovery from eager initialization to deferred response interception. That caused update-job failures when authenticated resource URLs were needed before the proxy had observed the service-index response. This PR restores eager initialization and improves its performance, matching, determinism, and redirect handling.

The proxy still completes NuGet discovery before opening port 1080. Discovery requests now run through a bounded pool of eight workers, while results are merged in configured credential order.

### Behavior before PR #203 compared with this PR

| Area | Before PR #203 | Current behavior |
|---|---|---|
| Initialization | Service indexes were fetched eagerly and serially. | Service indexes are fetched eagerly with up to eight concurrent requests. Port 1080 is opened only after all discovery finishes. |
| Discovery client | Used a private client with a 10-second timeout and the default transport. | Uses the proxy's shared 10-second client and restricted transport, including the safe dialer and TLS settings. |
| Unusable credentials | Credentials without a token or password were stored and queried without authentication. | Unusable static credentials are ignored and do not trigger discovery. |
| Duplicate sources | Every configured source was queried, including equivalent duplicates. | Canonically equivalent sources are queried once, with first-configured precedence. HTTP and HTTPS sources remain distinct. |
| Credential precedence | Discovery was interleaved with configuration processing, so an earlier discovered credential could shadow a later explicit credential. | All explicit credentials are registered before discovered credentials, so explicit configuration wins. Duplicate discovered resources use deterministic configured-source order. |
| Path matching | Used decoded string-prefix matching; `/feed` could match `/feedback`, and escaped separators could be conflated with literal separators. The first matching credential won. | Uses canonical path-segment matching, preserves escaped separators, rejects ambiguous dot segments, and selects the most-specific matching URL credential. |
| Host credentials | A host credential could shadow a URL credential based on configuration order. | URL-scoped credentials take precedence; host credentials are fallback matches. |
| Proxy-only credentials | Had no special NuGet behavior and acted like ordinary credentials. | Are host-only fallback credentials used only for HTTPS on the default port when no explicit/OIDC credential or usable request authorization applies. |
| Response handling | Parsed any response below HTTP 400 and could panic on short or empty unrecognized bodies. | Parses only HTTP 200 responses and safely handles empty, short, invalid, and non-success responses. |
| Service-index redirects | Relied on the standard client's redirect-header behavior and did not register redirected index URLs. | Explicitly retains `Authorization` or `X-Api-Key` across redirects, including redirects to another host, and registers every followed redirect URL for later authenticated requests. |
| Discovered resources | Registered service-index resource URLs with the source credential, including resources on other hosts. | Retains that behavior while canonicalizing and deduplicating registrations. |
| OIDC matching | Used decoded path-prefix matching. | Uses canonical, most-specific path matching and participates in concurrent discovery, deduplication, and redirect registration. |

Authentication formatting is unchanged: username/password values use Basic authentication, ordinary tokens use Bearer authentication, and Azure DevOps tokens are treated as Basic-auth passwords. Discovery still supports v2 `xml:base` and non-template v3 resources.

### Anything you want to highlight for special attention from reviewers?

- Authentication is intentionally retained when a service-index redirect changes hosts, matching the treatment of cross-host resource URLs returned by NuGet indexes.
- Discovery concurrency is capped at eight workers. Workers collect results independently; shared credential and OIDC state is updated afterward in deterministic configuration order.
- Canonical static URL deduplication is scheme-agnostic for compatibility, while source discovery keeps HTTP and HTTPS distinct.

### How will you know you've accomplished your goal?

- All NuGet resource and redirected service-index URLs are registered before the proxy accepts connections.
- Slow feeds do not serialize discovery of every other configured feed.
- The most-specific applicable credential is selected safely and deterministically.
- Explicit credentials take precedence over discovered credentials.
- Cross-host redirects and cross-host resources retain authentication.
- Empty, malformed, and non-200 discovery responses do not add credentials or panic.
- `go test ./...` passes.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
